### PR TITLE
fixed breaking change in useMutation use

### DIFF
--- a/frontend/components/Dashboard/Editor/Course/index.tsx
+++ b/frontend/components/Dashboard/Editor/Course/index.tsx
@@ -17,9 +17,6 @@ import { StudyModules_study_modules } from "/static/types/StudyModules"
 import { CourseQuery } from "/pages/courses/[id]/edit"
 import { FetchResult, PureQueryOptions } from "apollo-boost"
 import { toCourseForm, fromCourseForm } from "./serialization"
-import { addCourse_addCourse } from "/static/types/generated/addCourse"
-import { updateCourse_updateCourse } from "/static/types/generated/updateCourse"
-import { deleteCourse_deleteCourse } from "/static/types/generated/deleteCourse"
 
 const CourseEdit = ({
   course,
@@ -28,17 +25,11 @@ const CourseEdit = ({
   course?: CourseDetails_course
   modules?: StudyModules_study_modules[]
 }) => {
-  // FIXME: (?) apollo client hooks migration broke typings, so they're any for now
-  const addCourse: any = useMutation<addCourse_addCourse>(AddCourseMutation)
-  const updateCourse: any = useMutation<updateCourse_updateCourse>(
-    UpdateCourseMutation,
-  )
-  const deleteCourse: any = useMutation<deleteCourse_deleteCourse>(
-    DeleteCourseMutation,
-    {
-      refetchQueries: [{ query: AllCoursesQuery }],
-    },
-  )
+  const [addCourse] = useMutation(AddCourseMutation)
+  const [updateCourse] = useMutation(UpdateCourseMutation)
+  const [deleteCourse] = useMutation(DeleteCourseMutation, {
+    refetchQueries: [{ query: AllCoursesQuery }],
+  })
   const checkSlug = CheckSlugQuery
 
   const client = useApolloClient()

--- a/frontend/components/Dashboard/Editor/StudyModule/index.tsx
+++ b/frontend/components/Dashboard/Editor/StudyModule/index.tsx
@@ -22,9 +22,9 @@ const StudyModuleEdit = ({
 }: {
   module?: StudyModuleDetails_study_module
 }) => {
-  const addStudyModule: any = useMutation(AddStudyModuleMutation)
-  const updateStudyModule: any = useMutation(UpdateStudyModuleMutation)
-  const deleteStudyModule: any = useMutation(DeleteStudyModuleMutation, {
+  const [addStudyModule] = useMutation(AddStudyModuleMutation)
+  const [updateStudyModule] = useMutation(UpdateStudyModuleMutation)
+  const [deleteStudyModule] = useMutation(DeleteStudyModuleMutation, {
     refetchQueries: [{ query: AllModulesQuery }],
   })
   const checkSlug = CheckModuleSlugQuery


### PR DESCRIPTION
@apollo/react-hooks version of useMutation had a breaking change from react-apollo-hooks I missed, so the editor couldn't save. 

The return value is now a tuple [mutateFunction, mutationResult] instead of just mutateFunction.