### PR TITLE
Add ects and translation vars

### DIFF
--- a/backend/datamodel.prisma
+++ b/backend/datamodel.prisma
@@ -30,6 +30,8 @@ type Course @db(name: "course") {
   name: String!
   "identify course in other api Equerys"
   slug: String! @unique
+  "amount of ECTS you can get from this course, can be a range like 2-5"
+  ects: String
   "aliases that can be used in this this api instead of slug "
   course_aliases: [CourseAlias!]! @relation(name: "CourseToCourseAlias")
   services: [Service] @relation(name: "CourseToService")

--- a/backend/resolvers/Mutation/course.ts
+++ b/backend/resolvers/Mutation/course.ts
@@ -26,7 +26,7 @@ const addCourse = async (t: PrismaObjectDefinitionBlock<"Mutation">) => {
     args: {
       name: stringArg(),
       slug: stringArg(),
-      // photo: idArg(),
+      ects: stringArg(),
       new_photo: arg({ type: "Upload", required: false }),
       base64: booleanArg(),
       start_point: booleanArg(),
@@ -56,6 +56,7 @@ const addCourse = async (t: PrismaObjectDefinitionBlock<"Mutation">) => {
       const {
         name,
         slug,
+        ects,
         start_point,
         hidden,
         study_module_start_point,
@@ -83,6 +84,7 @@ const addCourse = async (t: PrismaObjectDefinitionBlock<"Mutation">) => {
       const course: Course = await prisma.createCourse({
         name,
         slug,
+        ects,
         promote,
         start_point,
         hidden,
@@ -135,6 +137,7 @@ const updateCourse = (t: PrismaObjectDefinitionBlock<"Mutation">) => {
       name: stringArg(),
       slug: stringArg(),
       new_slug: stringArg(),
+      ects: stringArg(),
       photo: idArg(),
       new_photo: arg({ type: "Upload", required: false }),
       base64: booleanArg(),
@@ -167,6 +170,7 @@ const updateCourse = (t: PrismaObjectDefinitionBlock<"Mutation">) => {
         name,
         slug,
         new_slug,
+        ects,
         new_photo,
         base64,
         start_point,
@@ -266,6 +270,7 @@ const updateCourse = (t: PrismaObjectDefinitionBlock<"Mutation">) => {
         data: {
           name,
           slug: new_slug ? new_slug : slug,
+          ects,
           photo: !!photo ? { connect: { id: photo } } : null,
           start_point,
           promote,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "/*": ["./*"],
+      "/*": ["./*"]
     },
     "lib": ["es2016", "esnext.asynciterable"],
     "outDir": "./dist",

--- a/backend/types/Completion.ts
+++ b/backend/types/Completion.ts
@@ -1,6 +1,7 @@
 import { prismaObjectType } from "nexus-prisma"
 import { Course } from "../generated/prisma-client"
 import { ForbiddenError } from "apollo-server-core"
+import { stringArg } from "nexus/dist"
 
 const Completion = prismaObjectType({
   name: "Completion",
@@ -9,13 +10,40 @@ const Completion = prismaObjectType({
       "id",
       "created_at",
       "updated_at",
-      "course",
       "completion_language",
       "email",
       "student_number",
       "user_upstream_id",
       "completions_registered",
     ])
+    t.field("course", {
+      type: "Course",
+      args: {
+        language: stringArg(),
+      },
+      resolve: async (parent, args, ctx) => {
+        const { language } = args
+        const { prisma } = ctx
+
+        const course = await prisma.course({ id: parent.course })
+
+        if (language) {
+          const course_translations = await prisma.courseTranslations({
+            where: { course, language },
+          })
+
+          if (!course_translations.length) {
+            return course
+          }
+
+          const { name = course.name, description } = course_translations[0]
+
+          return { ...course, name, description }
+        }
+
+        return course
+      },
+    })
 
     t.field("user", {
       type: "User",

--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -94,7 +94,7 @@ Pick<
 >) => (
   <Form>
     <Grid container direction="row" spacing={2}>
-      <Grid item xs={12} sm={6} md={8}>
+      <Grid item xs={12} sm={12} md={6}>
         <Field
           name="name"
           type="text"
@@ -106,7 +106,19 @@ Pick<
           component={StyledTextField}
         />
       </Grid>
-      <Grid item xs={6} sm={3} md={2}>
+      <Grid item xs={4} sm={4} md={2}>
+        <Field
+          name="ects"
+          type="text"
+          label="ECTS"
+          errors={errors.ects}
+          fullWidth
+          autoComplete="off"
+          variant="outlined"
+          component={StyledTextField}
+        />
+      </Grid>
+      <Grid item xs={4} sm={4} md={2}>
         <Field
           name="order"
           type="number"
@@ -118,7 +130,7 @@ Pick<
           component={StyledTextField}
         />
       </Grid>
-      <Grid item xs={6} sm={3} md={2}>
+      <Grid item xs={4} sm={4} md={2}>
         <Field
           name="study_module_order"
           type="number"

--- a/frontend/components/Dashboard/Editor/Course/form-validation.ts
+++ b/frontend/components/Dashboard/Editor/Course/form-validation.ts
@@ -139,6 +139,10 @@ const courseEditSchema = ({
     study_module_order: Yup.number()
       .transform(value => (isNaN(value) ? undefined : Number(value)))
       .integer("must be integer"),
+    ects: Yup.string().matches(
+      /(^\d+(\-\d+)?$|^$)/,
+      "must be a number or a range",
+    ),
   })
 
 const validateSlug = ({

--- a/frontend/components/Dashboard/Editor/Course/serialization.ts
+++ b/frontend/components/Dashboard/Editor/Course/serialization.ts
@@ -144,6 +144,7 @@ export const fromCourseForm = ({
     id: undefined,
     slug: !newCourse ? values.slug : values.new_slug.trim(),
     new_slug: values.new_slug.trim(),
+    ects: values.ects ? values.ects.trim() : undefined,
     base64: !isProduction,
     photo: getIn(values, "photo.id"),
     // despite order being a number in the typings, it comes back as an empty string without TS yelling at you

--- a/frontend/components/Dashboard/Editor/Course/types.ts
+++ b/frontend/components/Dashboard/Editor/Course/types.ts
@@ -9,6 +9,7 @@ export interface CourseFormValues extends FormValues {
   id?: string | null
   name: string
   slug: string
+  ects?: string
   photo?: string | CourseDetails_course_photo | null
   start_point: boolean
   promote: boolean

--- a/frontend/components/Home/NaviCard.tsx
+++ b/frontend/components/Home/NaviCard.tsx
@@ -66,6 +66,7 @@ const gridLayout = (count: number): { [key: string]: number } =>
 
 function NaviCard(props: NaviCardProps) {
   const { item, count } = props
+  console.log(item)
   const image = require(`../../static/images/${item.img}`)
 
   return (

--- a/frontend/components/Home/NaviCard.tsx
+++ b/frontend/components/Home/NaviCard.tsx
@@ -66,7 +66,6 @@ const gridLayout = (count: number): { [key: string]: number } =>
 
 function NaviCard(props: NaviCardProps) {
   const { item, count } = props
-  console.log(item)
   const image = require(`../../static/images/${item.img}`)
 
   return (

--- a/frontend/pages/[lng]/register-completion/[slug].tsx
+++ b/frontend/pages/[lng]/register-completion/[slug].tsx
@@ -85,10 +85,7 @@ const RegisterCompletion = (props: RegisterCompletionPageProps) => {
   const { language } = useContext(LanguageContext)
 
   const t = getRegisterCompletionTranslator(language)
-  const { loading, error, data } = useQuery<UserOverViewData>(
-    UserOverViewQuery,
-    { variables: { language } },
-  )
+  const { loading, error, data } = useQuery<UserOverViewData>(UserOverViewQuery)
 
   if (error) {
     return (

--- a/frontend/pages/[lng]/register-completion/[slug].tsx
+++ b/frontend/pages/[lng]/register-completion/[slug].tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles(() =>
 )
 
 export const UserOverViewQuery = gql`
-  query RegisterCompletionUserOverView {
+  query RegisterCompletionUserOverView($language: String) {
     currentUser {
       id
       upstream_id
@@ -57,10 +57,11 @@ export const UserOverViewQuery = gql`
         completion_link
         student_number
         created_at
-        course {
+        course(language: $language) {
           id
           slug
           name
+          ects
         }
         completions_registered {
           id
@@ -81,10 +82,13 @@ interface RegisterCompletionPageProps {
 const RegisterCompletion = (props: RegisterCompletionPageProps) => {
   const { router, slug } = props
   const classes = useStyles()
-  const lng = useContext(LanguageContext)
+  const { language } = useContext(LanguageContext)
 
-  const t = getRegisterCompletionTranslator(lng.language)
-  const { loading, error, data } = useQuery<UserOverViewData>(UserOverViewQuery)
+  const t = getRegisterCompletionTranslator(language)
+  const { loading, error, data } = useQuery<UserOverViewData>(
+    UserOverViewQuery,
+    { variables: { language } },
+  )
 
   if (error) {
     return (
@@ -152,7 +156,7 @@ const RegisterCompletion = (props: RegisterCompletionPageProps) => {
         {t("title")}
       </Typography>
       <Typography variant="h6" component="p" className={classes.courseInfo}>
-        {t("course")}
+        {t("course", { course: completion.course.name })}
       </Typography>
       <Typography
         variant="h6"
@@ -160,7 +164,7 @@ const RegisterCompletion = (props: RegisterCompletionPageProps) => {
         className={classes.courseInfo}
         gutterBottom={true}
       >
-        {t("credits")}
+        {t("credits", { ects: completion.course.ects })}
       </Typography>
       <Paper className={classes.paper}>
         <Typography variant="body1" paragraph>

--- a/frontend/static/types/generated/RegisterCompletionUserOverView.ts
+++ b/frontend/static/types/generated/RegisterCompletionUserOverView.ts
@@ -11,6 +11,7 @@ export interface RegisterCompletionUserOverView_currentUser_completions_course {
   id: any
   slug: string
   name: string
+  ects: string | null
 }
 
 export interface RegisterCompletionUserOverView_currentUser_completions_completions_registered_organization {
@@ -50,4 +51,8 @@ export interface RegisterCompletionUserOverView_currentUser {
 
 export interface RegisterCompletionUserOverView {
   currentUser: RegisterCompletionUserOverView_currentUser | null
+}
+
+export interface RegisterCompletionUserOverViewVariables {
+  language?: string | null
 }

--- a/frontend/translations/index.ts
+++ b/frontend/translations/index.ts
@@ -6,7 +6,58 @@ type Translation = {
 
 const getTranslator = <T extends Translation>(dicts: { [lang: string]: T }) => (
   lng: string,
-) => (key: keyof T) =>
-  (dicts[lng] || {})[key] || (dicts[defaultLanguage] || {})[key] || key
+) => (key: keyof T, variables?: { [key: string]: any }) => {
+  const translation: T | keyof T | T[keyof T] =
+    (dicts[lng] || {})[key] || (dicts[defaultLanguage] || {})[key] || key
+
+  return Array.isArray(translation)
+    ? translation.map(t => substitute<T>(t, variables))
+    : substitute<T>(translation, variables)
+}
+
+const substitute = <T>(
+  translation: T | keyof T | T[keyof T],
+  variables?: { [key: string]: any },
+): any => {
+  if (typeof translation === "object") {
+    return Object.keys(translation).reduce(
+      (obj, key) => ({
+        ...obj,
+        // @ts-ignore
+        [key]: substitute(translation[key], variables),
+      }),
+      {},
+    )
+  }
+
+  const groups = (translation as string).match(/{{(.*?)}}/gm)
+
+  if (!groups) {
+    return translation
+  }
+
+  if (!variables) {
+    console.warn(
+      `WARNING: no variables present for translation string "${translation}"`,
+    )
+    return translation
+  }
+
+  let ret = translation as string
+  ;(groups || []).forEach((g: string) => {
+    const key = (g.match(/{{(.*?)}}/) || [])[1]
+    const variable = (variables || {})[key]
+
+    if (!variable) {
+      console.warn(
+        `WARNING: no variable present for translation string "${translation}" and key "${key}"`,
+      )
+    } else {
+      ret = ret.replace(`{{${key}}}`, `${variable}`)
+    }
+  })
+
+  return ret
+}
 
 export default getTranslator

--- a/frontend/translations/register-completion/en.json
+++ b/frontend/translations/register-completion/en.json
@@ -1,7 +1,7 @@
 {
     "title": "Register Completion",
-    "course": "Course: The Elements of AI.",
-    "credits":"Credits: 2 (Requires a Finnish social security number). ",
+    "course": "Course: {{course}}",
+    "credits":"Credits: {{ects}} (Requires a Finnish social security number). ",
     "credits_details": "The open university of the University of Helsinki is responsible for registering the credits. Registering the credits is free.",
     "donow": "Register to the Open University of the University of Helsinki, so we can process your credits.",
     "instructions-title": "Follow these instructions: ",

--- a/frontend/translations/register-completion/fi.json
+++ b/frontend/translations/register-completion/fi.json
@@ -1,7 +1,7 @@
 {
     "title": "Opintopisteiden Rekisteröinti",
-    "course": "Kurssi: The elements of AI.",
-    "credits": "Opintopisteet: 2 (Vaatii suomalaisen henkilötunnuksen).",
+    "course": "Kurssi: {{course}}",
+    "credits": "Opintopisteet: {{ects}} (Vaatii suomalaisen henkilötunnuksen).",
     "credits_details": "Helsingin yliopiston avoin yliopisto hoitaa suoritusten rekisteröinnin. Opintosuorituksen rekisteröinti on ilmaista.",
     "donow": "Sinun tulee ilmoittautua Helsingin yliopiston avoimeen yliopistoon, jotta voimme rekisteröidä suorituksesi.",
     "instructions-title": "Toimi näin:",


### PR DESCRIPTION
- course now has an ECTS field - a string, so ranges like 2-5 can be used
- translator now accepts variables. For example, {{a}} inside translation is replaced by value given to the translation in an object as a second variable - like t("translation", { a: "value of a" })