### PR TITLE
Fix logging in and make logging out snappy

### DIFF
--- a/frontend/components/HeaderBar/UserOptionsMenu.tsx
+++ b/frontend/components/HeaderBar/UserOptionsMenu.tsx
@@ -26,7 +26,7 @@ const UserOptionsMenu = (props: Props) => {
         <HeaderMenuButton
           color="inherit"
           variant="text"
-          onClick={() => signOut(client).then(logInOrOut)}
+          onClick={() => signOut(client, logInOrOut)}
         >
           {t("logout")}
         </HeaderMenuButton>

--- a/frontend/components/SignInForm.tsx
+++ b/frontend/components/SignInForm.tsx
@@ -7,7 +7,7 @@ import {
   Link,
 } from "@material-ui/core"
 
-import { signIn } from "../lib/authentication"
+import { signIn, isSignedIn } from "../lib/authentication"
 import LanguageContext from "/contexes/LanguageContext"
 import LoginStateContext from "/contexes/LoginStateContext"
 import getCommonTranslator from "/translations/common"
@@ -93,14 +93,23 @@ function SignIn() {
             onClick={async e => {
               e.preventDefault()
               try {
-                await signIn({ email, password, shallow: false }).then(
-                  logInOrOut,
-                )
+                await signIn({ email, password, shallow: false })
+                try {
+                  await logInOrOut()
+                } catch (e) {
+                  console.error("Login in or out failed")
+                }
+
                 if (errorTimeout) {
                   clearTimeout(errorTimeout)
                 }
               } catch (error) {
+                console.error("Login failed due to this error: ", error)
                 setError(true)
+                // @ts-ignore
+                if (isSignedIn(undefined)) {
+                  console.error("Logging in was successful but it crashed")
+                }
                 errorTimeout = setTimeout(() => {
                   setError(false)
                   if (errorTimeout) {

--- a/frontend/lib/authentication.ts
+++ b/frontend/lib/authentication.ts
@@ -40,29 +40,45 @@ export const signIn = async ({
   document.cookie = `access_token=${res.accessToken};path=/`
   document.cookie = `admin=${details.administrator};path=/`
 
-  const { as, href } = JSON.parse(nookies.get()["redirect-back"] ?? "")
+  const rawRedirectLocation = nookies.get()["redirect-back"]
 
-  if (redirect) {
-    setTimeout(() => {
-      if (as && href) {
-        Router.push(href, as, { shallow })
-      } else {
-        window.history.back()
-      }
-    }, 200)
+  if (!rawRedirectLocation || rawRedirectLocation === "") {
+    window.history.back()
+    return
+  }
+
+  try {
+    const { as, href } = JSON.parse(rawRedirectLocation)
+
+    if (redirect) {
+      setTimeout(() => {
+        if (as && href) {
+          Router.push(href, as, { shallow })
+        } else {
+          window.history.back()
+        }
+      }, 200)
+    }
+  } catch (e) {
+    // Mostly to catch invalid JSON in the cookie
+    console.error("Redirecting back failed because of", e)
+    Router.push("/", undefined, { shallow })
   }
 
   return res
 }
 
-export const signOut = async (apollo: ApolloClient<any>) => {
-  await apollo.resetStore().then(() => {
-    document.cookie =
-      "access_token" + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/"
-    nookies.destroy({}, "access_token") // mooc-access-token
-  })
-  const { pathname = "/", asPath = "/" } = Router?.router ?? {}
-  Router.push(pathname, asPath)
+export const signOut = async (apollo: ApolloClient<any>, cb: any) => {
+  document.cookie =
+    "access_token" + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/"
+  document.cookie = "admin" + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/"
+  // Give browser a moment to react to the change
+  setTimeout(() => {
+    cb()
+    setTimeout(() => {
+      apollo.resetStore()
+    }, 100)
+  }, 100)
 }
 
 const getCookie = (key: string) => {

--- a/frontend/lib/with-apollo-client/get-apollo.ts
+++ b/frontend/lib/with-apollo-client/get-apollo.ts
@@ -27,7 +27,10 @@ const cypress = process.env.CYPRESS === "true"
 function create(initialState: any, originalAccessToken?: string) {
   const authLink = setContext((_, { headers }) => {
     // Always get the current access token from cookies in case it has changed
-    const accessToken = nookies.get()["access_token"] || originalAccessToken
+    let accessToken: string | undefined = nookies.get()["access_token"]
+    if (!accessToken && !process.browser) {
+      accessToken = originalAccessToken
+    }
 
     return {
       headers: {

--- a/frontend/lib/with-signed-in.tsx
+++ b/frontend/lib/with-signed-in.tsx
@@ -2,14 +2,20 @@ import React from "react"
 import { NextPageContext as NextContext } from "next"
 import { isSignedIn } from "/lib/authentication"
 import redirect from "/lib/redirect"
+import LoginStateContext from "/contexes/LoginStateContext"
+
+let prevContext: NextContext | null = null
 
 // TODO: might need to wrap in function to give redirect parameters (= shallow?)
 export default function withSignedIn(Component: any) {
   return class WithSignedIn extends React.Component<{ signedIn: boolean }> {
     static displayName = `withSignedIn(${Component.displayName ?? "Component"})`
+    static contextType = LoginStateContext
 
     static async getInitialProps(context: NextContext) {
       const signedIn = isSignedIn(context)
+
+      prevContext = context
 
       if (!signedIn) {
         redirect(context, "/sign-in")
@@ -24,8 +30,19 @@ export default function withSignedIn(Component: any) {
     }
 
     render() {
+      // Needs to be before context check so that we don't redirect twice
       if (!this.props.signedIn) {
         return <div>Redirecting...</div>
+      }
+
+      // Logging out is communicated with a context change
+      if (!this.context.loggedIn) {
+        if (prevContext) {
+          redirect(prevContext, "/sign-in")
+        }
+        // We don't return here because when logging out it is better to keep the old content for a moment
+        // than flashing a message while the redirect happens
+        // return <div>You've logged out.</div>
       }
 
       return <Component {...this.props}>{this.props.children}</Component>


### PR DESCRIPTION
Logging in was broken when there was no redirect back cookie.

I also made logging out much faster by reacting to the context change in the appropriate HOCs. Now the logout happens immediately.