### PR TITLE
refactored admin, signin/out checks to hocs

### DIFF
--- a/frontend/components/Dashboard/PaginatedPointsList.tsx
+++ b/frontend/components/Dashboard/PaginatedPointsList.tsx
@@ -85,12 +85,12 @@ const LoadingPointCardSkeleton = styled(Skeleton)`
 `
 
 interface Props {
-  courseID: string
+  courseId: string
   cursor?: string
 }
 
 function PaginatedPointsList(props: Props) {
-  const { courseID } = props
+  const { courseId } = props
   const [searchString, setSearchString] = useState("")
   const [cutterValue, setCutterValue] = useState(0)
   const [search, setSearch] = useDebounce(searchString, 1000)
@@ -106,10 +106,10 @@ function PaginatedPointsList(props: Props) {
     () =>
       getData({
         variables: {
-          course_id: courseID,
+          course_id: courseId,
           cursor: null,
           search,
-          course_string: courseID,
+          course_string: courseId,
         },
       }),
     [search],
@@ -197,10 +197,10 @@ function PaginatedPointsList(props: Props) {
               fetchMore({
                 query: StudentProgresses,
                 variables: {
-                  course_id: courseID,
+                  course_id: courseId,
                   cursor: UserCourseSettingses.pageInfo.endCursor,
                   search: search !== "" ? search : undefined,
-                  course_string: courseID,
+                  course_string: courseId,
                 },
 
                 updateQuery: (previousResult, { fetchMoreResult }) => {

--- a/frontend/lib/redirect.ts
+++ b/frontend/lib/redirect.ts
@@ -6,7 +6,7 @@ export default (context: NextContext, target: string, savePage = true) => {
   let language = context?.query?.lng ?? "fi"
 
   // @ts-ignore
-  if (savePage && context?.req?.originalUrl) {
+  if (savePage && context?.pathname /* context?.req?.originalUrl */) {
     nookies.set(
       context,
       "redirect-back",
@@ -31,7 +31,6 @@ export default (context: NextContext, target: string, savePage = true) => {
     context.res.end()
   } else {
     // In the browser, we just pretend like this never even happened ;)
-    // FIXME: (?) add other fields to push
     if (target !== "/") {
       Router.push(`/[lng]${sep}${target}`, targetWithLanguage, {
         shallow: true,

--- a/frontend/lib/with-admin.tsx
+++ b/frontend/lib/with-admin.tsx
@@ -1,24 +1,40 @@
 import React from "react"
 import { NextPageContext as NextContext } from "next"
-import { isAdmin } from "/lib/authentication"
+import { isAdmin, isSignedIn } from "/lib/authentication"
 import AdminError from "/components/Dashboard/AdminError"
+import redirect from "/lib/redirect"
 
 export default function withAdmin(Component: any) {
-  return class WithAdmin extends React.Component<{ admin: boolean }> {
+  return class WithAdmin extends React.Component<{
+    admin: boolean
+    signedIn: boolean
+  }> {
     static displayName = `withAdmin(${Component.displayName ?? "Component"})`
 
     static async getInitialProps(context: NextContext) {
       const admin = isAdmin(context)
+      const signedIn = isSignedIn(context)
+
+      if (!signedIn) {
+        redirect(context, "/sign-in")
+
+        return {}
+      }
 
       return {
         ...(await Component.getInitialProps?.(context)),
         admin,
+        signedIn,
       }
     }
 
     render() {
       if (!this.props.admin) {
         return <AdminError />
+      }
+
+      if (!this.props.signedIn) {
+        return <div>Redirecting...</div>
       }
 
       return <Component {...this.props}>{this.props.children}</Component>

--- a/frontend/lib/with-admin.tsx
+++ b/frontend/lib/with-admin.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { NextPageContext as NextContext } from "next"
+import { isAdmin } from "/lib/authentication"
+import AdminError from "/components/Dashboard/AdminError"
+
+export default function withAdmin(Component: any) {
+  return class WithAdmin extends React.Component<{ admin: boolean }> {
+    static displayName = `withAdmin(${Component.displayName ?? "Component"})`
+
+    static async getInitialProps(context: NextContext) {
+      const admin = isAdmin(context)
+
+      return {
+        ...(await Component.getInitialProps?.(context)),
+        admin,
+      }
+    }
+
+    render() {
+      if (!this.props.admin) {
+        return <AdminError />
+      }
+
+      return <Component {...this.props}>{this.props.children}</Component>
+    }
+  }
+}

--- a/frontend/lib/with-signed-in.tsx
+++ b/frontend/lib/with-signed-in.tsx
@@ -3,21 +3,31 @@ import { NextPageContext as NextContext } from "next"
 import { isSignedIn } from "/lib/authentication"
 import redirect from "/lib/redirect"
 
+// TODO: might need to wrap in function to give redirect parameters (= shallow?)
 export default function withSignedIn(Component: any) {
-  return class WithSignedIn extends React.Component {
+  return class WithSignedIn extends React.Component<{ signedIn: boolean }> {
     static displayName = `withSignedIn(${Component.displayName ?? "Component"})`
 
     static async getInitialProps(context: NextContext) {
-      if (!isSignedIn(context)) {
+      const signedIn = isSignedIn(context)
+
+      if (!signedIn) {
         redirect(context, "/sign-in")
+
+        return {}
       }
 
       return {
         ...(await Component.getInitialProps?.(context)),
+        signedIn,
       }
     }
 
     render() {
+      if (!this.props.signedIn) {
+        return <div>Redirecting...</div>
+      }
+
       return <Component {...this.props}>{this.props.children}</Component>
     }
   }

--- a/frontend/lib/with-signed-in.tsx
+++ b/frontend/lib/with-signed-in.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { NextPageContext as NextContext } from "next"
+import { isSignedIn } from "/lib/authentication"
+import redirect from "/lib/redirect"
+
+export default function withSignedIn(Component: any) {
+  return class WithSignedIn extends React.Component {
+    static displayName = `withSignedIn(${Component.displayName ?? "Component"})`
+
+    static async getInitialProps(context: NextContext) {
+      if (!isSignedIn(context)) {
+        redirect(context, "/sign-in")
+      }
+
+      return {
+        ...(await Component.getInitialProps?.(context)),
+      }
+    }
+
+    render() {
+      return <Component {...this.props}>{this.props.children}</Component>
+    }
+  }
+}

--- a/frontend/lib/with-signed-out.tsx
+++ b/frontend/lib/with-signed-out.tsx
@@ -3,23 +3,31 @@ import { NextPageContext as NextContext } from "next"
 import { isSignedIn } from "/lib/authentication"
 import redirectTo from "/lib/redirect"
 
+// TODO: add more redirect parameters?
 export default function withSignedOut(redirect = "/") {
   return (Component: any) => {
-    return class WithSignedOut extends React.Component {
+    return class WithSignedOut extends React.Component<{ signedIn: boolean }> {
       static displayName = `withSignedOut(${Component.displayName ??
         "Component"})`
 
       static async getInitialProps(context: NextContext) {
-        if (isSignedIn(context)) {
+        const signedIn = isSignedIn(context)
+
+        if (signedIn) {
           redirectTo(context, redirect)
         }
 
         return {
           ...(await Component.getInitialProps?.(context)),
+          signedIn,
         }
       }
 
       render() {
+        if (this.props.signedIn) {
+          return <div>Redirecting...</div>
+        }
+
         return <Component {...this.props}>{this.props.children}</Component>
       }
     }

--- a/frontend/lib/with-signed-out.tsx
+++ b/frontend/lib/with-signed-out.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { NextPageContext as NextContext } from "next"
+import { isSignedIn } from "/lib/authentication"
+import redirectTo from "/lib/redirect"
+
+export default function withSignedOut(redirect = "/") {
+  return (Component: any) => {
+    return class WithSignedOut extends React.Component {
+      static displayName = `withSignedOut(${Component.displayName ??
+        "Component"})`
+
+      static async getInitialProps(context: NextContext) {
+        if (isSignedIn(context)) {
+          redirectTo(context, redirect)
+        }
+
+        return {
+          ...(await Component.getInitialProps?.(context)),
+        }
+      }
+
+      render() {
+        return <Component {...this.props}>{this.props.children}</Component>
+      }
+    }
+  }
+}

--- a/frontend/pages/[lng]/courses.tsx
+++ b/frontend/pages/[lng]/courses.tsx
@@ -1,27 +1,20 @@
 import * as React from "react"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import { AllEditorCourses } from "/static/types/generated/AllEditorCourses"
 import { useQuery } from "@apollo/react-hooks"
 import CourseGrid from "/components/CourseGrid"
-import AdminError from "/components/Dashboard/AdminError"
 import { WideContainer } from "/components/Container"
 import styled from "styled-components"
-// import Spinner from "/components/Spinner"
 import { H1Background } from "/components/Text/headers"
 import { AllEditorCoursesQuery } from "/graphql/queries/courses"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withSignedIn from "/lib/with-signed-in"
+import withAdmin from "/lib/with-admin"
 
 const Background = styled.section`
   background-color: #61baad;
 `
 
-interface CourseProps {
-  admin: boolean
-}
-
-const Courses = ({ admin }: CourseProps) => {
+const Courses = () => {
   const { loading, error, data } = useQuery<AllEditorCourses>(
     AllEditorCoursesQuery,
   )
@@ -32,10 +25,6 @@ const Courses = ({ admin }: CourseProps) => {
         errorMessage={JSON.stringify(error, undefined, 2)}
       />
     )
-  }
-
-  if (!admin) {
-    return <AdminError />
   }
 
   return (
@@ -50,14 +39,6 @@ const Courses = ({ admin }: CourseProps) => {
   )
 }
 
-Courses.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+Courses.displayName = "Courses"
 
-export default Courses
+export default withAdmin(withSignedIn(Courses))

--- a/frontend/pages/[lng]/courses.tsx
+++ b/frontend/pages/[lng]/courses.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components"
 import { H1Background } from "/components/Text/headers"
 import { AllEditorCoursesQuery } from "/graphql/queries/courses"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
-import withSignedIn from "/lib/with-signed-in"
 import withAdmin from "/lib/with-admin"
 
 const Background = styled.section`
@@ -41,4 +40,4 @@ const Courses = () => {
 
 Courses.displayName = "Courses"
 
-export default withAdmin(withSignedIn(Courses))
+export default withAdmin(Courses)

--- a/frontend/pages/[lng]/courses/[id]/completions.tsx
+++ b/frontend/pages/[lng]/courses/[id]/completions.tsx
@@ -1,8 +1,4 @@
 import React, { useContext, useState } from "react"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import { NextPageContext as NextContext } from "next"
-import AdminError from "/components/Dashboard/AdminError"
 import CompletionsList from "/components/Dashboard/CompletionsList"
 import { WideContainer } from "/components/Container"
 import CourseLanguageContext from "/contexes/CourseLanguageContext"
@@ -18,6 +14,9 @@ import { useQueryParameter } from "/util/useQueryParameter"
 import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/generated/CourseDetailsFromSlug"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
+
 export const CourseDetailsFromSlugQuery = gql`
   query CompletionCourseDetails($slug: String) {
     course(slug: $slug) {
@@ -27,12 +26,7 @@ export const CourseDetailsFromSlugQuery = gql`
   }
 `
 
-interface CompletionsProps {
-  admin: boolean
-  router: SingletonRouter
-}
-
-const Completions = ({ admin, router }: CompletionsProps) => {
+const Completions = ({ router }: { router: SingletonRouter }) => {
   const { language } = useContext(LanguageContext)
   const [lng, changeLng] = useState(
     (router?.query?.language as string) ??
@@ -58,10 +52,6 @@ const Completions = ({ admin, router }: CompletionsProps) => {
       variables: { slug: slug },
     },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   if (loading || !data) {
     return <Spinner />
@@ -99,15 +89,6 @@ const Completions = ({ admin, router }: CompletionsProps) => {
   )
 }
 
-Completions.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
+Completions.displayName = "Completions"
 
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
-
-export default withRouter(Completions)
+export default withRouter(withAdmin(withSignedIn(Completions)) as any)

--- a/frontend/pages/[lng]/courses/[id]/completions.tsx
+++ b/frontend/pages/[lng]/courses/[id]/completions.tsx
@@ -15,7 +15,6 @@ import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/genera
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const CourseDetailsFromSlugQuery = gql`
   query CompletionCourseDetails($slug: String) {
@@ -91,4 +90,4 @@ const Completions = ({ router }: { router: SingletonRouter }) => {
 
 Completions.displayName = "Completions"
 
-export default withRouter(withAdmin(withSignedIn(Completions)) as any)
+export default withRouter(withAdmin(Completions) as any)

--- a/frontend/pages/[lng]/courses/[id]/edit.tsx
+++ b/frontend/pages/[lng]/courses/[id]/edit.tsx
@@ -16,7 +16,6 @@ import { H1NoBackground } from "/components/Text/headers"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import { useQueryParameter } from "/util/useQueryParameter"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const CourseQuery = gql`
   query CourseDetails($slug: String) {
@@ -164,4 +163,4 @@ const EditCourse = ({ router }: EditCourseProps) => {
 
 EditCourse.displayName = "EditCourse"
 
-export default withRouter(withAdmin(withSignedIn(EditCourse)) as any)
+export default withRouter(withAdmin(EditCourse) as any)

--- a/frontend/pages/[lng]/courses/[id]/index.tsx
+++ b/frontend/pages/[lng]/courses/[id]/index.tsx
@@ -1,10 +1,6 @@
 import React from "react"
 import DashboardTabBar from "/components/Dashboard/DashboardTabBar"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import AdminError from "/components/Dashboard/AdminError"
 import CourseDashboard from "/components/Dashboard/CourseDashboard"
-import { NextPageContext as NextContext } from "next"
 import { WideContainer } from "/components/Container"
 import { useQuery } from "@apollo/react-hooks"
 import { gql } from "apollo-boost"
@@ -13,6 +9,8 @@ import { useQueryParameter } from "/util/useQueryParameter"
 import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/generated/CourseDetailsFromSlug"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 export const CourseDetailsFromSlugQuery = gql`
   query CourseDetailsFromSlugQuery($slug: String) {
@@ -23,10 +21,7 @@ export const CourseDetailsFromSlugQuery = gql`
   }
 `
 
-interface CourseProps {
-  admin: boolean
-}
-const Course = ({ admin }: CourseProps) => {
+const Course = () => {
   const slug = useQueryParameter("id")
 
   const { data, loading, error } = useQuery<CourseDetailsData>(
@@ -35,10 +30,6 @@ const Course = ({ admin }: CourseProps) => {
       variables: { slug: slug },
     },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   //TODO add circular progress
   if (loading || !data) {
@@ -73,15 +64,6 @@ const Course = ({ admin }: CourseProps) => {
   )
 }
 
-Course.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
+Course.displayName = "Course"
 
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
-
-export default Course
+export default withAdmin(withSignedIn(Course))

--- a/frontend/pages/[lng]/courses/[id]/index.tsx
+++ b/frontend/pages/[lng]/courses/[id]/index.tsx
@@ -10,7 +10,6 @@ import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/genera
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const CourseDetailsFromSlugQuery = gql`
   query CourseDetailsFromSlugQuery($slug: String) {
@@ -66,4 +65,4 @@ const Course = () => {
 
 Course.displayName = "Course"
 
-export default withAdmin(withSignedIn(Course))
+export default withAdmin(Course)

--- a/frontend/pages/[lng]/courses/[id]/points.tsx
+++ b/frontend/pages/[lng]/courses/[id]/points.tsx
@@ -12,7 +12,6 @@ import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/genera
 import Spinner from "/components/Spinner"
 import ModifiableErrorMesage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const CourseDetailsFromSlugQuery = gql`
   query CourseDetailsFromSlug($slug: String) {
@@ -69,4 +68,4 @@ const Points = () => {
 
 Points.displayName = "Points"
 
-export default withAdmin(withSignedIn(Points))
+export default withAdmin(Points)

--- a/frontend/pages/[lng]/courses/[id]/points.tsx
+++ b/frontend/pages/[lng]/courses/[id]/points.tsx
@@ -1,8 +1,4 @@
 import React from "react"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import { NextPageContext as NextContext } from "next"
-import AdminError from "/components/Dashboard/AdminError"
 import Container from "/components/Container"
 import CourseLanguageContext from "/contexes/CourseLanguageContext"
 import DashboardTabBar from "/components/Dashboard/DashboardTabBar"
@@ -15,6 +11,8 @@ import { useQueryParameter } from "/util/useQueryParameter"
 import { CourseDetailsFromSlug as CourseDetailsData } from "/static/types/generated/CourseDetailsFromSlug"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMesage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 export const CourseDetailsFromSlugQuery = gql`
   query CourseDetailsFromSlug($slug: String) {
@@ -25,11 +23,7 @@ export const CourseDetailsFromSlugQuery = gql`
   }
 `
 
-interface CompletionsProps {
-  admin: boolean
-}
-
-const Points = ({ admin }: CompletionsProps) => {
+const Points = () => {
   const slug = useQueryParameter("id")
   const lng = useQueryParameter("lng")
 
@@ -39,10 +33,6 @@ const Points = ({ admin }: CompletionsProps) => {
       variables: { slug: slug },
     },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   if (loading || !data) {
     return <Spinner />
@@ -71,21 +61,12 @@ const Points = ({ admin }: CompletionsProps) => {
           Points
         </SubtitleNoBackground>
         <PointsExportButton slug={slug} />
-        <PaginatedPointsList courseID={data.course.id} />
+        <PaginatedPointsList courseId={data.course.id} />
       </Container>
     </CourseLanguageContext.Provider>
   )
 }
 
-Points.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
+Points.displayName = "Points"
 
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
-
-export default Points
+export default withAdmin(withSignedIn(Points))

--- a/frontend/pages/[lng]/courses/new.tsx
+++ b/frontend/pages/[lng]/courses/new.tsx
@@ -1,8 +1,4 @@
 import React from "react"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import AdminError from "/components/Dashboard/AdminError"
 import { WideContainer } from "/components/Container"
 import { gql } from "apollo-boost"
 import { useQuery } from "@apollo/react-hooks"
@@ -12,6 +8,8 @@ import { H1NoBackground } from "/components/Text/headers"
 import { StudyModules as StudyModuleData } from "/static/types/generated/StudyModules"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 export const StudyModuleQuery = gql`
   query StudyModules {
@@ -23,19 +21,8 @@ export const StudyModuleQuery = gql`
   }
 `
 
-interface NewCourseProps {
-  admin: boolean
-  nameSpacesRequired: string[]
-}
-
-const NewCourse = (props: NewCourseProps) => {
-  const { admin } = props
-
+const NewCourse = () => {
   const { data, loading, error } = useQuery<StudyModuleData>(StudyModuleQuery)
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   if (error) {
     return <ModifiableErrorMessage errorMessage={JSON.stringify(error)} />
@@ -61,14 +48,6 @@ const NewCourse = (props: NewCourseProps) => {
   )
 }
 
-NewCourse.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+NewCourse.displayName = "NewCourse"
 
-export default NewCourse
+export default withAdmin(withSignedIn(NewCourse))

--- a/frontend/pages/[lng]/courses/new.tsx
+++ b/frontend/pages/[lng]/courses/new.tsx
@@ -9,7 +9,6 @@ import { StudyModules as StudyModuleData } from "/static/types/generated/StudyMo
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const StudyModuleQuery = gql`
   query StudyModules {
@@ -50,4 +49,4 @@ const NewCourse = () => {
 
 NewCourse.displayName = "NewCourse"
 
-export default withAdmin(withSignedIn(NewCourse))
+export default withAdmin(NewCourse)

--- a/frontend/pages/[lng]/installation/netbeans.tsx
+++ b/frontend/pages/[lng]/installation/netbeans.tsx
@@ -133,8 +133,6 @@ const NetBeans = () => {
   )
 }
 
-NetBeans.getInitialProps = () => {
-  return {}
-}
+NetBeans.displayName = "NetBeans"
 
 export default NetBeans

--- a/frontend/pages/[lng]/profile.tsx
+++ b/frontend/pages/[lng]/profile.tsx
@@ -1,15 +1,13 @@
 import React from "react"
-import { NextPageContext as NextContext } from "next"
-import redirect from "/lib/redirect"
 import { gql } from "apollo-boost"
 import { useQuery } from "@apollo/react-hooks"
 import { ProfileUserOverView as UserOverViewData } from "/static/types/generated/ProfileUserOverView"
-import { isSignedIn } from "/lib/authentication"
 import Spinner from "/components/Spinner"
 import ErrorMessage from "/components/ErrorMessage"
 import ProfilePageHeader from "/components/Profile/ProfilePageHeader"
 import StudentDataDisplay from "/components/Profile/StudentDataDisplay"
 import Container from "/components/Container"
+import withSignedIn from "/lib/with-signed-in"
 
 export const UserOverViewQuery = gql`
   query ProfileUserOverView {
@@ -76,11 +74,6 @@ function Profile() {
   )
 }
 
-Profile.getInitialProps = function(context: NextContext) {
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {}
-}
+Profile.displayName = "Profile"
 
-export default Profile
+export default withSignedIn(Profile)

--- a/frontend/pages/[lng]/profile/completions.tsx
+++ b/frontend/pages/[lng]/profile/completions.tsx
@@ -1,7 +1,4 @@
 import React from "react"
-import { isSignedIn } from "/lib/authentication"
-import { NextPageContext as NextContext } from "next"
-import redirect from "/lib/redirect"
 import { gql } from "apollo-boost"
 import { useQuery } from "@apollo/react-hooks"
 import { CurrentUserUserOverView as UserOverViewData } from "/static/types/generated/CurrentUserUserOverView"
@@ -9,6 +6,7 @@ import Container from "/components/Container"
 import Completions from "/components/Completions"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withSignedIn from "/lib/with-signed-in"
 
 export const UserOverViewQuery = gql`
   query CurrentUserUserOverView {
@@ -26,6 +24,7 @@ export const UserOverViewQuery = gql`
 
 function CompletionsPage() {
   const { loading, error, data } = useQuery<UserOverViewData>(UserOverViewQuery)
+
   if (error) {
     return (
       <ModifiableErrorMessage
@@ -51,11 +50,6 @@ function CompletionsPage() {
   )
 }
 
-CompletionsPage.getInitialProps = function(context: NextContext) {
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {}
-}
+CompletionsPage.displayName = "CompletionsPage"
 
-export default CompletionsPage
+export default withSignedIn(CompletionsPage)

--- a/frontend/pages/[lng]/profile/points.tsx
+++ b/frontend/pages/[lng]/profile/points.tsx
@@ -1,10 +1,8 @@
 import React from "react"
-import { isSignedIn } from "/lib/authentication"
-import { NextPageContext as NextContext } from "next"
-import redirect from "/lib/redirect"
 import Container from "/components/Container"
 import PointsList from "/components/User/Points/PointsList"
 import { H1NoBackground } from "/components/Text/headers"
+import withSignedIn from "/lib/with-signed-in"
 
 function Points() {
   return (
@@ -19,11 +17,6 @@ function Points() {
   )
 }
 
-Points.getInitialProps = function(context: NextContext) {
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {}
-}
+Points.displayName = "Points"
 
-export default Points
+export default withSignedIn(Points)

--- a/frontend/pages/[lng]/register-completion/[slug].tsx
+++ b/frontend/pages/[lng]/register-completion/[slug].tsx
@@ -1,8 +1,5 @@
 import * as React from "react"
 import { gql } from "apollo-boost"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import { useQuery } from "@apollo/react-hooks"
 import { RegisterCompletionUserOverView as UserOverViewData } from "/static/types/generated/RegisterCompletionUserOverView"
 import { Typography, Paper, SvgIcon } from "@material-ui/core"
@@ -18,6 +15,7 @@ import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import styled from "styled-components"
 import UserDetailContext from "/contexes/UserDetailContext"
+import withSignedIn from "/lib/with-signed-in"
 
 const StyledPaper = styled(Paper)`
   padding: 1em;
@@ -80,15 +78,11 @@ export const UserOverViewQuery = gql`
   }
 `
 
-interface RegisterCompletionPageProps {
-  slug?: string | string[]
-}
-
-const RegisterCompletion = ({ slug }: RegisterCompletionPageProps) => {
+const RegisterCompletion = () => {
   const { language } = useContext(LanguageContext)
   const { currentUser } = useContext(UserDetailContext)
 
-  const courseSlug = slug || useQueryParameter("slug")
+  const courseSlug = useQueryParameter("slug")
 
   const t = getRegisterCompletionTranslator(language)
   const { loading, error, data } = useQuery<UserOverViewData>(UserOverViewQuery)
@@ -194,11 +188,6 @@ const RegisterCompletion = ({ slug }: RegisterCompletionPageProps) => {
   )
 }
 
-RegisterCompletion.getInitialProps = function(context: NextContext) {
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in", true)
-  }
-  return {}
-}
+RegisterCompletion.displayName = "RegisterCompletion"
 
-export default RegisterCompletion
+export default withSignedIn(RegisterCompletion)

--- a/frontend/pages/[lng]/register.tsx
+++ b/frontend/pages/[lng]/register.tsx
@@ -1,7 +1,4 @@
 import React, { useState, useEffect, useContext } from "react"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import { gql } from "apollo-boost"
 import { useQuery, useMutation } from "@apollo/react-hooks"
 import {
@@ -33,6 +30,7 @@ import getRegistrationTranslator from "/translations/register"
 import { WideContainer } from "/components/Container"
 import Skeleton from "@material-ui/lab/Skeleton"
 import { range } from "lodash"
+import withSignedIn from "/lib/with-signed-in"
 
 export const OrganizationsQuery = gql`
   query Organizations {
@@ -344,14 +342,6 @@ const Register = () => {
   )
 }
 
-Register.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+Register.displayName = "Register"
 
-export default Register
+export default withSignedIn(Register)

--- a/frontend/pages/[lng]/sign-in.tsx
+++ b/frontend/pages/[lng]/sign-in.tsx
@@ -1,7 +1,4 @@
 import * as React from "react"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import Paper from "@material-ui/core/Paper"
 import Typography from "@material-ui/core/Typography"
 import SignInForm from "/components/SignInForm"
@@ -10,6 +7,7 @@ import LanguageContext from "/contexes/LanguageContext"
 import getSignInTranslator from "/translations/common"
 import { useContext } from "react"
 import styled from "styled-components"
+import withSignedOut from "/lib/with-signed-out"
 
 const StyledPaper = styled(Paper)`
   display: flex;
@@ -25,6 +23,7 @@ const Header = styled(Typography)`
 const SignInPage = () => {
   const lng = useContext(LanguageContext)
   const t = getSignInTranslator(lng.language)
+
   return (
     <>
       <Container style={{ width: "90%", maxWidth: 900 }}>
@@ -42,13 +41,8 @@ const SignInPage = () => {
   )
 }
 
+SignInPage.displayName = "SignInPage"
+
 //If user is already logged in, redirect them straight to
 //register-completion page
-SignInPage.getInitialProps = function(context: NextContext) {
-  if (isSignedIn(context)) {
-    redirect(context, "/")
-  }
-  return {}
-}
-
-export default SignInPage
+export default withSignedOut()(SignInPage)

--- a/frontend/pages/[lng]/sign-up.tsx
+++ b/frontend/pages/[lng]/sign-up.tsx
@@ -4,9 +4,7 @@ import CreateAccountForm from "/components/CreateAccountForm"
 import ConfirmEmail from "/components/ConfirmEmail"
 
 import { RegularContainer } from "/components/Container"
-import { NextPageContext } from "next"
-import { isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
+import withSignedOut from "/lib/with-signed-out"
 
 const SignUpPage = () => {
   const [state, setState] = useState({
@@ -21,12 +19,13 @@ const SignUpPage = () => {
       window.scrollTo(0, 0)
     }
   }
-  let stepComponent
-  if (state.step === 1) {
-    stepComponent = <CreateAccountForm onComplete={onStepComplete} />
-  } else {
-    stepComponent = <ConfirmEmail onComplete={onStepComplete} />
-  }
+
+  const stepComponent =
+    state.step === 1 ? (
+      <CreateAccountForm onComplete={onStepComplete} />
+    ) : (
+      <ConfirmEmail onComplete={onStepComplete} />
+    )
 
   return (
     <div>
@@ -35,11 +34,6 @@ const SignUpPage = () => {
   )
 }
 
-SignUpPage.getInitialProps = function(context: NextPageContext) {
-  if (isSignedIn(context)) {
-    redirect(context, "/")
-  }
-  return {}
-}
+SignUpPage.displayName = "SignUpPage"
 
-export default SignUpPage
+export default withSignedOut()(SignUpPage)

--- a/frontend/pages/[lng]/study-modules.tsx
+++ b/frontend/pages/[lng]/study-modules.tsx
@@ -7,7 +7,6 @@ import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import { H1NoBackground } from "/components/Text/headers"
 import { AllEditorModulesQuery } from "/graphql/queries/study-modules"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 const StudyModules = () => {
   const { loading, error, data } = useQuery<AllEditorModulesWithTranslations>(
@@ -30,4 +29,6 @@ const StudyModules = () => {
   )
 }
 
-export default withAdmin(withSignedIn(StudyModules))
+StudyModules.displayName = "StudyModules"
+
+export default withAdmin(StudyModules)

--- a/frontend/pages/[lng]/study-modules.tsx
+++ b/frontend/pages/[lng]/study-modules.tsx
@@ -1,31 +1,21 @@
 import * as React from "react"
-import { NextPageContext as NextContext } from "next"
 import { useQuery } from "@apollo/react-hooks"
-import AdminError from "/components/Dashboard/AdminError"
 import { WideContainer } from "/components/Container"
 import { AllEditorModulesWithTranslations } from "/static/types/generated/AllEditorModulesWithTranslations"
-import { isAdmin, isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import ModuleGrid from "/components/ModuleGrid"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import { H1NoBackground } from "/components/Text/headers"
 import { AllEditorModulesQuery } from "/graphql/queries/study-modules"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
-interface StudyModuleProps {
-  admin: boolean
-}
-
-const StudyModules = ({ admin }: StudyModuleProps) => {
+const StudyModules = () => {
   const { loading, error, data } = useQuery<AllEditorModulesWithTranslations>(
     AllEditorModulesQuery,
   )
 
   if (error) {
     return <ModifiableErrorMessage errorMessage={JSON.stringify(error)} />
-  }
-
-  if (!admin) {
-    return <AdminError />
   }
 
   return (
@@ -40,16 +30,4 @@ const StudyModules = ({ admin }: StudyModuleProps) => {
   )
 }
 
-StudyModules.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-    // @ts-ignore
-    language: context?.req?.language || "",
-  }
-}
-
-export default StudyModules
+export default withAdmin(withSignedIn(StudyModules))

--- a/frontend/pages/[lng]/study-modules/[id]/edit.tsx
+++ b/frontend/pages/[lng]/study-modules/[id]/edit.tsx
@@ -2,13 +2,9 @@ import React, { useContext } from "react"
 import { gql } from "apollo-boost"
 import { useQuery } from "@apollo/react-hooks"
 import { SingletonRouter, withRouter } from "next/router"
-import AdminError from "/components/Dashboard/AdminError"
 import Typography from "@material-ui/core/Typography"
 import Paper from "@material-ui/core/Paper"
 import { WideContainer } from "/components/Container"
-import { NextPageContext as NextContext } from "next"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import styled from "styled-components"
 import { StudyModuleDetails } from "/static/types/generated/StudyModuleDetails"
 import StudyModuleEdit from "/components/Dashboard/Editor/StudyModule"
@@ -18,6 +14,8 @@ import FormSkeleton from "/components/Dashboard/Editor/FormSkeleton"
 import { H1NoBackground } from "/components/Text/headers"
 import { useQueryParameter } from "/util/useQueryParameter"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 export const StudyModuleQuery = gql`
   query StudyModuleDetails($slug: String!) {
@@ -48,11 +46,10 @@ const ErrorContainer = styled(Paper)`
 
 interface EditStudyModuleProps {
   router: SingletonRouter
-  admin: boolean
 }
 
 const EditStudyModule = (props: EditStudyModuleProps) => {
-  const { admin, router } = props
+  const { router } = props
   const { language } = useContext(LanguageContext)
   const id = useQueryParameter("id")
 
@@ -64,10 +61,6 @@ const EditStudyModule = (props: EditStudyModuleProps) => {
       variables: { slug: id },
     },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   if (error) {
     return <ModifiableErrorMessage errorMessage={JSON.stringify(error)} />
@@ -119,14 +112,6 @@ const EditStudyModule = (props: EditStudyModuleProps) => {
   )
 }
 
-EditStudyModule.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+EditStudyModule.displayName = "EditStudyModule"
 
-export default withRouter(EditStudyModule)
+export default withRouter(withAdmin(withSignedIn(EditStudyModule)) as any)

--- a/frontend/pages/[lng]/study-modules/[id]/edit.tsx
+++ b/frontend/pages/[lng]/study-modules/[id]/edit.tsx
@@ -15,7 +15,6 @@ import { H1NoBackground } from "/components/Text/headers"
 import { useQueryParameter } from "/util/useQueryParameter"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const StudyModuleQuery = gql`
   query StudyModuleDetails($slug: String!) {
@@ -114,4 +113,4 @@ const EditStudyModule = (props: EditStudyModuleProps) => {
 
 EditStudyModule.displayName = "EditStudyModule"
 
-export default withRouter(withAdmin(withSignedIn(EditStudyModule)) as any)
+export default withRouter(withAdmin(EditStudyModule) as any)

--- a/frontend/pages/[lng]/study-modules/new.tsx
+++ b/frontend/pages/[lng]/study-modules/new.tsx
@@ -3,7 +3,6 @@ import { WideContainer } from "/components/Container"
 import StudyModuleEdit from "/components/Dashboard/Editor/StudyModule"
 import { H1NoBackground } from "/components/Text/headers"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 const NewStudyModule = () => {
   return (
@@ -20,4 +19,4 @@ const NewStudyModule = () => {
 
 NewStudyModule.displayName = "NewStudyModule"
 
-export default withAdmin(withSignedIn(NewStudyModule))
+export default withAdmin(NewStudyModule)

--- a/frontend/pages/[lng]/study-modules/new.tsx
+++ b/frontend/pages/[lng]/study-modules/new.tsx
@@ -1,21 +1,11 @@
 import React from "react"
-import { NextPageContext as NextContext } from "next"
-import AdminError from "/components/Dashboard/AdminError"
 import { WideContainer } from "/components/Container"
-import { isAdmin, isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
 import StudyModuleEdit from "/components/Dashboard/Editor/StudyModule"
 import { H1NoBackground } from "/components/Text/headers"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
-interface NewStudyModuleProps {
-  admin: boolean
-}
-
-const NewStudyModule = ({ admin }: NewStudyModuleProps) => {
-  if (!admin) {
-    return <AdminError />
-  }
-
+const NewStudyModule = () => {
   return (
     <section>
       <WideContainer>
@@ -28,14 +18,6 @@ const NewStudyModule = ({ admin }: NewStudyModuleProps) => {
   )
 }
 
-NewStudyModule.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+NewStudyModule.displayName = "NewStudyModule"
 
-export default NewStudyModule
+export default withAdmin(withSignedIn(NewStudyModule))

--- a/frontend/pages/[lng]/teachers.tsx
+++ b/frontend/pages/[lng]/teachers.tsx
@@ -43,6 +43,7 @@ const StyledButton = styled(Button)`
 const ForTeachers = () => {
   const lng = useContext(LanguageContext)
   const t = getTeachersTranslator(lng.language)
+
   return (
     <section>
       <H1NoBackground variant="h1" component="h1" align="center">
@@ -135,5 +136,7 @@ const ForTeachers = () => {
     </section>
   )
 }
+
+ForTeachers.displayName = "ForTeachers"
 
 export default ForTeachers

--- a/frontend/pages/[lng]/users/[id].tsx
+++ b/frontend/pages/[lng]/users/[id].tsx
@@ -9,7 +9,6 @@ import { CircularProgress } from "@material-ui/core"
 import { useQueryParameter } from "/util/useQueryParameter"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 const UserPage = () => {
   const id = useQueryParameter("id")
@@ -70,7 +69,7 @@ const UserPage = () => {
 
 UserPage.displayName = "UserPage"
 
-export default withAdmin(withSignedIn(UserPage))
+export default withAdmin(UserPage)
 
 const GET_DATA = gql`
   query UserCourseSettingsesForUserPage($upstream_id: Int) {

--- a/frontend/pages/[lng]/users/[id].tsx
+++ b/frontend/pages/[lng]/users/[id].tsx
@@ -1,9 +1,5 @@
 import * as React from "react"
 import Container from "/components/Container"
-import { NextPageContext } from "next"
-import { isAdmin, isSignedIn } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import AdminError from "/components/Dashboard/AdminError"
 import gql from "graphql-tag"
 import { useQuery, ApolloConsumer } from "@apollo/react-hooks"
 import { UserCourseSettingsesForUserPage } from "/static/types/generated/UserCourseSettingsesForUserPage"
@@ -12,12 +8,10 @@ import Button from "@material-ui/core/Button"
 import { CircularProgress } from "@material-ui/core"
 import { useQueryParameter } from "/util/useQueryParameter"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
-interface UserPageProps {
-  admin: boolean
-}
-
-const UserPage = ({ admin }: UserPageProps) => {
+const UserPage = () => {
   const id = useQueryParameter("id")
   const [more, setMore]: any[] = React.useState([])
 
@@ -25,10 +19,6 @@ const UserPage = ({ admin }: UserPageProps) => {
     GET_DATA,
     { variables: { upstream_id: Number(id) } },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   if (error) {
     return (
@@ -78,16 +68,9 @@ const UserPage = ({ admin }: UserPageProps) => {
   )
 }
 
-UserPage.getInitialProps = function(context: NextPageContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
-export default UserPage
+UserPage.displayName = "UserPage"
+
+export default withAdmin(withSignedIn(UserPage))
 
 const GET_DATA = gql`
   query UserCourseSettingsesForUserPage($upstream_id: Int) {

--- a/frontend/pages/[lng]/users/[id]/completions.tsx
+++ b/frontend/pages/[lng]/users/[id]/completions.tsx
@@ -8,7 +8,6 @@ import { useQueryParameter } from "/util/useQueryParameter"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 export const UserOverViewQuery = gql`
   query ShowUserUserOverView($upstream_id: Int) {
@@ -59,4 +58,4 @@ function CompletionsPage() {
 
 CompletionsPage.displayName = "CompletionsPage"
 
-export default withAdmin(withSignedIn(CompletionsPage))
+export default withAdmin(CompletionsPage)

--- a/frontend/pages/[lng]/users/[id]/completions.tsx
+++ b/frontend/pages/[lng]/users/[id]/completions.tsx
@@ -1,16 +1,14 @@
 import React from "react"
-import { isSignedIn, isAdmin } from "/lib/authentication"
-import { NextPageContext as NextContext } from "next"
-import redirect from "/lib/redirect"
 import { gql } from "apollo-boost"
 import { useQuery } from "@apollo/react-hooks"
 import { ShowUserUserOverView as UserOverViewData } from "/static/types/generated/ShowUserUserOverView"
 import Container from "/components/Container"
 import Completions from "/components/Completions"
-import AdminError from "/components/Dashboard/AdminError"
 import { useQueryParameter } from "/util/useQueryParameter"
 import Spinner from "/components/Spinner"
 import ModifiableErrorMessage from "/components/ModifiableErrorMessage"
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 export const UserOverViewQuery = gql`
   query ShowUserUserOverView($upstream_id: Int) {
@@ -26,21 +24,13 @@ export const UserOverViewQuery = gql`
   ${Completions.fragments.completions}
 `
 
-interface CompletionsProps {
-  admin: boolean
-}
-
-function CompletionsPage({ admin }: CompletionsProps) {
+function CompletionsPage() {
   const id = useQueryParameter("id")
 
   const { loading, error, data } = useQuery<UserOverViewData>(
     UserOverViewQuery,
     { variables: { upstream_id: Number(id) }, ssr: false },
   )
-
-  if (!admin) {
-    return <AdminError />
-  }
 
   const completions = data?.user?.completions ?? []
 
@@ -67,14 +57,6 @@ function CompletionsPage({ admin }: CompletionsProps) {
   )
 }
 
-CompletionsPage.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
-  return {
-    admin,
-  }
-}
+CompletionsPage.displayName = "CompletionsPage"
 
-export default CompletionsPage
+export default withAdmin(withSignedIn(CompletionsPage))

--- a/frontend/pages/[lng]/users/search.tsx
+++ b/frontend/pages/[lng]/users/search.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react"
-import { SingletonRouter } from "next/router"
 import gql from "graphql-tag"
 import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
 import { useTheme } from "@material-ui/core/styles"
@@ -10,21 +9,13 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import LastPageIcon from "@material-ui/icons/LastPage"
 import Container from "/components/Container"
 import styled from "styled-components"
-import { NextPageContext as NextContext } from "next"
-import { isAdmin } from "/lib/authentication"
-import redirect from "/lib/redirect"
-import { isSignedIn } from "/lib/authentication"
-import AdminError from "/components/Dashboard/AdminError"
 import { useLazyQuery } from "@apollo/react-hooks"
 import WideGrid from "/components/Dashboard/Users/WideGrid"
 import MobileGrid from "/components/Dashboard/Users/MobileGrid"
 import { H1NoBackground } from "/components/Text/headers"
 import { ButtonWithPaddingAndMargin } from "/components/Buttons/ButtonWithPaddingAndMargin"
-interface UserSearchProps {
-  namespacesRequired: string[]
-  router: SingletonRouter
-  admin: boolean
-}
+import withAdmin from "/lib/with-admin"
+import withSignedIn from "/lib/with-signed-in"
 
 const StyledForm = styled.form`
   display: flex;
@@ -156,7 +147,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
   )
 }
 
-const UserSearch = (props: UserSearchProps) => {
+const UserSearch = () => {
   const [searchText, setSearchText] = React.useState("")
   const [page, setPage] = React.useState(0)
   const [rowsPerPage, setRowsPerPage] = React.useState(10)
@@ -166,10 +157,6 @@ const UserSearch = (props: UserSearchProps) => {
   const isMobile = useMediaQuery("(max-width:800px)", { noSsr: true })
 
   const GridComponent = isMobile ? MobileGrid : WideGrid
-
-  if (!props.admin) {
-    return <AdminError />
-  }
 
   const onTextBoxChange = (event: any) => {
     setSearchText(event.target.value as string)
@@ -283,15 +270,6 @@ const GET_DATA = gql`
   }
 `
 
-UserSearch.getInitialProps = function(context: NextContext) {
-  const admin = isAdmin(context)
-  if (!isSignedIn(context)) {
-    redirect(context, "/sign-in")
-  }
+UserSearch.displayName = "UserSearch"
 
-  return {
-    admin,
-  }
-}
-
-export default UserSearch
+export default withAdmin(withSignedIn(UserSearch))

--- a/frontend/pages/[lng]/users/search.tsx
+++ b/frontend/pages/[lng]/users/search.tsx
@@ -15,7 +15,6 @@ import MobileGrid from "/components/Dashboard/Users/MobileGrid"
 import { H1NoBackground } from "/components/Text/headers"
 import { ButtonWithPaddingAndMargin } from "/components/Buttons/ButtonWithPaddingAndMargin"
 import withAdmin from "/lib/with-admin"
-import withSignedIn from "/lib/with-signed-in"
 
 const StyledForm = styled.form`
   display: flex;
@@ -272,4 +271,4 @@ const GET_DATA = gql`
 
 UserSearch.displayName = "UserSearch"
 
-export default withAdmin(withSignedIn(UserSearch))
+export default withAdmin(UserSearch)


### PR DESCRIPTION
- withAdmin returns AdminError if not admin, otherwise wrapped component
- withSignedIn redirects to signin if not signed in
- withSignedOut redirects to / (or specified location) if signed in
- refactored these in to pages
- gave pages proper display names to help debug
- fixed redirect not actually redirecting to the page you came from when logging in
- some other small fixes here and there

Would've preferred to use some form of `compose` or `pipe` to wrap, ie.

```
export default compose(
  withAdmin,
  withSignedIn,
  withRouter
)(Component)
```

but apparently TypeScript doesn't really like that.