### PR TITLE
Update links to download.mooc.fi, fix bug in linux selector

### DIFF
--- a/frontend/pages/[lng]/installation/netbeans.tsx
+++ b/frontend/pages/[lng]/installation/netbeans.tsx
@@ -48,6 +48,7 @@ export const ContentBox = styled.div`
   margin-left: auto;
   margin-right: auto;
   padding: 2em;
+  padding-top: 5em;
   margin-top: 1em;
   font-size: 18px;
   line-height: 37px;

--- a/frontend/static/md_pages/netbeans_installation_any_fi.mdx
+++ b/frontend/static/md_pages/netbeans_installation_any_fi.mdx
@@ -2,10 +2,20 @@ import {ContentBox, SectionBox} from "/pages/[lng]/installation/netbeans"
 
 <ContentBox>
 
-## ZIP kansion käyttäminen
+## ZIP version lataaminen
 
-TMCBeansista on myös saatavilla suoraan puretusta kansiosta ajettava versio, joka on saatavilla täältä: [https://storage.googleapis.com/tmcbeans/tmcbeans.zip](https://storage.googleapis.com/tmcbeans/tmcbeans.zip)
+TMCBeansista on myös saatavilla suoraan puretusta kansiosta ajettava versio, joka on saatavilla täältä: [https://download.mooc.fi/tmcbeans/installers/tmcbeans.zip](https://download.mooc.fi/tmcbeans/installers/tmcbeans.zip)
 
 Tarvitset tätä varten JDK:n version 11. Huommaathan, että tämä on vain edistyneemmille käyttäjille. Suosittelemme ensisijaisesti käyttämään käyttöjärjestelmällesi sopivaa asennusohjetta tämän ohjeen yläpuolella olevasta valikosta.
+
+## ZIP version käynnistäminen
+
+Kun olet ladannut ZIP version ylläolevan ohjeen mukaisesti, seuraa seuraavia askelia:
+
+1. Mene kansioon, johon latasit zip-paketin.
+2. Pura zip-paketti.
+3. Mene purettuun tmcbeans/ -kansioon.
+4. Avaa bin/ -alikansio.
+5. Käynnistä suoritettava tiedosto tmcbeans ajamalla komento `./tmcbeans` tai kaksoisklikkaamalla tiedoston nimeä.
 
 </ContentBox>

--- a/frontend/static/md_pages/netbeans_installation_fi.mdx
+++ b/frontend/static/md_pages/netbeans_installation_fi.mdx
@@ -60,7 +60,7 @@ Voit asentaa OpenJFX:n seuraavalla komennolla:
 
 ###  TMCBeansin asentaminen <a name="tmcbeansin-asentaminen"></a>
 
-Lataa tiedosto [https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_amd64.snap](https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_amd64.snap).
+Lataa tiedosto [https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_amd64.snap](https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_amd64.snap).
 
 Mene terminaalissa siihen kansioon, johon latasit tiedoston ja aja komento
 
@@ -69,6 +69,8 @@ Mene terminaalissa siihen kansioon, johon latasit tiedoston ja aja komento
 Syötä salasanasi terminaaliin pyydettäessä ja paina enter.
 
 Kun saat viestin 'tmcbeans 1.3.0 installed', voit käynnistää TMCBeansin joko terminaalista komennolla `tmcbeans` tai avaamalla sen Activities:stä.
+
+**Jos snap install ei toimi koneellasi**, katso täältä miten saat snapin asennettua: [Installing snapd](https://snapcraft.io/docs/installing-snapd). Jos käyttöjärjestelmällesi ei saa asennettua snap:iä tuolta, lataa sivun yläreunasta TMCBeansin zip-versio.
 
 ***
 

--- a/frontend/static/md_pages/netbeans_installation_mac_fi.mdx
+++ b/frontend/static/md_pages/netbeans_installation_mac_fi.mdx
@@ -51,7 +51,7 @@ width="100%" height="100%" />
 
 ###  2.TMCBeansin Asentaminen <a name="tmcbeansin-asentaminen"></a>
 
-1. Lataa tiedosto [https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_installer.dmg](https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_installer.dmg).
+1. Lataa tiedosto [https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_installer.dmg](https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_installer.dmg).
 2. Kun tiedoston lataaminen on valmis, avaa ladattu tiedosto. Näkyviin pitäisi tulla allaoleva näkymä.
 
 <img src="/static/images/installation/macos-tmcbeans-installer.png"

--- a/frontend/static/md_pages/netbeans_installation_windows_fi.mdx
+++ b/frontend/static/md_pages/netbeans_installation_windows_fi.mdx
@@ -46,7 +46,7 @@ width="100%" height="100%" />
 
 ###  TMCBeansin Asentaminen <a name="tmcbeansin-asentaminen"></a>
 
-1. Lataa tiedosto [https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_installer.exe](https://storage.googleapis.com/tmcbeans/tmcbeans_1.3.0_installer.exe).
+1. Lataa tiedosto [https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_installer.exe](https://download.mooc.fi/tmcbeans/installers/tmcbeans_1.3.0_installer.exe).
 2. Kun tiedoston lataaminen on valmis, tuplaklikkaa tiedostoa avataksesi asennusohjelman.
 3. Tämän jälkeen seuraa ruudulle tulevia ohjeita.
 

--- a/frontend/util/getUserOS.tsx
+++ b/frontend/util/getUserOS.tsx
@@ -6,6 +6,7 @@ function getUserOS(): userOsType {
     if (window.navigator.appVersion.indexOf("Win") != -1) OSName = "Windows"
     if (window.navigator.appVersion.indexOf("Mac") != -1) OSName = "macOS"
     if (window.navigator.appVersion.indexOf("Linux") != -1) OSName = "Linux"
+    if (window.navigator.appVersion.indexOf("X11") != -1) OSName = "Linux"
     return OSName
   } else {
     return OSName


### PR DESCRIPTION
Update TMCBeans installation links to point to download.mooc.fi.
Fix a bug in os detector to detect Linux correctly.