### PR TITLE
save button on editor takes user to erroneous field

### DIFF
--- a/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
+++ b/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components"
 import Button from "@material-ui/core/Button"
 
-export const ButtonWithPaddingAndMargin = styled(Button)<{ color: string }>`
+export const ButtonWithPaddingAndMargin = styled(Button)<{ color?: string }>`
   margin: 0.5rem;
-  color: ${({ color }) => (color === "primary" ? "#FFFFFF" : "#4e4637")};
+  color: ${({ color }) => (color === "secondary" ? "#4e4637" : "#FFFFFF")};
   font-size: 18px;
   padding: 0.5em;
 `

--- a/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
+++ b/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components"
 import Button from "@material-ui/core/Button"
 
-export const ButtonWithPaddingAndMargin = styled(Button)`
+export const ButtonWithPaddingAndMargin = styled(Button)<{ color: string }>`
   margin: 0.5rem;
-  color: #4e4637;
+  color: ${({ color }) => (color === "primary" ? "#FFFFFF" : "#4e4637")};
   font-size: 18px;
   padding: 0.5em;
 `

--- a/frontend/components/Dashboard/DashboardBreadCrumbs.tsx
+++ b/frontend/components/Dashboard/DashboardBreadCrumbs.tsx
@@ -185,16 +185,16 @@ const DashboardBreadCrumbs = React.memo((props: Props) => {
 
   //split the url path into parts
   //remove the first item, as we know it to be homepage
-  const urlWithQueryRemoved = currentUrl.split("?")[0]
+  const urlWithQueryAndAnchorRemoved = currentUrl.split("?")[0].split("#")[0]
 
   let homeLink: string = "/"
-  if (urlWithQueryRemoved.startsWith("/en")) {
+  if (urlWithQueryAndAnchorRemoved.startsWith("/en")) {
     homeLink = "/en/"
   }
 
   const t = getPageTranslator(language)
 
-  let urlRouteComponents = urlWithQueryRemoved.split("/")
+  let urlRouteComponents = urlWithQueryAndAnchorRemoved.split("/")
   urlRouteComponents = urlRouteComponents.slice(
     urlRouteComponents[1] === "register-completion" ? 1 : 2,
   )
@@ -283,7 +283,7 @@ const DashboardBreadCrumbs = React.memo((props: Props) => {
               content = awaitedCrumb
               document.title =
                 t("title", { title: content ?? "..." })?.[
-                  getRoute(urlWithQueryRemoved)
+                  getRoute(urlWithQueryAndAnchorRemoved)
                 ] || document.title
             }
           }

--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -30,7 +30,10 @@ import { statuses as statusesT } from "./form-validation"
 import { CourseFormValues } from "./types"
 import styled from "styled-components"
 import FormWrapper from "/components/Dashboard/Editor/FormWrapper"
-import { StyledTextField } from "/components/Dashboard/Editor/common"
+import {
+  StyledTextField,
+  StyledFieldWithAnchor,
+} from "/components/Dashboard/Editor/common"
 import getCoursesTranslator from "/translations/courses"
 import LanguageContext from "/contexes/LanguageContext"
 import DatePickerField from "./DatePickers"
@@ -77,17 +80,6 @@ export const FormFieldGroup = styled.div`
   border-bottom: 4px dotted #98b0a9;
 `
 
-const StyledField = styled(Field)`
-  .input-label {
-    background-color: white;
-    font-size: 23px;
-    padding-right: 7px;
-    transform: translate(14px, -9px) scale(0.75);
-  }
-  .input-required {
-    color: #df7a46;
-  }
-`
 const inputLabelProps = {
   fontSize: 16,
   shrink: true,
@@ -153,7 +145,7 @@ Pick<
             {t("courseDetails")}
           </FormSubtitle>
           <FormFieldGroup>
-            <StyledField
+            <StyledFieldWithAnchor
               id="input-course-name"
               style={{ width: "80%" }}
               name="name"
@@ -166,7 +158,7 @@ Pick<
               component={StyledTextField}
               required={true}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               id="input-course-slug"
               style={{ width: "40%" }}
               name="new_slug"
@@ -180,7 +172,7 @@ Pick<
               required={true}
               helperText={t("courseSlugHelper")}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               style={{ width: "25%" }}
               name="ects"
               type="text"
@@ -194,7 +186,7 @@ Pick<
           </FormFieldGroup>
 
           <FormFieldGroup>
-            <StyledField
+            <StyledFieldWithAnchor
               id="start-date"
               name="start_date"
               label={t("courseStartDate")}
@@ -204,7 +196,7 @@ Pick<
               InputLabelProps={inputLabelProps}
               emptyLabel={t("courseDatePlaceholder")}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               id="end-date"
               name="end_date"
               error={errors.end_date}
@@ -216,7 +208,7 @@ Pick<
           </FormFieldGroup>
 
           <FormFieldGroup>
-            <StyledField
+            <StyledFieldWithAnchor
               id="input-teacher-in-charge-name"
               style={{ width: "80%" }}
               name="teacher_in_charge_name"
@@ -229,7 +221,7 @@ Pick<
               component={StyledTextField}
               required={true}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               id="input-teacher-in-charge-email"
               style={{ width: "60%" }}
               name="teacher_in_charge_email"
@@ -242,7 +234,7 @@ Pick<
               component={StyledTextField}
               required={true}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               id="support-email"
               style={{ width: "60%" }}
               name="support_email"
@@ -261,6 +253,7 @@ Pick<
               <FormLabel component="legend" style={{ color: "#DF7A46" }}>
                 {t("courseStatus")}*
               </FormLabel>
+              <a id="status" />
               <RadioGroup
                 aria-label="course status"
                 name="status"
@@ -289,6 +282,7 @@ Pick<
               <FormLabel>{t("courseModules")}</FormLabel>
               <FormGroup>
                 <ModuleList>
+                  <a id="study_modules" />
                   {studyModules?.map(
                     (module: CourseEditorStudyModules_study_modules) => (
                       <ModuleListItem key={module.id}>
@@ -367,7 +361,7 @@ Pick<
             </FormControl>
           </FormFieldGroup>
           <FormFieldGroup>
-            <StyledField
+            <StyledFieldWithAnchor
               name="order"
               type="number"
               label={t("courseOrder")}
@@ -379,7 +373,7 @@ Pick<
               style={{ width: "20%" }}
               InputLabelProps={inputLabelProps}
             />
-            <StyledField
+            <StyledFieldWithAnchor
               label={t("courseModuleOrder")}
               name="study_module_order"
               type="number"

--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -94,11 +94,8 @@ interface RenderFormProps {
 
 const renderForm = ({ courses, studyModules }: RenderFormProps) => ({
   errors,
-
   values,
-
   isSubmitting,
-
   setFieldValue,
 }: // setStatus
 Pick<

--- a/frontend/components/Dashboard/Editor/Course/CourseLanguageSelector.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseLanguageSelector.tsx
@@ -92,20 +92,20 @@ const CourseLanguageSelector = (props: LanguageSelectorProps) => {
             </StyledLanguageButton>
             <StyledLanguageButton
               selected={selectedLanguage === "both"}
-              onClick={async () => {
+              onClick={() => {
                 if (selectedLanguage === "") {
-                  await helpers.push({
+                  helpers.push({
                     ...initialTranslation,
                     language: "en_US",
                   })
-                  await helpers.push({
+                  helpers.push({
                     ...initialTranslation,
                     language: "fi_FI",
                   })
                 } else if (selectedLanguage === "fi") {
                   helpers.push({ ...initialTranslation, language: "en_US" })
                 } else {
-                  await helpers.push({
+                  helpers.push({
                     ...initialTranslation,
                     language: "fi_FI",
                   })

--- a/frontend/components/Dashboard/Editor/Course/CourseTranslationListItem.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseTranslationListItem.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from "react"
-import { Field, getIn } from "formik"
-import { StyledTextField } from "/components/Dashboard/Editor/common"
+import { getIn } from "formik"
+import {
+  StyledTextField,
+  StyledFieldWithAnchor,
+} from "/components/Dashboard/Editor/common"
 import getCoursesTranslator from "/translations/courses"
 import LanguageContext from "/contexes/LanguageContext"
 import styled from "styled-components"
@@ -14,23 +17,14 @@ const LanguageVersionContainer = styled.div`
   width: 90%;
   margin: auto;
 `
+
 const LanguageVersionTitle = styled(Typography)`
   margin-bottom: 1.5rem;
   font-size: 33px;
   line-height: 52px;
   color: #005b5b;
 `
-const StyledField = styled(Field)`
-  .input-label {
-    background-color: white;
-    font-size: 23px;
-    padding-right: 7px;
-    transform: translate(14px, -9px) scale(0.75);
-  }
-  .input-required {
-    color: #df7a46;
-  }
-`
+
 const inputLabelProps = {
   fontSize: 16,
   shrink: true,
@@ -55,7 +49,7 @@ const CourseTranslationListItem = (props: Props) => {
           mapLangToLanguage[translationLanguage]
         }`}
       </LanguageVersionTitle>
-      <StyledField
+      <StyledFieldWithAnchor
         id={`course_translations[${index}].name`}
         name={`course_translations[${index}].name`}
         label={t("courseName")}
@@ -68,7 +62,7 @@ const CourseTranslationListItem = (props: Props) => {
         variant="outlined"
         component={StyledTextField}
       />
-      <StyledField
+      <StyledFieldWithAnchor
         id={`course_translations[${index}].description`}
         name={`course_translations[${index}].description`}
         type="textarea"
@@ -82,7 +76,7 @@ const CourseTranslationListItem = (props: Props) => {
         variant="outlined"
         component={StyledTextField}
       />
-      <StyledField
+      <StyledFieldWithAnchor
         id={`course_translations[${index}].link`}
         name={`course_translations[${index}].link`}
         type="text"
@@ -94,7 +88,7 @@ const CourseTranslationListItem = (props: Props) => {
         variant="outlined"
         component={StyledTextField}
       />
-      <StyledField
+      <StyledFieldWithAnchor
         label={t("courseOpenCode")}
         InputLabelProps={inputLabelProps}
         id={`course_translations[${index}].open_university_course_code`}

--- a/frontend/components/Dashboard/Editor/Course/CourseVariantEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseVariantEditForm.tsx
@@ -1,17 +1,19 @@
 import React, { useContext } from "react"
 import { CourseVariantFormValues } from "/components/Dashboard/Editor/Course/types"
-import { Field, FieldArray, FormikErrors, getIn } from "formik"
+import { FieldArray, FormikErrors, getIn } from "formik"
 import { Grid, FormControl, FormGroup, Typography } from "@material-ui/core"
 import { initialVariant } from "./form-validation"
 import AddIcon from "@material-ui/icons/Add"
 import RemoveIcon from "@material-ui/icons/Remove"
-import { StyledTextField } from "/components/Dashboard/Editor/common"
+import {
+  StyledTextField,
+  StyledFieldWithAnchor,
+} from "/components/Dashboard/Editor/common"
 
 import { ButtonWithPaddingAndMargin as StyledButton } from "/components/Buttons/ButtonWithPaddingAndMargin"
 import styled from "styled-components"
 import getCoursesTranslator from "/translations/courses"
 import LanguageContext from "/contexes/LanguageContext"
-import { StyledLabel } from "./CourseEditForm"
 import { useConfirm } from "material-ui-confirm"
 
 const ButtonWithWhiteText = styled(StyledButton)`
@@ -44,36 +46,25 @@ const CourseVariantEditForm = ({
                     values!.map((variant, index: number) => (
                       <Grid container spacing={2} key={`variant-${index}`}>
                         <Grid item xs={4}>
-                          <StyledLabel
-                            htmlFor={`course_variants[${index}].slug`}
-                            required={true}
-                          >
-                            {t("courseSlug")}
-                          </StyledLabel>
-
-                          <Field
+                          <StyledFieldWithAnchor
                             id={`course_variants[${index}].slug`}
                             name={`course_variants[${index}].slug`}
                             type="text"
                             component={StyledTextField}
                             value={variant.slug}
+                            label={t("courseSlug")}
                             errors={[getIn(errors, `[${index}].slug`)]}
                             variant="outlined"
                           />
                         </Grid>
                         <Grid item xs={6}>
-                          <StyledLabel
-                            htmlFor={`course_variants[${index}].description`}
-                            required={false}
-                          >
-                            {t("courseDescription")}
-                          </StyledLabel>
-                          <Field
+                          <StyledFieldWithAnchor
                             id={`course_variants[${index}].description`}
                             name={`course_variants[${index}].description`}
                             type="text"
                             component={StyledTextField}
                             value={variant.description}
+                            label={t("courseDescription")}
                             errors={[getIn(errors, `[${index}].description`)]}
                             variant="outlined"
                           />

--- a/frontend/components/Dashboard/Editor/FormWrapper.tsx
+++ b/frontend/components/Dashboard/Editor/FormWrapper.tsx
@@ -14,6 +14,7 @@ import { ButtonWithPaddingAndMargin as StyledButton } from "/components/Buttons/
 import getCommonTranslator from "/translations/common"
 import LanguageContext from "/contexes/LanguageContext"
 import { useConfirm } from "material-ui-confirm"
+// import Router from "next/router"
 
 // TODO: show delete to course owner
 const isProduction = process.env.NODE_ENV === "production"
@@ -60,9 +61,28 @@ function FormWrapper<T extends FormValues>(props: FormWrapperProps<T>) {
             <StyledButton
               color="primary"
               disabled={
-                !dirty || Object.keys(errors).length > 0 || isSubmitting
+                !dirty || isSubmitting
+                //!dirty || Object.keys(errors).length > 0 || isSubmitting
               }
-              onClick={submitForm}
+              onClick={() => {
+                if (Object.keys(errors).length) {
+                  const [key, value] = Object.entries(errors)[0]
+
+                  let anchorLink = key
+                  if (Array.isArray(value)) {
+                    const firstIndex = parseInt(Object.keys(value)[0])
+                    anchorLink = `${key}[${firstIndex}].${
+                      Object.keys(value[firstIndex])[0]
+                    }`
+                  }
+                  window.location.replace(
+                    window.location.href.split("#")[0] + `#${anchorLink}`,
+                  )
+                  // Router.replace(`#${Object.keys(errors)[0]}`)
+                } else {
+                  submitForm()
+                }
+              }}
               style={{ width: "100%" }}
             >
               {isSubmitting ? <CircularProgress size={20} /> : t("save")}

--- a/frontend/components/Dashboard/Editor/StudyModule/StudyModuleEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/StudyModule/StudyModuleEditForm.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useContext, useState } from "react"
 import { StudyModuleFormValues } from "./types"
 import {
-  Field,
   Formik,
   Form,
   FormikActions,
@@ -28,6 +27,7 @@ import {
   OutlinedFormControl,
   OutlinedInputLabel,
   OutlinedFormGroup,
+  StyledFieldWithAnchor,
 } from "/components/Dashboard/Editor/common"
 import { ButtonWithPaddingAndMargin as StyledButton } from "/components/Buttons/ButtonWithPaddingAndMargin"
 import { FormSubmitButton } from "/components/Buttons/FormSubmitButton"
@@ -81,7 +81,7 @@ const RenderForm = ({
     <Form>
       <Grid container direction="row" spacing={2}>
         <Grid item xs={10}>
-          <Field
+          <StyledFieldWithAnchor
             name="name"
             type="text"
             label={t("moduleName")}
@@ -93,7 +93,7 @@ const RenderForm = ({
           />
         </Grid>
         <Grid item xs={2}>
-          <Field
+          <StyledFieldWithAnchor
             name="order"
             type="number"
             label={t("moduleOrder")}
@@ -105,7 +105,7 @@ const RenderForm = ({
           />
         </Grid>
       </Grid>
-      <Field
+      <StyledFieldWithAnchor
         name="new_slug"
         type="text"
         label={t("moduleSlug")}
@@ -115,7 +115,7 @@ const RenderForm = ({
         autoComplete="off"
         component={StyledTextField}
       />
-      <Field
+      <StyledFieldWithAnchor
         name="image"
         type="text"
         label={t("moduleImageName")}
@@ -161,7 +161,7 @@ const RenderForm = ({
                 (_: any, index: number) => (
                   <LanguageEntry item key={`translation-${index}`}>
                     <EntryContainer elevation={2}>
-                      <Field
+                      <StyledFieldWithAnchor
                         name={`study_module_translations[${index}].language`}
                         type="select"
                         label={t("moduleLanguage")}
@@ -182,8 +182,8 @@ const RenderForm = ({
                             {option.label}
                           </MenuItem>
                         ))}
-                      </Field>
-                      <Field
+                      </StyledFieldWithAnchor>
+                      <StyledFieldWithAnchor
                         name={`study_module_translations[${index}].name`}
                         type="text"
                         label={t("moduleName")}
@@ -196,7 +196,7 @@ const RenderForm = ({
                         variant="outlined"
                         component={StyledTextField}
                       />
-                      <Field
+                      <StyledFieldWithAnchor
                         name={`study_module_translations[${index}].description`}
                         type="textarea"
                         label={t("moduleDescription")}

--- a/frontend/components/Dashboard/Editor/common.tsx
+++ b/frontend/components/Dashboard/Editor/common.tsx
@@ -1,4 +1,5 @@
 import { FormControl, FormGroup, InputLabel } from "@material-ui/core"
+import { Field } from "formik"
 import { TextField } from "formik-material-ui"
 import styled from "styled-components"
 
@@ -37,3 +38,34 @@ export const OutlinedFormGroup = styled(FormGroup)<{ error?: boolean }>`
     border: 1px solid rgba(0, 0, 0, 0.23);
   }
 `
+
+export const StyledField = styled(Field)`
+  .input-label {
+    background-color: white;
+    font-size: 23px;
+    padding-right: 7px;
+    transform: translate(14px, -9px) scale(0.75);
+  }
+  .input-required {
+    color: #df7a46;
+  }
+`
+
+export const AdjustingAnchorLink = styled.a<{ id: string }>`
+  display: block;
+  position: relative;
+  top: -90px;
+  visibliity: hidden;
+`
+
+export const StyledFieldWithAnchor: React.FC<any> = ({
+  name,
+  ...props
+}: {
+  name: string
+}) => (
+  <>
+    <AdjustingAnchorLink id={name} />
+    <StyledField name={name} {...props} />
+  </>
+)


### PR DESCRIPTION
The save button on editor forms is now only disabled when the form is clean or it's submitting. When the form is dirty but there are errors, it takes user to the first error and shows error messages on all erroneous fields. 

The first error isn't necessarily the first in the form, though, as the error object keys are alphabetically ordered. That could be handled by having a rolling index on the `StyledFieldWithAnchor` and keeping track which field key corresponds to which index.

Now it scrolls into the element instead of changing the location with the anchor link.

That `errorsToTouched` thing converts the error object to touched object - we set the erroneous fields as touched to force showing all the errors.

Also: button text color is white on the default background, it was hard to see before.