### PR TITLE
Temporary installation guide for Linux users

### DIFF
--- a/frontend/static/md_pages/netbeans_installation_fi.mdx
+++ b/frontend/static/md_pages/netbeans_installation_fi.mdx
@@ -60,11 +60,15 @@ Voit asentaa OpenJFX:n seuraavalla komennolla:
 
 ###  TMCBeansin asentaminen <a name="tmcbeansin-asentaminen"></a>
 
-Aja terminaalissa komento
+Lataa tiedosto [https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_amd64.snap](https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_amd64.snap).
 
-> `sudo snap install tmcbeans`
+Mene terminaalissa siihen kansioon, johon latasit tiedoston ja aja komento
 
-Voit nyt käynnistää TMCBeansin joko terminaalista komennolla `tmcbeans` tai avaamalla sen Activities:stä.
+> `sudo snap install --classic --dangerous tmcbeans_1.3.0_amd64.snap`
+
+Syötä salasanasi terminaaliin pyydettäessä ja paina enter.
+
+Kun saat viestin 'tmcbeans 1.3.0 installed', voit käynnistää TMCBeansin joko terminaalista komennolla `tmcbeans` tai avaamalla sen Activities:stä.
 
 ***
 


### PR DESCRIPTION
Temporary instalation guide for Linux user guiding them to download the snap package and running snap install at download location. Will be changed back once TMCBeans is approved for snap store.