### PR TITLE
Module card fix

### DIFF
--- a/frontend/components/Home/CourseAndModuleList.tsx
+++ b/frontend/components/Home/CourseAndModuleList.tsx
@@ -86,10 +86,10 @@ const CourseAndModuleList = () => {
           title={t("highlightTitle")}
           headerImage={highlightsBanner}
           subtitle={t("highlightSubtitle")}
-          backgroundColor="#009CA6"
+          backgroundColor="#4D78A3"
           hueRotateAngle={177}
           brightness={5.5}
-          fontColor="black"
+          fontColor="#4D78A3"
           titleBackground="#ffffff"
         />
         <CourseHighlights
@@ -109,7 +109,7 @@ const CourseAndModuleList = () => {
           backgroundColor="#007DC8"
           hueRotateAngle={0}
           brightness={5.5}
-          fontColor="black"
+          fontColor="#007DC8"
           titleBackground="#ffffff"
         />
       </section>

--- a/frontend/components/Home/CourseHighlights.tsx
+++ b/frontend/components/Home/CourseHighlights.tsx
@@ -11,11 +11,10 @@ interface RootProps {
 }
 
 const Root = styled.div<RootProps>`
-  margin-top: 1em;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  margin-bottom: 5em;
+
   padding-bottom: 4em;
   position: relative;
   ${props => `background-color: ${props.backgroundColor};`}
@@ -65,7 +64,11 @@ const CourseHighlights = (props: CourseHighlightsProps) => {
           {title}
         </H2Background>
         {subtitle && (
-          <SubtitleBackground component="div" variant="subtitle1">
+          <SubtitleBackground
+            component="div"
+            variant="subtitle1"
+            fontcolor={fontColor}
+          >
             {subtitle}
           </SubtitleBackground>
         )}

--- a/frontend/components/Home/ModuleNavi.tsx
+++ b/frontend/components/Home/ModuleNavi.tsx
@@ -6,7 +6,18 @@ import LanguageContext from "/contexes/LanguageContext"
 import getHomeTranslator from "/translations/home"
 import { AllModules_study_modules } from "/static/types/generated/AllModules"
 import { H2Background } from "/components/Text/headers"
+import styled from "styled-components"
 
+const NaviArea = styled.section`
+  margin-bottom: 5em;
+  margin-top: 5em;
+`
+
+const NaviTitle = styled(H2Background)`
+  margin-top: 1.3em;
+  margin-bottom: 1em;
+  border-bottom: 5px solid #00281c;
+`
 const ModuleNavi = ({
   modules,
   loading,
@@ -18,16 +29,16 @@ const ModuleNavi = ({
   const t = getHomeTranslator(lng.language)
 
   return (
-    <section style={{ marginBottom: "5em" }}>
-      <H2Background
+    <NaviArea>
+      <NaviTitle
         component="h2"
         variant="h2"
         align="center"
-        fontcolor="#ffffff"
-        titlebackground="rgba(34, 141, 189)"
+        fontcolor="#00281C"
+        titlebackground="#ffffff"
       >
         {t("modulesTitle")}
-      </H2Background>
+      </NaviTitle>
       <Container>
         <Grid container spacing={5}>
           {loading ? (
@@ -42,7 +53,7 @@ const ModuleNavi = ({
           )}
         </Grid>
       </Container>
-    </section>
+    </NaviArea>
   )
 }
 

--- a/frontend/components/Home/ModuleNaviCard.tsx
+++ b/frontend/components/Home/ModuleNaviCard.tsx
@@ -4,9 +4,13 @@ import styled from "styled-components"
 import LangLink from "/components/LangLink"
 import Skeleton from "@material-ui/lab/Skeleton"
 import { AllModules_study_modules } from "/static/types/generated/AllModules"
+
 import ModuleImage from "/components/Home/ModuleImage"
+
 import { CardTitle } from "/components/Text/headers"
+
 import { CardText } from "/components/Text/paragraphs"
+
 import { FullCoverTextBackground } from "/components/Images/CardBackgroundFullCover"
 import { ClicableButtonBase } from "/components/Surfaces/ClicableCard"
 
@@ -22,31 +26,44 @@ const SkeletonBodyText = styled(Skeleton)`
   margin-top: 0.2rem;
 `
 
+const Base = styled(ClicableButtonBase)`
+  height: 200px;
+  width: 100%;
+  background-color: transparent;
+`
+
+const TextBackground = styled(FullCoverTextBackground)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 70%;
+`
+
 const ModuleNaviCard = ({ module }: { module?: AllModules_study_modules }) => (
   <Grid item xs={12} md={6} lg={6}>
     <LangLink href={`#${module ? module.slug : ""}`}>
-      <ClicableButtonBase focusRipple>
+      <Base>
         {module ? (
           <>
             <ModuleImage module={module} />
-            <FullCoverTextBackground style={{ width: "70%" }}>
+            <TextBackground>
               <CardTitle variant="h3" component="h3" align="left">
                 {module.name}
               </CardTitle>
               <CardText component="p" variant="body1" align="left">
                 {module.description}
               </CardText>
-            </FullCoverTextBackground>
+            </TextBackground>
           </>
         ) : (
           <>
-            <FullCoverTextBackground style={{ width: "70%" }}>
+            <TextBackground style={{ width: "70%" }}>
               <SkeletonTitle width="100%" />
               <SkeletonBodyText variant="text" />
-            </FullCoverTextBackground>
+            </TextBackground>
           </>
         )}
-      </ClicableButtonBase>
+      </Base>
     </LangLink>
   </Grid>
 )

--- a/frontend/components/Home/NaviCardList.tsx
+++ b/frontend/components/Home/NaviCardList.tsx
@@ -22,7 +22,7 @@ function NaviCardList() {
 
   return (
     <Container>
-      <Grid container spacing={3}>
+      <Grid container spacing={3} style={{ marginBottom: "3em" }}>
         {items.map(item => (
           <NaviCard
             key={`navi-${item.title}`}

--- a/frontend/components/ModuleCard.tsx
+++ b/frontend/components/ModuleCard.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Grid, Button } from "@material-ui/core"
+import { Grid, Typography } from "@material-ui/core"
 import EditIcon from "@material-ui/icons/Edit"
 import AddIcon from "@material-ui/icons/Add"
 import AddCircleIcon from "@material-ui/icons/AddCircle"
@@ -7,19 +7,18 @@ import styled from "styled-components"
 import { mime } from "/util/imageUtils"
 import LangLink from "/components/LangLink"
 import { AllEditorModulesWithTranslations_study_modules } from "/static/types/generated/AllEditorModulesWithTranslations"
-import { CardTitle } from "/components/Text/headers"
+import { ClicableDiv } from "/components/Surfaces/ClicableCard"
+import { ButtonWithPaddingAndMargin } from "/components/Buttons/ButtonWithPaddingAndMargin"
 
-const Base = styled.div`
-  position: relative;
+const Base = styled(ClicableDiv)`
   width: 100%;
   overflow: hidden;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
   height: 200px;
   @media (min-width: 720px) {
     height: 300px;
   }
 `
+
 const ImageBackground = styled.span`
   position: absolute;
   left: 0;
@@ -61,6 +60,26 @@ const ContentArea = styled.span`
   padding-top: 1em;
 `
 
+const NaviCardTitle = styled(Typography)`
+  margin-bottom: 1rem;
+  margin-left: 1rem;
+  max-width: 60%;
+  line-height: 1.2em;
+  @media (min-width: 320px) {
+    font-size: 26px;
+  }
+  @media (min-width: 420px) {
+    font-size: 32px;
+  }
+  @media (min-width: 720px) {
+    font-size: 46px;
+  }
+  @media (min-width: 720px) {
+    font-size: 48px;
+  }
+  flex: 1;
+`
+
 function ModuleCard({
   module,
 }: {
@@ -94,26 +113,34 @@ function ModuleCard({
         )}
         <ImageCover />
         <ContentArea>
-          <CardTitle component="h2" variant="h3" align="left">
+          <NaviCardTitle align="left">
             {module ? module.name : "New module"}
-          </CardTitle>
+          </NaviCardTitle>
 
           {module ? (
             <LangLink href={`/study-modules/${module.slug}/edit`}>
               <a>
-                <Button variant="contained" color="secondary" fullWidth>
+                <ButtonWithPaddingAndMargin
+                  variant="contained"
+                  color="secondary"
+                  style={{ width: "68%" }}
+                >
                   <EditIcon />
                   Edit
-                </Button>
+                </ButtonWithPaddingAndMargin>
               </a>
             </LangLink>
           ) : (
             <LangLink href={`/study-modules/new`}>
               <a>
-                <Button variant="contained" color="secondary" fullWidth>
+                <ButtonWithPaddingAndMargin
+                  variant="contained"
+                  color="secondary"
+                  style={{ width: "68%" }}
+                >
                   <AddIcon />
                   Create
-                </Button>
+                </ButtonWithPaddingAndMargin>
               </a>
             </LangLink>
           )}

--- a/frontend/components/Text/headers.tsx
+++ b/frontend/components/Text/headers.tsx
@@ -47,17 +47,25 @@ export const H2Background = styled(Typography)<TitleProps>`
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 1rem;
   display: table;
+  font-family: Roboto;
+  font-weight: 550;
 
   ${props =>
     ` background-color: ${props.titlebackground}; color: ${props.fontcolor};`}
 `
-export const SubtitleBackground = styled(Typography)`
+interface SubTitleProps {
+  fontcolor?: string
+}
+export const SubtitleBackground = styled(Typography)<SubTitleProps>`
   margin: 0rem auto 3rem auto;
   padding: 1rem;
   display: table;
   background-color: white;
+  font-family: Roboto;
+  font-weight: 450;
+  ${props => `color: ${props.fontcolor ? props.fontcolor : `black`};`}
 `
 
 export const CardTitle = styled(Typography)`


### PR DESCRIPTION
- Small ui fixes on the homepage: 
Colours changed on new courses 
More font weight and font color matching the background colour on course highlights headers
Gaps removed from between course highlights components
Study modules title now more distinct from course listing titles

-ModuleNavi and ModuleCards now match what they were before refactoring
(ModuleCard still needs some refactoring done)


