### PR TITLE
downgraded graphql-upload to enable image uploads again

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4130,22 +4130,16 @@
       }
     },
     "graphql-upload": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-10.0.0.tgz",
-      "integrity": "sha512-8n11qujsqHWT48visvQbqLqAj8o6NCLJ35tGkI/RynhDs7E07TxlswVe4vPZaLiXJeemZA7xrxkMohwP//DOqA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
       "requires": {
         "busboy": "^0.3.1",
-        "fs-capacitor": "^6.1.0",
+        "fs-capacitor": "^2.0.4",
         "http-errors": "^1.7.3",
-        "isobject": "^4.0.0",
         "object-path": "^0.11.4"
       },
       "dependencies": {
-        "fs-capacitor": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.1.0.tgz",
-          "integrity": "sha512-YsKGCLAB40P3OKeciIa7cKzt7WkY8QT9ETa2wVIG3fQDHW2h3xtRo0770lUIbPrjCr5Sa+zFhixNJ+2xNxaraQ=="
-        },
         "http-errors": {
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -4829,11 +4823,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,7 +52,7 @@
     "dotenv-safe": "^8.2.0",
     "express": "^4.17.1",
     "graphql": "^14.6.0",
-    "graphql-upload": "^10.0.0",
+    "graphql-upload": "8.1.0",
     "graphql-yoga": "^1.18.3",
     "lodash": "^4.17.15",
     "luxon": "^1.22.0",


### PR DESCRIPTION
- downgraded `graphql-upload` to version 8.1.0. Issue: https://github.com/jaydenseric/graphql-upload/issues/185#issuecomment-583572804