### PR TITLE
sign in from header link was broken because of redirect bug

### DIFF
--- a/frontend/components/Dashboard/Editor/FormWrapper.tsx
+++ b/frontend/components/Dashboard/Editor/FormWrapper.tsx
@@ -13,6 +13,7 @@ import ConfirmationDialog from "/components/Dashboard/ConfirmationDialog"
 import styled from "styled-components"
 import { ButtonWithPaddingAndMargin as StyledButton } from "/components/Buttons/ButtonWithPaddingAndMargin"
 
+// TODO: show delete to course owner
 const isProduction = process.env.NODE_ENV === "production"
 
 const FormBackground = styled(Paper)`

--- a/frontend/lib/authentication.ts
+++ b/frontend/lib/authentication.ts
@@ -36,12 +36,12 @@ export const signIn = async ({
   document.cookie = `access_token=${res.accessToken};path=/`
   document.cookie = `admin=${details.administrator};path=/`
 
-  const { as, href } = JSON.parse(nookies.get()["redirect-back"] ?? {})
+  const { as, href } = JSON.parse(nookies.get()["redirect-back"] ?? "")
 
   if (redirect) {
     setTimeout(() => {
       if (as && href) {
-        Router.push(href, as, { shallow: true })
+        Router.push(href, as /* , { shallow: true } */)
       } else {
         window.history.back()
       }

--- a/frontend/lib/redirect.ts
+++ b/frontend/lib/redirect.ts
@@ -7,7 +7,6 @@ export default (context: NextContext, target: string, savePage = true) => {
 
   // @ts-ignore
   if (savePage && context?.req?.originalUrl) {
-    // @ts-ignore
     nookies.set(
       context,
       "redirect-back",

--- a/frontend/lib/with-apollo-client.tsx
+++ b/frontend/lib/with-apollo-client.tsx
@@ -97,9 +97,13 @@ const withApolloClient = (App: any) => {
 
       // Extract query data from the Apollo store
       const apolloState = apollo.cache.extract()
+      ;(apollo as any).toJSON = () => {
+        return null
+      }
 
       return {
         ...appProps,
+        apollo,
         apolloState,
         accessToken,
       }
@@ -107,7 +111,8 @@ const withApolloClient = (App: any) => {
 
     constructor(props: Props) {
       super(props)
-      this.apolloClient = initApollo(props.apolloState, props.accessToken)
+      this.apolloClient =
+        props.apollo || initApollo(props.apolloState, props.accessToken)
     }
 
     render() {

--- a/frontend/lib/with-apollo-client.tsx
+++ b/frontend/lib/with-apollo-client.tsx
@@ -97,9 +97,6 @@ const withApolloClient = (App: any) => {
 
       // Extract query data from the Apollo store
       const apolloState = apollo.cache.extract()
-      ;(apollo as any).toJSON = () => {
-        return null
-      }
 
       return {
         ...appProps,


### PR DESCRIPTION
- when there was no `redirect-back` cookie, it defaulted to a wrong value
- disabled shallow redirect for now just to make sure