### PR TITLE
User search query params

### DIFF
--- a/backend/resolvers/Query/user.ts
+++ b/backend/resolvers/Query/user.ts
@@ -57,15 +57,17 @@ const UserDetailsContains = async (t: PrismaObjectDefinitionBlock<"Query">) => {
       first: intArg(),
       after: idArg(),
       last: intArg(),
+      skip: intArg(),
       before: idArg(),
     },
     resolve: async (_, args, ctx) => {
       checkAccess(ctx)
-      const { search, first, after, last, before } = args
+      const { search, first, after, last, before, skip } = args
       if ((!first && !last) || (first ?? 0) > 50 || (last ?? 0) > 50) {
         throw new ForbiddenError("Cannot query more than 50 objects")
       }
       const prisma: Prisma = ctx.prisma
+
       return prisma.usersConnection({
         where: {
           OR: buildSearch(
@@ -82,6 +84,7 @@ const UserDetailsContains = async (t: PrismaObjectDefinitionBlock<"Query">) => {
         last: last ?? undefined,
         after: after ?? undefined,
         before: before ?? undefined,
+        skip: skip ?? undefined,
       })
     },
   })

--- a/frontend/components/Dashboard/DashboardBreadCrumbs.tsx
+++ b/frontend/components/Dashboard/DashboardBreadCrumbs.tsx
@@ -119,6 +119,7 @@ const asToHref = {
   "/(courses|study-modules)/(?!new)([^/]+)(/.+)?": "/$1/[id]$3", // matches /(courses|study-modules)/[id]*, doesn't match new
   "/users/(.+)(/+)(.+)": "/users/[id]$2$3", // matches /users/[id]/*, doesn't match /users/[id] or search
   "/users/(?!search)([^/]+)$": "/users/[id]", // matches /users/[id], doesn't match /users/[id]/* or search
+  "/users/search/(.+)": "/users/search/[text]",
   "/register-completion/(.+)": "/register-completion/[slug]",
   "/(en|fi|se)/": "/[lng]/",
 }
@@ -192,7 +193,7 @@ const DashboardBreadCrumbs = React.memo((props: Props) => {
     homeLink = "/en/"
   }
 
-  const t = getPageTranslator(language)
+  const t = getPageTranslator(language, router)
 
   let urlRouteComponents = urlWithQueryAndAnchorRemoved.split("/")
   urlRouteComponents = urlRouteComponents.slice(

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -11,6 +11,7 @@ import {
   Table,
   TableBody,
   TableRow,
+  TableCell,
 } from "@material-ui/core"
 import Skeleton from "@material-ui/lab/Skeleton"
 import LangLink from "/components/LangLink"
@@ -42,7 +43,9 @@ const MobileGrid: React.FC<any> = () => {
           <TableBody>
             <TableRow>
               {loading ? (
-                <Skeleton style={{ margin: "0 0.5rem 0 0.5rem" }} height={52} />
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
               ) : (
                 <Pagination />
               )}

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -16,7 +16,6 @@ import Skeleton from "@material-ui/lab/Skeleton"
 import LangLink from "/components/LangLink"
 import {
   UserDetailsContains_userDetailsContains_edges,
-  UserDetailsContains,
   UserDetailsContains_userDetailsContains_edges_node,
 } from "/static/types/generated/UserDetailsContains"
 import Pagination from "/components/Dashboard/Users/Pagination"
@@ -24,44 +23,16 @@ import styled from "styled-components"
 import range from "lodash/range"
 import getUsersTranslator from "/translations/users"
 import LanguageContext from "/contexes/LanguageContext"
+import UserSearchContext from "/contexes/UserSearchContext"
 
 const UserCard = styled(Card)`
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 `
 
-interface HandleChangeRowsPerPageProps {
-  eventValue: string
-}
-
-interface GridProps {
-  data: UserDetailsContains
-  loadData: Function
-  loading: boolean
-  handleChangeRowsPerPage: (props: HandleChangeRowsPerPageProps) => void
-  TablePaginationActions: Function
-  page: number
-  rowsPerPage: number
-  searchText: string
-  setPage: React.Dispatch<React.SetStateAction<number>>
-  updateRoute: (_: string, __: number, ___: number) => void
-  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
-}
-
-const MobileGrid: React.FC<GridProps> = ({
-  data,
-  loadData,
-  handleChangeRowsPerPage,
-  TablePaginationActions,
-  page,
-  rowsPerPage,
-  searchText,
-  setPage,
-  loading,
-  updateRoute,
-  setSearchVariables,
-}: GridProps) => {
+const MobileGrid: React.FC<any> = () => {
   const { language } = useContext(LanguageContext)
+  const { data, page, rowsPerPage, loading } = useContext(UserSearchContext)
   const t = getUsersTranslator(language)
 
   const PaginationComponent = useCallback(
@@ -73,18 +44,7 @@ const MobileGrid: React.FC<GridProps> = ({
               {loading ? (
                 <Skeleton style={{ margin: "0 0.5rem 0 0.5rem" }} height={52} />
               ) : (
-                <Pagination
-                  data={data}
-                  rowsPerPage={rowsPerPage}
-                  page={page}
-                  setPage={setPage}
-                  searchText={searchText}
-                  loadData={loadData}
-                  handleChangeRowsPerPage={handleChangeRowsPerPage}
-                  TablePaginationActions={TablePaginationActions}
-                  updateRoute={updateRoute}
-                  setSearchVariables={setSearchVariables}
-                />
+                <Pagination />
               )}
             </TableRow>
           </TableBody>
@@ -101,16 +61,15 @@ const MobileGrid: React.FC<GridProps> = ({
       ) : (
         <Typography>{t("noResults")}</Typography>
       )}
-      <RenderCards data={data} loading={loading} />
+      <RenderCards />
       <PaginationComponent />
     </>
   )
 }
 
-const RenderCards: React.FC<{
-  data: UserDetailsContains
-  loading: boolean
-}> = ({ data, loading }) => {
+const RenderCards: React.FC<any> = () => {
+  const { data, loading } = useContext(UserSearchContext)
+
   if (loading) {
     return (
       <>

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -44,6 +44,8 @@ interface GridProps {
   rowsPerPage: number
   searchText: string
   setPage: React.Dispatch<React.SetStateAction<number>>
+  updateRoute: (_: string, __: number, ___: number) => void
+  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
 }
 
 const MobileGrid: React.FC<GridProps> = ({
@@ -56,6 +58,8 @@ const MobileGrid: React.FC<GridProps> = ({
   searchText,
   setPage,
   loading,
+  updateRoute,
+  setSearchVariables,
 }: GridProps) => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
@@ -66,22 +70,28 @@ const MobileGrid: React.FC<GridProps> = ({
         <Table>
           <TableBody>
             <TableRow>
-              <Pagination
-                data={data}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                setPage={setPage}
-                searchText={searchText}
-                loadData={loadData}
-                handleChangeRowsPerPage={handleChangeRowsPerPage}
-                TablePaginationActions={TablePaginationActions}
-              />
+              {loading ? (
+                <Skeleton style={{ margin: "0 0.5rem 0 0.5rem" }} height={52} />
+              ) : (
+                <Pagination
+                  data={data}
+                  rowsPerPage={rowsPerPage}
+                  page={page}
+                  setPage={setPage}
+                  searchText={searchText}
+                  loadData={loadData}
+                  handleChangeRowsPerPage={handleChangeRowsPerPage}
+                  TablePaginationActions={TablePaginationActions}
+                  updateRoute={updateRoute}
+                  setSearchVariables={setSearchVariables}
+                />
+              )}
             </TableRow>
           </TableBody>
         </Table>
       </Paper>
     ),
-    [data, rowsPerPage, page],
+    [data, rowsPerPage, page, loading],
   )
 
   return (

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -23,7 +23,7 @@ const TablePaginationActions: React.FC<any> = () => {
     page,
     rowsPerPage,
     setPage,
-    searchText,
+    searchVariables,
     setSearchVariables,
   } = useContext(UserSearchContext)
 
@@ -34,7 +34,7 @@ const TablePaginationActions: React.FC<any> = () => {
   const handleFirstPageButtonClick = useCallback(
     async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
-        search: searchText,
+        search: searchVariables.search,
         first: rowsPerPage,
       })
       setPage(0)
@@ -45,7 +45,7 @@ const TablePaginationActions: React.FC<any> = () => {
   const handleBackButtonClick = useCallback(
     async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
-        search: searchText,
+        search: searchVariables.search,
         last: rowsPerPage,
         before: startCursor,
       })
@@ -57,7 +57,7 @@ const TablePaginationActions: React.FC<any> = () => {
   const handleNextButtonClick = useCallback(
     async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
-        search: searchText,
+        search: searchVariables.search,
         first: rowsPerPage,
         after: endCursor,
       })
@@ -69,7 +69,7 @@ const TablePaginationActions: React.FC<any> = () => {
   const handleLastPageButtonClick = useCallback(
     async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
-        search: searchText,
+        search: searchVariables.search,
         last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
       })
       setPage(Math.max(0, Math.ceil(count / rowsPerPage) - 1))
@@ -122,8 +122,28 @@ const TablePaginationActions: React.FC<any> = () => {
 const Pagination: React.FC<any> = () => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
-  const { data, rowsPerPage, page, handleChangeRowsPerPage } = useContext(
-    UserSearchContext,
+  const {
+    data,
+    rowsPerPage,
+    page,
+    setPage,
+    setRowsPerPage,
+    searchVariables,
+    setSearchVariables,
+  } = useContext(UserSearchContext)
+
+  const handleChangeRowsPerPage = useCallback(
+    async ({ eventValue }: { eventValue: string }) => {
+      const newRowsPerPage = parseInt(eventValue, 10)
+
+      setSearchVariables({
+        search: searchVariables.search,
+        first: newRowsPerPage,
+      })
+      setPage(0)
+      setRowsPerPage(newRowsPerPage)
+    },
+    [searchVariables],
   )
 
   return (
@@ -139,7 +159,9 @@ const Pagination: React.FC<any> = () => {
       }}
       labelRowsPerPage={t("rowsPerPage")}
       labelDisplayedRows={({ from, to, count }) =>
-        `${from}-${to === -1 ? count : to}${t("displayedRowsOf")}${count}`
+        count > 0
+          ? `${from}-${to === -1 ? count : to}${t("displayedRowsOf")}${count}`
+          : ""
       }
       onChangePage={() => null}
       onChangeRowsPerPage={(

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -15,6 +15,8 @@ interface PaginationProps {
   rowsPerPage: number
   searchText: string
   setPage: React.Dispatch<React.SetStateAction<number>>
+  updateRoute: (_: string, __: number, ___: number) => void
+  setSearchVariables: React.Dispatch<React.SetStateAction<Record<string, any>>>
 }
 
 const Pagination: React.FC<PaginationProps> = ({
@@ -26,6 +28,8 @@ const Pagination: React.FC<PaginationProps> = ({
   loadData,
   TablePaginationActions,
   handleChangeRowsPerPage,
+  updateRoute,
+  setSearchVariables,
 }: PaginationProps) => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
@@ -56,6 +60,8 @@ const Pagination: React.FC<PaginationProps> = ({
           searchText,
           loadData,
           data,
+          updateRoute,
+          setSearchVariables,
         })
       }
     />

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -1,38 +1,130 @@
-import React, { useContext } from "react"
+import React, { useContext, useCallback } from "react"
 import { TablePagination } from "@material-ui/core"
-import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
 import getUsersTranslator from "/translations/users"
 import LanguageContext from "/contexes/LanguageContext"
+import UserSearchContext from "/contexes/UserSearchContext"
+import styled from "styled-components"
+import FirstPageIcon from "@material-ui/icons/FirstPage"
+import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft"
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
+import LastPageIcon from "@material-ui/icons/LastPage"
+import { useTheme } from "@material-ui/core/styles"
+import { IconButton } from "@material-ui/core"
 
-interface PaginationProps {
-  data: UserDetailsContains
-  loadData: Function
-  handleChangeRowsPerPage: (props: { eventValue: string }) => void
-  TablePaginationActions: Function /* (
-    props: TablePaginationActionsProps,
-  ) =>  */
-  page: number
-  rowsPerPage: number
-  searchText: string
-  setPage: React.Dispatch<React.SetStateAction<number>>
-  updateRoute: (_: string, __: number, ___: number) => void
-  setSearchVariables: React.Dispatch<React.SetStateAction<Record<string, any>>>
+const StyledFooter = styled.footer`
+  flex-shrink: 0;
+  margin-left: 2.5;
+`
+
+const TablePaginationActions: React.FC<any> = () => {
+  const theme = useTheme()
+  const {
+    data,
+    page,
+    rowsPerPage,
+    setPage,
+    searchText,
+    setSearchVariables,
+  } = useContext(UserSearchContext)
+
+  const startCursor = data?.userDetailsContains?.pageInfo?.startCursor
+  const endCursor = data?.userDetailsContains?.pageInfo?.endCursor
+  const count = data?.userDetailsContains?.count ?? 0
+
+  const handleFirstPageButtonClick = useCallback(
+    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      setSearchVariables({
+        search: searchText,
+        first: rowsPerPage,
+      })
+      setPage(0)
+    },
+    [],
+  )
+
+  const handleBackButtonClick = useCallback(
+    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      setSearchVariables({
+        search: searchText,
+        last: rowsPerPage,
+        before: startCursor,
+      })
+      setPage(page - 1)
+    },
+    [],
+  )
+
+  const handleNextButtonClick = useCallback(
+    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      setSearchVariables({
+        search: searchText,
+        first: rowsPerPage,
+        after: endCursor,
+      })
+      setPage(page + 1)
+    },
+    [],
+  )
+
+  const handleLastPageButtonClick = useCallback(
+    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      setSearchVariables({
+        search: searchText,
+        last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
+      })
+      setPage(Math.max(0, Math.ceil(count / rowsPerPage) - 1))
+    },
+    [],
+  )
+
+  return (
+    <StyledFooter>
+      <IconButton
+        onClick={handleFirstPageButtonClick}
+        disabled={page === 0}
+        aria-label="first page"
+      >
+        {theme.direction === "rtl" ? <LastPageIcon /> : <FirstPageIcon />}
+      </IconButton>
+      <IconButton
+        onClick={handleBackButtonClick}
+        disabled={page === 0}
+        aria-label="previous page"
+      >
+        {theme.direction === "rtl" ? (
+          <KeyboardArrowRight />
+        ) : (
+          <KeyboardArrowLeft />
+        )}
+      </IconButton>
+      <IconButton
+        onClick={handleNextButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        aria-label="next page"
+      >
+        {theme.direction === "rtl" ? (
+          <KeyboardArrowLeft />
+        ) : (
+          <KeyboardArrowRight />
+        )}
+      </IconButton>
+      <IconButton
+        onClick={handleLastPageButtonClick}
+        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        aria-label="last page"
+      >
+        {theme.direction === "rtl" ? <FirstPageIcon /> : <LastPageIcon />}
+      </IconButton>
+    </StyledFooter>
+  )
 }
 
-const Pagination: React.FC<PaginationProps> = ({
-  data,
-  rowsPerPage,
-  page,
-  setPage,
-  searchText,
-  loadData,
-  TablePaginationActions,
-  handleChangeRowsPerPage,
-  updateRoute,
-  setSearchVariables,
-}: PaginationProps) => {
+const Pagination: React.FC<any> = () => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
+  const { data, rowsPerPage, page, handleChangeRowsPerPage } = useContext(
+    UserSearchContext,
+  )
 
   return (
     <TablePagination
@@ -53,17 +145,7 @@ const Pagination: React.FC<PaginationProps> = ({
       onChangeRowsPerPage={(
         event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
       ) => handleChangeRowsPerPage({ eventValue: event.target.value })}
-      ActionsComponent={props =>
-        TablePaginationActions({
-          ...props,
-          setPage,
-          searchText,
-          loadData,
-          data,
-          updateRoute,
-          setSearchVariables,
-        })
-      }
+      ActionsComponent={() => <TablePaginationActions />}
     />
   )
 }

--- a/frontend/components/Dashboard/Users/SearchForm.tsx
+++ b/frontend/components/Dashboard/Users/SearchForm.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback, useContext, useState } from "react"
+import UserSearchContext from "/contexes/UserSearchContext"
+import { H1NoBackground } from "/components/Text/headers"
+import { TextField, useMediaQuery } from "@material-ui/core"
+import LanguageContext from "/contexes/LanguageContext"
+import { ButtonWithPaddingAndMargin } from "/components/Buttons/ButtonWithPaddingAndMargin"
+import getUsersTranslator from "/translations/users"
+import styled from "styled-components"
+import MobileGrid from "/components/Dashboard/Users/MobileGrid"
+import WideGrid from "/components/Dashboard/Users/WideGrid"
+
+const StyledForm = styled.form`
+  display: flex;
+  width: 100%;
+`
+
+const StyledButton = styled(ButtonWithPaddingAndMargin)`
+  color: white;
+`
+
+const SearchForm = () => {
+  const {
+    page,
+    rowsPerPage,
+    searchVariables,
+    setPage,
+    setSearchVariables,
+  } = useContext(UserSearchContext)
+  const { language } = useContext(LanguageContext)
+  const t = getUsersTranslator(language)
+
+  const [searchFormText, setSearchFormText] = useState(searchVariables.search)
+
+  const handleSubmit = useCallback(() => {
+    if (searchFormText !== "") {
+      setSearchVariables({
+        search: searchFormText,
+        first: rowsPerPage,
+        skip: 0,
+      })
+      setPage(0)
+    }
+  }, [searchFormText, page, rowsPerPage])
+
+  const onTextBoxChange = (event: any) => {
+    setSearchFormText(event.target.value as string)
+  }
+
+  const isMobile = useMediaQuery("(max-width:800px)", { noSsr: true })
+  const GridComponent = isMobile ? MobileGrid : WideGrid
+
+  return (
+    <>
+      <H1NoBackground component="h1" variant="h1" align="center">
+        {t("userSearch")}
+      </H1NoBackground>
+      <div>
+        <StyledForm
+          onSubmit={async (event: any) => {
+            event.preventDefault()
+            handleSubmit()
+          }}
+        >
+          <TextField
+            id="standard-search"
+            label={t("searchByString")}
+            type="search"
+            margin="normal"
+            autoComplete="off"
+            value={searchFormText}
+            onChange={onTextBoxChange}
+          />
+
+          <StyledButton
+            variant="contained"
+            disabled={searchFormText === ""}
+            onClick={async (event: any) => {
+              event.preventDefault()
+              handleSubmit()
+            }}
+          >
+            {t("search")}
+          </StyledButton>
+        </StyledForm>
+        <GridComponent />
+      </div>
+    </>
+  )
+}
+
+export default SearchForm

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -13,13 +13,10 @@ import Skeleton from "@material-ui/lab/Skeleton"
 import styled from "styled-components"
 import range from "lodash/range"
 import LangLink from "/components/LangLink"
-import {
-  UserDetailsContains_userDetailsContains_edges,
-  UserDetailsContains,
-} from "/static/types/generated/UserDetailsContains"
 import Pagination from "/components/Dashboard/Users/Pagination"
 import getUsersTranslator from "/translations/users"
 import LanguageContext from "/contexes/LanguageContext"
+import UserSearchContext from "/contexes/UserSearchContext"
 
 const TableWrapper = styled.div`
   overflow-x: auto;
@@ -35,58 +32,16 @@ const StyledPaper = styled(Paper)`
   margin-top: 5px;
 `
 
-interface GridProps {
-  data: UserDetailsContains
-  loadData: Function
-  loading: boolean
-  handleChangeRowsPerPage: (props: { eventValue: string }) => void
-  TablePaginationActions: Function /* (
-    props: TablePaginationActionsProps,
-  ) =>  */
-  page: number
-  rowsPerPage: number
-  searchText: string
-  setPage: React.Dispatch<React.SetStateAction<number>>
-  updateRoute: (_: string, __: number, ___: number) => void
-  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
-}
-
-const WideGrid = ({
-  data,
-  loadData,
-  loading,
-  handleChangeRowsPerPage,
-  TablePaginationActions,
-  page,
-  rowsPerPage,
-  searchText,
-  setPage,
-  updateRoute,
-  setSearchVariables,
-}: GridProps) => {
+const WideGrid = () => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
+  const { data, rowsPerPage, page, loading } = useContext(UserSearchContext)
 
   const PaginationComponent = useCallback(
     () => (
       <TableRow>
         <td colSpan={5} align="center">
-          {loading ? (
-            <Skeleton />
-          ) : (
-            <Pagination
-              data={data}
-              rowsPerPage={rowsPerPage}
-              page={page}
-              setPage={setPage}
-              searchText={searchText}
-              loadData={loadData}
-              handleChangeRowsPerPage={handleChangeRowsPerPage}
-              TablePaginationActions={TablePaginationActions}
-              updateRoute={updateRoute}
-              setSearchVariables={setSearchVariables}
-            />
-          )}
+          {loading ? <Skeleton /> : <Pagination />}
         </td>
       </TableRow>
     ),
@@ -118,10 +73,7 @@ const WideGrid = ({
               </StyledTableCell>
             </TableRow>
           </TableHead>
-          <RenderResults
-            data={data?.userDetailsContains?.edges ?? []}
-            loading={loading}
-          />
+          <RenderResults />
           <TableFooter>
             <PaginationComponent />
           </TableFooter>
@@ -131,15 +83,12 @@ const WideGrid = ({
   )
 }
 
-interface RenderResultsProps {
-  data: UserDetailsContains_userDetailsContains_edges[]
-  loading: boolean
-}
-
-const RenderResults = (props: RenderResultsProps) => {
+const RenderResults = () => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
-  const { data, loading } = props
+  const { data, loading } = useContext(UserSearchContext)
+
+  const results = data?.userDetailsContains?.edges ?? []
 
   if (loading) {
     return (
@@ -155,7 +104,7 @@ const RenderResults = (props: RenderResultsProps) => {
     )
   }
 
-  if (!data || (data && data.length < 1))
+  if (!results || results?.length < 1)
     return (
       <TableBody>
         <TableRow>
@@ -166,7 +115,7 @@ const RenderResults = (props: RenderResultsProps) => {
 
   return (
     <TableBody>
-      {data.map(row => {
+      {results.map(row => {
         const {
           upstream_id,
           email,

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -47,6 +47,8 @@ interface GridProps {
   rowsPerPage: number
   searchText: string
   setPage: React.Dispatch<React.SetStateAction<number>>
+  updateRoute: (_: string, __: number, ___: number) => void
+  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
 }
 
 const WideGrid = ({
@@ -59,6 +61,8 @@ const WideGrid = ({
   rowsPerPage,
   searchText,
   setPage,
+  updateRoute,
+  setSearchVariables,
 }: GridProps) => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
@@ -67,20 +71,26 @@ const WideGrid = ({
     () => (
       <TableRow>
         <td colSpan={5} align="center">
-          <Pagination
-            data={data}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            setPage={setPage}
-            searchText={searchText}
-            loadData={loadData}
-            handleChangeRowsPerPage={handleChangeRowsPerPage}
-            TablePaginationActions={TablePaginationActions}
-          />
+          {loading ? (
+            <Skeleton />
+          ) : (
+            <Pagination
+              data={data}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              setPage={setPage}
+              searchText={searchText}
+              loadData={loadData}
+              handleChangeRowsPerPage={handleChangeRowsPerPage}
+              TablePaginationActions={TablePaginationActions}
+              updateRoute={updateRoute}
+              setSearchVariables={setSearchVariables}
+            />
+          )}
         </td>
       </TableRow>
     ),
-    [data, rowsPerPage, page],
+    [data, rowsPerPage, page, loading],
   )
 
   return (

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -41,7 +41,13 @@ const WideGrid = () => {
     () => (
       <TableRow>
         <td colSpan={5} align="center">
-          {loading ? <Skeleton /> : <Pagination />}
+          {loading ? (
+            <TableCell>
+              <Skeleton />
+            </TableCell>
+          ) : (
+            <Pagination />
+          )}
         </td>
       </TableRow>
     ),

--- a/frontend/contexes/UserSearchContext.ts
+++ b/frontend/contexes/UserSearchContext.ts
@@ -1,1 +1,28 @@
-// TODO: context to pass the things in user search around instead of drilling
+import { createContext } from "react"
+import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
+
+interface UserSearchContext {
+  data: UserDetailsContains
+  loadData: Function
+  loading: boolean
+  handleChangeRowsPerPage: ({ eventValue }: { eventValue: string }) => void
+  page: number
+  rowsPerPage: number
+  searchText: string
+  setPage: React.Dispatch<React.SetStateAction<number>>
+  // updateRoute: (_: string, __: number, ___: number) => void
+  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
+}
+
+export default createContext<UserSearchContext>({
+  data: {} as UserDetailsContains,
+  loadData: () => {},
+  loading: false,
+  handleChangeRowsPerPage: (_: any) => {},
+  page: 0,
+  rowsPerPage: 10,
+  searchText: "",
+  setPage: () => {},
+  // updateRoute: (_: string, __: number, ___: number) => {},
+  setSearchVariables: () => {},
+})

--- a/frontend/contexes/UserSearchContext.ts
+++ b/frontend/contexes/UserSearchContext.ts
@@ -1,0 +1,1 @@
+// TODO: context to pass the things in user search around instead of drilling

--- a/frontend/contexes/UserSearchContext.ts
+++ b/frontend/contexes/UserSearchContext.ts
@@ -1,28 +1,35 @@
 import { createContext } from "react"
 import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
 
+export interface SearchVariables {
+  search: string
+  first?: number
+  last?: number
+  skip?: number
+  after?: string | null
+  before?: string | null
+}
+
 interface UserSearchContext {
   data: UserDetailsContains
-  loadData: Function
   loading: boolean
-  handleChangeRowsPerPage: ({ eventValue }: { eventValue: string }) => void
   page: number
   rowsPerPage: number
-  searchText: string
+  searchVariables: SearchVariables
   setPage: React.Dispatch<React.SetStateAction<number>>
-  // updateRoute: (_: string, __: number, ___: number) => void
   setSearchVariables: React.Dispatch<React.SetStateAction<any>>
+  setRowsPerPage: React.Dispatch<React.SetStateAction<any>>
 }
 
 export default createContext<UserSearchContext>({
   data: {} as UserDetailsContains,
-  loadData: () => {},
   loading: false,
-  handleChangeRowsPerPage: (_: any) => {},
   page: 0,
   rowsPerPage: 10,
-  searchText: "",
+  searchVariables: {
+    search: "",
+  },
   setPage: () => {},
-  // updateRoute: (_: string, __: number, ___: number) => {},
   setSearchVariables: () => {},
+  setRowsPerPage: () => {},
 })

--- a/frontend/pages/[lng]/users/search/[text]/index.tsx
+++ b/frontend/pages/[lng]/users/search/[text]/index.tsx
@@ -1,5 +1,3 @@
-// import React from "react"
-// import { useRouter } from "next/router"
 import UserSearch from "/pages/[lng]/users/search"
 import withAdmin from "/lib/with-admin"
 

--- a/frontend/pages/[lng]/users/search/[text]/index.tsx
+++ b/frontend/pages/[lng]/users/search/[text]/index.tsx
@@ -1,0 +1,10 @@
+// import React from "react"
+// import { useRouter } from "next/router"
+import UserSearch from "/pages/[lng]/users/search"
+import withAdmin from "/lib/with-admin"
+
+const SearchText = (props: any) => {
+  return <UserSearch {...props} />
+}
+
+export default withAdmin(SearchText)

--- a/frontend/pages/[lng]/users/search/index.tsx
+++ b/frontend/pages/[lng]/users/search/index.tsx
@@ -1,12 +1,7 @@
-import React, { useCallback, useContext, useEffect } from "react"
+import React, { useCallback, useContext, useEffect, useState } from "react"
 import gql from "graphql-tag"
 import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
-import { useTheme } from "@material-ui/core/styles"
-import { TextField, IconButton, useMediaQuery } from "@material-ui/core"
-import FirstPageIcon from "@material-ui/icons/FirstPage"
-import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft"
-import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
-import LastPageIcon from "@material-ui/icons/LastPage"
+import { TextField, useMediaQuery } from "@material-ui/core"
 import Container from "/components/Container"
 import styled from "styled-components"
 import { useLazyQuery } from "@apollo/react-hooks"
@@ -19,216 +14,40 @@ import getUsersTranslator from "/translations/users"
 import LanguageContext from "/contexes/LanguageContext"
 import { useQueryParameter } from "/util/useQueryParameter"
 import { useRouter } from "next/router"
+import UserSearchContext from "/contexes/UserSearchContext"
 
 const StyledForm = styled.form`
   display: flex;
   width: 100%;
 `
 
-const StyledFooter = styled.footer`
-  flex-shrink: 0;
-  margin-left: 2.5;
-`
-
 const StyledButton = styled(ButtonWithPaddingAndMargin)`
   color: white;
 `
-
-interface TablePaginationActionsProps {
-  count: number
-  page: number
-  rowsPerPage: number
-  onChangePage: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    newPage: number,
-  ) => void
-  data: UserDetailsContains
-  setPage: Function
-  loadData: Function
-  searchText: string
-  updateRoute: (_: string, __: number, ___: number) => void
-  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
-}
-
-const StyledErrorMessage = styled.p`
-  color: #f44336;
-  font-size: 0.75rem;
-  margin-top: 3px;
-  margin-left: 14px;
-  margin-right: 14px;
-  text-align: left;
-  line-height: 1.66;
-`
-
-function TablePaginationActions(props: TablePaginationActionsProps) {
-  const theme = useTheme()
-  const {
-    data,
-    page,
-    rowsPerPage,
-    setPage,
-    searchText,
-    /*loadData, */ updateRoute,
-    setSearchVariables,
-  } = props
-
-  const startCursor = data?.userDetailsContains?.pageInfo?.startCursor
-  const endCursor = data?.userDetailsContains?.pageInfo?.endCursor
-  const count = data?.userDetailsContains?.count ?? 0
-
-  const handleFirstPageButtonClick = useCallback(
-    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      setSearchVariables({
-        search: searchText,
-        first: rowsPerPage,
-      })
-      setPage(0)
-      /*       loadData({
-        variables: { search: searchText, first: rowsPerPage },
-      }) */
-      updateRoute(searchText, rowsPerPage, 0)
-    },
-    [],
-  )
-
-  const handleBackButtonClick = useCallback(
-    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      setSearchVariables({
-        search: searchText,
-        last: rowsPerPage,
-        before: startCursor,
-      })
-      setPage(page - 1)
-      /* 
-      loadData({
-        variables: {
-          search: searchText,
-          last: rowsPerPage,
-          before: startCursor, // cursor.before,
-        },
-      })
- */ updateRoute(
-        searchText,
-        rowsPerPage,
-        page - 1,
-      )
-    },
-    [],
-  )
-
-  const handleNextButtonClick = useCallback(
-    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      setSearchVariables({
-        search: searchText,
-        first: rowsPerPage,
-        after: endCursor,
-      })
-      setPage(page + 1)
-      /*       loadData({
-        variables: {
-          search: searchText,
-          first: rowsPerPage,
-          after: endCursor, // cursor.after,
-        },
-      }) */
-      // setCount(data.userDetailsContains.count)
-      updateRoute(searchText, rowsPerPage, page + 1)
-    },
-    [],
-  )
-
-  const handleLastPageButtonClick = useCallback(
-    async (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      setSearchVariables({
-        search: searchText,
-        last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
-      })
-      setPage(Math.max(0, Math.ceil(count / rowsPerPage) - 1))
-      /*       loadData({
-        variables: {
-          search: searchText,
-          last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
-        },
-      }) */
-      updateRoute(
-        searchText,
-        rowsPerPage,
-        Math.max(0, Math.ceil(count / rowsPerPage) - 1),
-      )
-    },
-    [],
-  )
-
-  return (
-    <StyledFooter>
-      <IconButton
-        onClick={handleFirstPageButtonClick}
-        disabled={page === 0}
-        aria-label="first page"
-      >
-        {theme.direction === "rtl" ? <LastPageIcon /> : <FirstPageIcon />}
-      </IconButton>
-      <IconButton
-        onClick={handleBackButtonClick}
-        disabled={page === 0}
-        aria-label="previous page"
-      >
-        {theme.direction === "rtl" ? (
-          <KeyboardArrowRight />
-        ) : (
-          <KeyboardArrowLeft />
-        )}
-      </IconButton>
-      <IconButton
-        onClick={handleNextButtonClick}
-        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-        aria-label="next page"
-      >
-        {theme.direction === "rtl" ? (
-          <KeyboardArrowLeft />
-        ) : (
-          <KeyboardArrowRight />
-        )}
-      </IconButton>
-      <IconButton
-        onClick={handleLastPageButtonClick}
-        disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-        aria-label="last page"
-      >
-        {theme.direction === "rtl" ? <FirstPageIcon /> : <LastPageIcon />}
-      </IconButton>
-    </StyledFooter>
-  )
-}
-
-// @ts-ignore: asdf
-interface Search {
-  text: string
-  page: number
-  rowsPerPage: number
-}
 
 const UserSearch = () => {
   const { language } = useContext(LanguageContext)
   const t = getUsersTranslator(language)
   const router = useRouter()
   const textParam = useQueryParameter("text", false)
+
   const pageParam = parseInt(useQueryParameter("page", false), 10) || 0
   const rowsParam = parseInt(useQueryParameter("rowsPerPage", false), 10) || 10
 
-  const [searchVariables, setSearchVariables] = React.useState({
+  const [searchVariables, setSearchVariables] = useState({
     search: textParam,
-    first: pageParam === 0 ? rowsParam : undefined,
+    first: rowsParam,
     skip: pageParam > 0 ? (pageParam - 1) * rowsParam : undefined,
   })
 
-  const [searchText, setSearchText] = React.useState(textParam)
-  const [page, setPage] = React.useState(pageParam)
-  const [rowsPerPage, setRowsPerPage] = React.useState(rowsParam)
-  // @ts-ignore: k
-  const [error, setError] = React.useState("")
+  const [searchText, setSearchText] = useState(textParam)
+  const [page, setPage] = useState(pageParam)
+  const [rowsPerPage, setRowsPerPage] = useState(rowsParam)
 
-  const [loadData, { data, loading }] = useLazyQuery(GET_DATA, { ssr: false })
+  const [loadData, { data, loading }] = useLazyQuery<UserDetailsContains>(
+    GET_DATA,
+    { ssr: false },
+  )
 
   const isMobile = useMediaQuery("(max-width:800px)", { noSsr: true })
 
@@ -236,9 +55,6 @@ const UserSearch = () => {
 
   const onTextBoxChange = (event: any) => {
     setSearchText(event.target.value as string)
-  }
-  interface HandleChangeRowsPerPageProps {
-    eventValue: string
   }
 
   useEffect(() => {
@@ -249,26 +65,22 @@ const UserSearch = () => {
     }
   }, [searchVariables])
 
-  // @ts-ignore: text
-  const updateRoute = useCallback(
-    (text, rows, page) => {
-      const params = [
-        rows !== 10 ? `rowsPerPage=${rows}` : "",
-        page > 0 ? `page=${page}` : "",
-      ].filter(v => !!v)
-      const query = params.length ? `?${params.join("&")}` : ""
+  useEffect(() => {
+    const params = [
+      rowsPerPage !== 10 ? `rowsPerPage=${rowsPerPage}` : "",
+      page > 0 ? `page=${page}` : "",
+    ].filter(v => !!v)
+    const query = params.length ? `?${params.join("&")}` : ""
 
-      if (text !== "") {
-        router.push(
-          "/[lng]/users/search/[text]",
-          `/${language}/users/search/${text}${query}`,
-        )
-      } else {
-        router.push("/[lng]/users/search", `/${language}/users/search${query}`)
-      }
-    },
-    [searchText, rowsPerPage],
-  )
+    if (searchText !== "") {
+      router.push(
+        "/[lng]/users/search/[text]",
+        `/${language}/users/search/${searchText}${query}`,
+      )
+    } else {
+      router.push("/[lng]/users/search", `/${language}/users/search${query}`)
+    }
+  }, [searchVariables.search, rowsPerPage, page])
 
   const handleSubmit = useCallback(() => {
     if (searchText !== "") {
@@ -276,24 +88,19 @@ const UserSearch = () => {
         ...searchVariables,
         search: searchText,
       })
-      updateRoute(searchText, rowsPerPage, page)
     }
   }, [searchText, rowsPerPage])
 
   const handleChangeRowsPerPage = useCallback(
-    async (props: HandleChangeRowsPerPageProps) => {
-      const { eventValue } = props
+    async ({ eventValue }: { eventValue: string }) => {
       const newRowsPerPage = parseInt(eventValue, 10)
 
-      if (searchText !== "") {
-        setSearchVariables({
-          ...searchVariables,
-          search: searchText,
-        })
-      }
+      setSearchVariables({
+        ...searchVariables,
+        first: newRowsPerPage,
+      })
       setPage(0)
       setRowsPerPage(newRowsPerPage)
-      updateRoute(searchText, newRowsPerPage, page)
     },
     [searchText],
   )
@@ -301,62 +108,53 @@ const UserSearch = () => {
   return (
     <>
       <Container>
-        <H1NoBackground component="h1" variant="h1" align="center">
-          {t("userSearch")}
-        </H1NoBackground>
-        <div>
-          <StyledForm
-            onSubmit={async (event: any) => {
-              event.preventDefault()
-              handleSubmit()
-              /*               loadData({
-                              variables: { search: searchText, first: rowsPerPage },
-                            }) */
-              /*updateRoute(searchText, rowsPerPage)
-              setPage(0)*/
-            }}
-          >
-            <TextField
-              id="standard-search"
-              label={t("searchByString")}
-              type="search"
-              margin="normal"
-              autoComplete="off"
-              value={searchText}
-              onChange={onTextBoxChange}
-            />
-
-            <StyledButton
-              variant="contained"
-              disabled={searchText === ""}
-              onClick={async (event: any) => {
+        <UserSearchContext.Provider
+          value={{
+            data: data || ({} as UserDetailsContains),
+            loading,
+            loadData,
+            handleChangeRowsPerPage,
+            page,
+            rowsPerPage,
+            searchText,
+            setPage,
+            setSearchVariables,
+          }}
+        >
+          <H1NoBackground component="h1" variant="h1" align="center">
+            {t("userSearch")}
+          </H1NoBackground>
+          <div>
+            <StyledForm
+              onSubmit={async (event: any) => {
                 event.preventDefault()
                 handleSubmit()
-                /*                 loadData({
-                                  variables: { search: searchText, first: rowsPerPage },
-                                }) */
-                /*                 updateRoute(searchText, rowsPerPage)
-                setPage(0) */
               }}
             >
-              {t("search")}
-            </StyledButton>
-          </StyledForm>
-          {error && <StyledErrorMessage>{error}</StyledErrorMessage>}
-          <GridComponent
-            data={data}
-            loading={loading}
-            loadData={loadData}
-            handleChangeRowsPerPage={handleChangeRowsPerPage}
-            TablePaginationActions={TablePaginationActions}
-            page={page}
-            rowsPerPage={rowsPerPage}
-            searchText={searchText}
-            setPage={setPage}
-            updateRoute={updateRoute}
-            setSearchVariables={setSearchVariables}
-          />
-        </div>
+              <TextField
+                id="standard-search"
+                label={t("searchByString")}
+                type="search"
+                margin="normal"
+                autoComplete="off"
+                value={searchText}
+                onChange={onTextBoxChange}
+              />
+
+              <StyledButton
+                variant="contained"
+                disabled={searchText === ""}
+                onClick={async (event: any) => {
+                  event.preventDefault()
+                  handleSubmit()
+                }}
+              >
+                {t("search")}
+              </StyledButton>
+            </StyledForm>
+            <GridComponent />
+          </div>
+        </UserSearchContext.Provider>
       </Container>
     </>
   )

--- a/frontend/pages/[lng]/users/search/index.tsx
+++ b/frontend/pages/[lng]/users/search/index.tsx
@@ -1,69 +1,37 @@
-import React, { useCallback, useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import gql from "graphql-tag"
 import { UserDetailsContains } from "/static/types/generated/UserDetailsContains"
-import { TextField, useMediaQuery } from "@material-ui/core"
 import Container from "/components/Container"
-import styled from "styled-components"
 import { useLazyQuery } from "@apollo/react-hooks"
-import WideGrid from "/components/Dashboard/Users/WideGrid"
-import MobileGrid from "/components/Dashboard/Users/MobileGrid"
-import { H1NoBackground } from "/components/Text/headers"
-import { ButtonWithPaddingAndMargin } from "/components/Buttons/ButtonWithPaddingAndMargin"
 import withAdmin from "/lib/with-admin"
-import getUsersTranslator from "/translations/users"
 import LanguageContext from "/contexes/LanguageContext"
 import { useQueryParameter } from "/util/useQueryParameter"
 import { useRouter } from "next/router"
-import UserSearchContext from "/contexes/UserSearchContext"
-
-const StyledForm = styled.form`
-  display: flex;
-  width: 100%;
-`
-
-const StyledButton = styled(ButtonWithPaddingAndMargin)`
-  color: white;
-`
+import UserSearchContext, { SearchVariables } from "/contexes/UserSearchContext"
+import SearchForm from "/components/Dashboard/Users/SearchForm"
 
 const UserSearch = () => {
   const { language } = useContext(LanguageContext)
-  const t = getUsersTranslator(language)
   const router = useRouter()
   const textParam = useQueryParameter("text", false)
-
   const pageParam = parseInt(useQueryParameter("page", false), 10) || 0
   const rowsParam = parseInt(useQueryParameter("rowsPerPage", false), 10) || 10
 
-  const [searchVariables, setSearchVariables] = useState({
+  const [searchVariables, setSearchVariables] = useState<SearchVariables>({
     search: textParam,
     first: rowsParam,
-    skip: pageParam > 0 ? (pageParam - 1) * rowsParam : undefined,
+    skip: pageParam > 0 ? pageParam * rowsParam : undefined,
   })
 
-  const [searchText, setSearchText] = useState(textParam)
   const [page, setPage] = useState(pageParam)
   const [rowsPerPage, setRowsPerPage] = useState(rowsParam)
 
   const [loadData, { data, loading }] = useLazyQuery<UserDetailsContains>(
     GET_DATA,
-    { ssr: false },
+    {
+      ssr: false,
+    },
   )
-
-  const isMobile = useMediaQuery("(max-width:800px)", { noSsr: true })
-
-  const GridComponent = isMobile ? MobileGrid : WideGrid
-
-  const onTextBoxChange = (event: any) => {
-    setSearchText(event.target.value as string)
-  }
-
-  useEffect(() => {
-    if (searchVariables.search !== "") {
-      loadData({
-        variables: searchVariables,
-      })
-    }
-  }, [searchVariables])
 
   useEffect(() => {
     const params = [
@@ -71,39 +39,26 @@ const UserSearch = () => {
       page > 0 ? `page=${page}` : "",
     ].filter(v => !!v)
     const query = params.length ? `?${params.join("&")}` : ""
+    const as =
+      searchVariables.search !== ""
+        ? `/${language}/users/search/${searchVariables.search}${query}`
+        : `/${language}/users/search${query}`
+    const href =
+      searchVariables.search !== ""
+        ? "/[lng]/users/search/[text]"
+        : "/[lng]/users/search"
 
-    if (searchText !== "") {
-      router.push(
-        "/[lng]/users/search/[text]",
-        `/${language}/users/search/${searchText}${query}`,
-      )
-    } else {
-      router.push("/[lng]/users/search", `/${language}/users/search${query}`)
-    }
-  }, [searchVariables.search, rowsPerPage, page])
-
-  const handleSubmit = useCallback(() => {
-    if (searchText !== "") {
-      setSearchVariables({
-        ...searchVariables,
-        search: searchText,
+    if (router?.pathname !== "/[lng]/users/search") {
+      loadData({
+        variables: searchVariables,
       })
     }
-  }, [searchText, rowsPerPage])
 
-  const handleChangeRowsPerPage = useCallback(
-    async ({ eventValue }: { eventValue: string }) => {
-      const newRowsPerPage = parseInt(eventValue, 10)
-
-      setSearchVariables({
-        ...searchVariables,
-        first: newRowsPerPage,
-      })
-      setPage(0)
-      setRowsPerPage(newRowsPerPage)
-    },
-    [searchText],
-  )
+    if (router?.asPath !== as) {
+      // the history is still a bit wonky - how should it work?
+      router.push(href, as, { shallow: true })
+    }
+  }, [searchVariables, rowsPerPage, page])
 
   return (
     <>
@@ -112,48 +67,15 @@ const UserSearch = () => {
           value={{
             data: data || ({} as UserDetailsContains),
             loading,
-            loadData,
-            handleChangeRowsPerPage,
             page,
             rowsPerPage,
-            searchText,
+            searchVariables,
             setPage,
             setSearchVariables,
+            setRowsPerPage,
           }}
         >
-          <H1NoBackground component="h1" variant="h1" align="center">
-            {t("userSearch")}
-          </H1NoBackground>
-          <div>
-            <StyledForm
-              onSubmit={async (event: any) => {
-                event.preventDefault()
-                handleSubmit()
-              }}
-            >
-              <TextField
-                id="standard-search"
-                label={t("searchByString")}
-                type="search"
-                margin="normal"
-                autoComplete="off"
-                value={searchText}
-                onChange={onTextBoxChange}
-              />
-
-              <StyledButton
-                variant="contained"
-                disabled={searchText === ""}
-                onClick={async (event: any) => {
-                  event.preventDefault()
-                  handleSubmit()
-                }}
-              >
-                {t("search")}
-              </StyledButton>
-            </StyledForm>
-            <GridComponent />
-          </div>
+          <SearchForm />
         </UserSearchContext.Provider>
       </Container>
     </>

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -58,7 +58,8 @@ class MyApp extends App {
       currentUser,
     } = this.props
 
-    const t = getPageTranslator(lng)
+    // give router to translator to get query parameters
+    const t = getPageTranslator(lng, Router.router)
     const titleString = t("title", { title: "..." })?.[hrefUrl]
 
     const title = `${titleString ? titleString + " - " : ""}MOOC.fi`

--- a/frontend/translations/pages/en.json
+++ b/frontend/translations/pages/en.json
@@ -16,6 +16,7 @@
     "/[lng]/users/[id]": "User - {{title}}",
     "/[lng]/users/[id]/completions": "Completions - {{title}}",
     "/[lng]/users/search": "Search users",
+    "/[lng]/users/search/[text]": "Search users - [[text]]",
     "/[lng]/users": "Users",
     "/[lng]/sign-in": "Sign in",
     "/[lng]/sign-up": "Sign up",

--- a/frontend/translations/pages/fi.json
+++ b/frontend/translations/pages/fi.json
@@ -16,6 +16,7 @@
     "/[lng]/users/[id]": "Käyttäjä - {{title}}",
     "/[lng]/users/[id]/completions": "Suoritukset - {{title}}",
     "/[lng]/users/search": "Hae käyttäjiä",
+    "/[lng]/users/search/[text]": "Hae käyttäjiä - [[text]]",
     "/[lng]/users": "Käyttäjät",
     "/[lng]/sign-in": "Kirjaudu",
     "/[lng]/sign-up": "Rekisteröidy",

--- a/frontend/util/useQueryParameter.tsx
+++ b/frontend/util/useQueryParameter.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router"
 
-export function useQueryParameter(parameter: string) {
+export function useQueryParameter(parameter: string, check: boolean = true) {
   const router = useRouter()
 
   if (!router) {
@@ -8,10 +8,14 @@ export function useQueryParameter(parameter: string) {
   }
 
   const checkingParameter = router?.query?.[parameter]
+
   if (checkingParameter === null || checkingParameter === undefined) {
-    throw new Error(
-      "You have tried to use useQueryParameter hook with a query parameter which is not in the path of this page.",
-    )
+    if (check) {
+      throw new Error(
+        "You have tried to use useQueryParameter hook with a query parameter which is not in the path of this page.",
+      )
+    }
+    return ""
   }
   if (typeof checkingParameter === "string") {
     return checkingParameter

--- a/frontend/util/useQueryParameter.tsx
+++ b/frontend/util/useQueryParameter.tsx
@@ -7,7 +7,22 @@ export function useQueryParameter(parameter: string, check: boolean = true) {
     return ""
   }
 
-  const checkingParameter = router?.query?.[parameter]
+  // combine params in the url with the dynamic params
+  const params: Record<string, any> = (
+    (router?.asPath?.split("?")[1] || "").split("&") || []
+  ).reduce(
+    (acc, curr) => {
+      const [key, val] = curr.split("=")
+
+      return {
+        ...acc,
+        [key]: val,
+      }
+    },
+    { ...router?.query },
+  )
+
+  const checkingParameter = params?.[parameter]
 
   if (checkingParameter === null || checkingParameter === undefined) {
     if (check) {


### PR DESCRIPTION
- user search updates the URL, so history works (at least to some point)
- useQueryParameter updated to include the query parameters in the URL that were previously ignored when dynamic routes were used
- user search now using its own context; refactored
- you can now use dynamic routes in the translations, as long as you pass the router to the translator
