### PR TITLE
Add enumerating anchors

### DIFF
--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -33,6 +33,7 @@ import FormWrapper from "/components/Dashboard/Editor/FormWrapper"
 import {
   StyledTextField,
   StyledFieldWithAnchor,
+  EnumeratingAnchor,
 } from "/components/Dashboard/Editor/common"
 import getCoursesTranslator from "/translations/courses"
 import LanguageContext from "/contexes/LanguageContext"
@@ -250,7 +251,7 @@ Pick<
               <FormLabel component="legend" style={{ color: "#DF7A46" }}>
                 {t("courseStatus")}*
               </FormLabel>
-              <a id="status" />
+              <EnumeratingAnchor id="status" />
               <RadioGroup
                 aria-label="course status"
                 name="status"
@@ -279,7 +280,7 @@ Pick<
               <FormLabel>{t("courseModules")}</FormLabel>
               <FormGroup>
                 <ModuleList>
-                  <a id="study_modules" />
+                  <EnumeratingAnchor id="study_modules" />
                   {studyModules?.map(
                     (module: CourseEditorStudyModules_study_modules) => (
                       <ModuleListItem key={module.id}>

--- a/frontend/components/Dashboard/Editor/common.tsx
+++ b/frontend/components/Dashboard/Editor/common.tsx
@@ -2,6 +2,8 @@ import { FormControl, FormGroup, InputLabel } from "@material-ui/core"
 import { Field } from "formik"
 import { TextField } from "formik-material-ui"
 import styled from "styled-components"
+import { useContext } from "react"
+import AnchorContext from "/contexes/AnchorContext"
 
 export const StyledTextField = styled(TextField)`
   margin-bottom: 1.5rem;
@@ -54,18 +56,27 @@ export const StyledField = styled(Field)`
 export const AdjustingAnchorLink = styled.a<{ id: string }>`
   display: block;
   position: relative;
-  top: -90px;
+  top: -120px;
   visibliity: hidden;
 `
+
+export const EnumeratingAnchor: React.FC<any> = ({ id }: { id: string }) => {
+  const { addAnchor } = useContext(AnchorContext)
+  addAnchor(id)
+
+  return <AdjustingAnchorLink id={id} />
+}
 
 export const StyledFieldWithAnchor: React.FC<any> = ({
   name,
   ...props
 }: {
   name: string
-}) => (
-  <>
-    <AdjustingAnchorLink id={name} />
-    <StyledField name={name} {...props} />
-  </>
-)
+}) => {
+  return (
+    <>
+      <EnumeratingAnchor id={name} />
+      <StyledField name={name} {...props} />
+    </>
+  )
+}

--- a/frontend/contexes/AnchorContext.ts
+++ b/frontend/contexes/AnchorContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react"
+
+interface AnchorContext {
+  anchors: Record<string, number>
+  addAnchor: (anchor: string) => void
+}
+
+export default createContext<AnchorContext>({
+  anchors: {} as Record<string, number>,
+  addAnchor: (_: string) => {},
+})

--- a/frontend/lib/with-enumerating-anchors.tsx
+++ b/frontend/lib/with-enumerating-anchors.tsx
@@ -1,0 +1,16 @@
+import * as React from "react"
+import AnchorContext from "/contexes/AnchorContext"
+
+const withEnumeratingAnchors = <T,>(Component: any) => (props: any) => {
+  let anchorId = 0
+  const anchors: Record<string, number> = {}
+  const addAnchor = (anchor: string) => (anchors[anchor] = anchorId++)
+
+  return (
+    <AnchorContext.Provider value={{ anchors, addAnchor }}>
+      <Component {...(props as T)}>{props.children}</Component>
+    </AnchorContext.Provider>
+  )
+}
+
+export default withEnumeratingAnchors

--- a/frontend/util/flattenKeys.ts
+++ b/frontend/util/flattenKeys.ts
@@ -1,0 +1,27 @@
+const flattenKeys = <T extends Record<any, any>>(
+  object: T,
+  output: Record<keyof T | keyof T[keyof T], any> = {} as Record<
+    keyof T | keyof T[keyof T],
+    any
+  >,
+  prefix = "",
+) => {
+  Object.keys(object).forEach(key => {
+    if (Array.isArray(object[key])) {
+      Object.assign(
+        output,
+        ...Object.keys(object[key]).map(key2 => ({
+          ...flattenKeys(object[key][key2], {}, `${key}[${key2}].`),
+        })),
+      )
+    } else {
+      output = {
+        ...output,
+        [`${prefix}${key}`]: object[key],
+      }
+    }
+  })
+  return output
+}
+
+export default flattenKeys

--- a/frontend/util/useEnumeratingAnchors.tsx
+++ b/frontend/util/useEnumeratingAnchors.tsx
@@ -1,0 +1,11 @@
+export function useEnumeratingAnchors(): [
+  Record<string, number>,
+  (_: string) => void,
+] {
+  let anchorId = 0
+
+  const anchors: Record<string, number> = {}
+  const addAnchor = (anchor: string) => (anchors[anchor] = anchorId++)
+
+  return [anchors, addAnchor]
+}


### PR DESCRIPTION
- keeps track of the field order, so we can scroll to the actual first error on the form
- `AnchorContext` available when wrapping component with the HOC; has list of anchors and function to add one