### PR TITLE
UI fixes

### DIFF
--- a/frontend/components/Container.tsx
+++ b/frontend/components/Container.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components"
 
 export default styled.div`
-  width: 90%;
-  max-width: 900px;
+  width: 85%;
+  max-width: 1600px;
   margin: 0 auto;
   margin-top: 2rem;
   padding: 0.5em;

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -6,6 +6,10 @@ import { useApolloClient } from "react-apollo-hooks"
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles"
 import NextI18Next from "../i18n"
 import LanguageSwitch from "./LanguageSwitch"
+import styled from "styled-components"
+import CssBaseline from "@material-ui/core/CssBaseline"
+import useScrollTrigger from "@material-ui/core/useScrollTrigger"
+import Slide from "@material-ui/core/Slide"
 
 function TitleText(props: any) {
   return (
@@ -48,26 +52,51 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 )
 
+interface Props {
+  window?: () => Window
+  children: React.ReactElement
+}
+
+function HideOnScroll(props: Props) {
+  const { children, window } = props
+  const trigger = useScrollTrigger({ target: window ? window() : undefined })
+
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      {children}
+    </Slide>
+  )
+}
+
 function Header() {
   const classes = useStyles()
   const loggedIn = React.useContext(LoginStateContext)
   const client = useApolloClient()
 
   return (
-    <AppBar position="static" color="inherit">
-      <Toolbar>
-        <div style={{ flex: 1 }}>
-          <NextI18Next.Link href="/">
-            <a href="/" aria-label="MOOC.fi homepage" className={classes.link}>
-              <LogoImage classes={{ root: classes.avatar }} />
-              <TitleText className={classes.title} />
-            </a>
-          </NextI18Next.Link>
-        </div>
-        <LanguageSwitch />
-        {loggedIn && <LogOutButton onclick={() => signOut(client)} />}
-      </Toolbar>
-    </AppBar>
+    <React.Fragment>
+      <CssBaseline />
+      <HideOnScroll>
+        <AppBar color="inherit">
+          <Toolbar>
+            <div style={{ flex: 1 }}>
+              <NextI18Next.Link href="/">
+                <a
+                  href="/"
+                  aria-label="MOOC.fi homepage"
+                  className={classes.link}
+                >
+                  <LogoImage classes={{ root: classes.avatar }} />
+                  <TitleText className={classes.title} />
+                </a>
+              </NextI18Next.Link>
+            </div>
+            <LanguageSwitch />
+            {loggedIn && <LogOutButton onclick={() => signOut(client)} />}
+          </Toolbar>
+        </AppBar>
+      </HideOnScroll>
+    </React.Fragment>
   )
 }
 

--- a/frontend/components/Home/CourseCard.tsx
+++ b/frontend/components/Home/CourseCard.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles((theme: Theme) =>
       [theme.breakpoints.up("md")]: {
         height: 500,
       },
-      maxWidth: 400,
     },
     imageSrc: {
       position: "absolute",
@@ -113,7 +112,7 @@ const BackgroundImage = styled.img`
 function CourseCard({ course }) {
   const classes = useStyles()
   return (
-    <Grid item xs={12} sm={6} md={4} lg={4} xl={4}>
+    <Grid item xs={12} sm={12} md={4} lg={4} xl={4}>
       <ButtonBase
         focusRipple
         className={classes.image}

--- a/frontend/components/Home/Explanation.tsx
+++ b/frontend/components/Home/Explanation.tsx
@@ -15,15 +15,17 @@ const ExplanationRoot = styled.div`
 const Title = styled(Typography)`
   padding-top: 2rem;
   padding-bottom: 2rem;
-  font-size: 72px;
+  font-size: 36px;
+  max-width: 60%;
   @media (min-width: 600px) {
-    font-size: 120px;
+    font-size: 48px;
   }
   @media (min-width: 960px) {
     margin-left: 1rem;
+    font-size: 52px;
   }
   @media (min-width: 1920px) {
-    font-size: 210px;
+    font-size: 82px;
   }
 `
 const Subtitle = styled(Typography)`
@@ -50,14 +52,19 @@ const CourseButton = styled(Button)`
   font-size: 24px;
   margin-left: 10%;
 `
-
-function Explanation({ t }) {
+interface ExplanationProps {
+  t: Function
+}
+function Explanation(props: ExplanationProps) {
+  const { t } = props
   return (
     <ExplanationRoot>
-      <Title component="h1">MOOC.fi</Title>
+      <Title component="h1" variant="h4">
+        {t("tagLine")}
+      </Title>
       <div>
         <Subtitle component="p">{t("intro")}</Subtitle>
-        <CourseButton variant="contained" href="#coursesAndModules">
+        <CourseButton variant="contained" href="#courses-and-modules">
           {t("courseButton")}
         </CourseButton>
       </div>

--- a/frontend/components/Home/NaviCard.tsx
+++ b/frontend/components/Home/NaviCard.tsx
@@ -1,108 +1,117 @@
 import React from "react"
-import { createStyles, makeStyles, Theme } from "@material-ui/core/styles"
 import NextI18Next from "../../i18n"
 import Grid from "@material-ui/core/Grid"
 import ButtonBase from "@material-ui/core/ButtonBase"
 import Typography from "@material-ui/core/Typography"
+import styled from "styled-components"
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    image: {
-      position: "relative",
-      height: 400,
+const NaviItemBase = styled(ButtonBase)`
+  position: relative;
+  height: 360px;
+  @media (min-width: 425px) {
+    height: 295px;
+  }
+  @media (min-width: 600px) {
+    height: 380px;
+  }
+  @media (min-width: 750px) {
+    height: 360px;
+  }
+  @media (min-width: 960px) {
+    height: 380px;
+  }
+  @media (min-width: 1280px) {
+    height: 310px;
+  }
+  @media (min-width: 1440px) {
+    height: 310px;
+  }
+  width: 100%;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+`
+const BackgroundImage = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -2;
+`
+const NaviTextContainer = styled.span`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  align-items: left;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 1em;
+  padding-top: 1em;
+`
 
-      width: "100%",
-      boxShadow:
-        "0 2px 2px 0 rgba(0,0,0,0.14), 0 3px 1px -2px rgba(0,0,0,0.12), 0 1px 5px 0 rgba(0,0,0,0.2)",
-      overflow: "hidden",
-    },
-    imageSrc: {
-      position: "absolute",
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-      backgroundSize: "cover",
-      backgroundPosition: "center 40%",
-    },
-    imageBackdrop: {
-      position: "absolute",
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-    },
-    imageButton: {
-      position: "absolute",
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-      alignItems: "left",
-      display: "flex",
-      flexDirection: "column",
-      paddingBottom: "1em",
-      paddingTop: "1em",
-    },
-    title: {
-      fontSize: 22,
-      marginBottom: "0.5rem",
-      marginLeft: "1rem",
-      maxWidth: "60%",
-    },
-    bodyText: {
-      fontSize: 16,
-      maxWidth: "60%",
-      textAlign: "left",
-      margin: 0,
-      marginLeft: "1rem",
-      flex: 1,
-      [theme.breakpoints.up("lg")]: {
-        maxWidth: "55%",
-      },
-    },
-    link: {
-      color: "#00A68D",
-      fontSize: 18,
-      maxWidth: "60%",
-      textAlign: "left",
-      marginLeft: "1rem",
-    },
-  }),
-)
+const Title = styled(Typography)`
+  font-size: 22px;
+  margin-bottom: 1rem;
+  margin-left: 1rem;
+  max-width: 60%;
+`
+const Text = styled(Typography)`
+  font-size: 16px;
+  max-width: 60%;
+  text-align: left;
+  margin: 0;
+  margin-left: 1rem;
+  @media (min-width: 1280px) {
+    max-width: 55%;
+  }
+  flex: 1;
+  margin-bottom: 1rem;
+`
 
-function NaviCard({ item }) {
-  const classes = useStyles()
+const Link = styled.a`
+  color: #00a68d;
+  font-size: 18px;
+  max-width: 60%;
+  text-align: left;
+  margin-left: 1rem;
+`
+type NaviItem = {
+  title: string
+  text: string
+  linkText: string
+  img: string
+  link: string
+}
+
+interface NaviCardProps {
+  item: NaviItem
+}
+
+function NaviCard(props: NaviCardProps) {
+  const { item } = props
   const image = require(`../../static/images/${item.img}`)
 
   return (
     <Grid item xs={12} sm={6} md={4} lg={4}>
-      <ButtonBase focusRipple className={classes.image}>
-        <span
-          className={classes.imageSrc}
-          style={{ backgroundImage: `url(${image})` }}
-        />
-        <span className={classes.imageBackdrop} />
-        <span className={classes.imageButton}>
-          <Typography className={classes.title} align="left">
-            {item.title}
-          </Typography>
-          <Typography className={classes.bodyText} paragraph>
-            {item.text}
-          </Typography>
+      <NaviItemBase focusRipple>
+        <BackgroundImage src={image} alt="" />
+
+        <NaviTextContainer>
+          <Title align="left">{item.title}</Title>
+          <Text>{item.text}</Text>
           <Typography align="left">
             <NextI18Next.Link href={item.link}>
-              <a
-                href={item.link}
-                className={classes.link}
-                aria-label={item.linkText}
-              >
+              <Link href={item.link} aria-label={item.linkText}>
                 {item.linkText}
-              </a>
+              </Link>
             </NextI18Next.Link>
           </Typography>
-        </span>
-      </ButtonBase>
+        </NaviTextContainer>
+      </NaviItemBase>
     </Grid>
   )
 }

--- a/frontend/components/LanguageSwitch.tsx
+++ b/frontend/components/LanguageSwitch.tsx
@@ -8,6 +8,7 @@ const SwitchButton = styled(Button)`
   font-size: 12px;
   line-height: 1.3;
   padding-right: 1px;
+  font-weight: bold;
 
   @media (min-width: 400px) {
     font-size: 14px;
@@ -25,8 +26,8 @@ const LanguageSwitch = ({ t }) => {
     >
       <Language style={{ marginRight: "0.5rem" }} />
       {NextI18Next.i18n.language === "en"
-        ? "Suomenkielinen versio"
-        : "English version"}
+        ? "SUOMENKIELINEN VERSIO"
+        : "ENGLISH VERSION"}
     </SwitchButton>
   )
 }

--- a/frontend/pages/_layout.tsx
+++ b/frontend/pages/_layout.tsx
@@ -18,7 +18,10 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
       <FooterDownPusherWrapper>
         <div>
           <Header />
-          <main id="main">{children}</main>
+          {/*add top margin to main to push the content from under the header*/}
+          <main id="main" style={{ marginTop: 100 }}>
+            {children}
+          </main>
         </div>
         <Footer />
       </FooterDownPusherWrapper>

--- a/frontend/static/locales/en/home.json
+++ b/frontend/static/locales/en/home.json
@@ -1,4 +1,5 @@
 {
+    "tagLine":"High-quality, open, and free courses for everyone!",
     "intro":"The courses are offered by University of Helsinki's Department of Computer Science. No prior knowledge is required-beginners can start to learn programming basics from the Programming with Java course, or start to get familiar with artificial intelligence from the course Elements of Ai.",
     "courseButton": "Our courses",
     "highlightTitle": "Start with these.",

--- a/frontend/static/locales/en/navi.json
+++ b/frontend/static/locales/en/navi.json
@@ -6,7 +6,7 @@
               "Online learning at its best. Don't worry about course fees or the commute. Study where it's convenient for you! As per their name, MOOCs (Massive Open Online Course) are all open, free of charge and fully available online.",
             "linkText": "Courses and Modules",
             "img": "AllCourses.jpg",
-            "link": "#coursesAndModules"
+            "link": "#courses-and-modules"
           },
           {
             "title": "Teach courses in your own classroom.",

--- a/frontend/static/locales/fi/home.json
+++ b/frontend/static/locales/fi/home.json
@@ -1,4 +1,5 @@
 {
+    "tagLine":"Laadukkaita, avoimia ja ilmaisia verkkokursseja kaikille",
     "intro": "Helsingin yliopiston tietojenkäsittelytieteen osasto tarjoaa avoimia laadukkaita ja ilmaisia verkkokursseja kaikille. Aloittelija voi lähteä liikkeelle Ohjelmoinnin MOOCista tai tekoälyn perusteisiin keskittyvästä Elements of AI -kurssista. Osaamistaan päivittävä voi syventyä vaikkapa tietoturvaan tai Fullstack -ohjelmointiin.",
     "courseButton": "Kurssimme",
     "highlightTitle": "Aloita näistä",

--- a/frontend/static/locales/fi/navi.json
+++ b/frontend/static/locales/fi/navi.json
@@ -6,7 +6,7 @@
               "Verkko-oppimista parhaimmillaan. Älä huolehdi kurssimaksuista tai koulumatkoista, vaan opiskele siellä missä sinulle sopii. MOOCit eli kaikille avoimet verkkokurssit (Massive Open Online Course) ovat nimensä mukaisesti avoimia, ilmaisia ja  verkkopohjaisia kursseja.",
             "linkText": "Kurssit ",
             "img": "AllCourses.jpg",
-            "link": "#coursesAndModules"
+            "link": "#courses-and-modules"
           },
           {
             "title": "Ensimmäisen vuoden opinnot kaikille",


### PR DESCRIPTION
UI Fixes:
-Tagline instead of MOOC.fi on main banner
-course cards wider and 2 per line on tablet size screens
-course card container area wider
-course cards wider and shorter
-Navicards shorter and less whitespace where possible
-Language switch button text bold and uppercase
- App bard scroll animation

Other:
-Link to courses now to the right place
