### PR TITLE
Fix translator error

### DIFF
--- a/backend/resolvers/Completion/index.ts
+++ b/backend/resolvers/Completion/index.ts
@@ -1,3 +1,3 @@
-// generated Mon Feb 24 2020 15:41:08 GMT+0200 (Eastern European Standard Time)
+// generated Thu Mar 05 2020 11:31:21 GMT+0200 (Eastern European Standard Time)
 
 export { default as Completion } from "./Completion"

--- a/backend/resolvers/Mutation/index.ts
+++ b/backend/resolvers/Mutation/index.ts
@@ -1,4 +1,4 @@
-// generated Mon Feb 24 2020 15:41:08 GMT+0200 (Eastern European Standard Time)
+// generated Thu Mar 05 2020 11:31:21 GMT+0200 (Eastern European Standard Time)
 
 export { default as addCompletionRegisteredMutations } from "./CompletionRegistered"
 export { default as addEmailTemplateMutations } from "./EmailTemplate"

--- a/backend/resolvers/Query/index.ts
+++ b/backend/resolvers/Query/index.ts
@@ -1,4 +1,4 @@
-// generated Mon Feb 24 2020 15:41:08 GMT+0200 (Eastern European Standard Time)
+// generated Thu Mar 05 2020 11:31:21 GMT+0200 (Eastern European Standard Time)
 
 export { default as addEmailTemplateQueries } from "./EmailTemplate"
 export { default as addExerciseQueries } from "./Exercise"

--- a/backend/types/index.ts
+++ b/backend/types/index.ts
@@ -1,4 +1,4 @@
-// generated Mon Feb 24 2020 15:41:08 GMT+0200 (Eastern European Standard Time)
+// generated Thu Mar 05 2020 11:31:21 GMT+0200 (Eastern European Standard Time)
 
 export { default as Completion } from "./Completion"
 export { default as CompletionArg } from "./CompletionArg"

--- a/frontend/static/types/generated/UserDetailsContains.ts
+++ b/frontend/static/types/generated/UserDetailsContains.ts
@@ -47,4 +47,5 @@ export interface UserDetailsContainsVariables {
   after?: string | null
   first?: number | null
   last?: number | null
+  skip?: number | null
 }

--- a/frontend/translations/index.ts
+++ b/frontend/translations/index.ts
@@ -68,7 +68,7 @@ const substitute = <T>({
   }
 
   if (keyGroups) {
-    if (!router) {
+    if (!router && process.browser) {
       console.warn(
         `WARNING: no router given to translator - needed to access query parameters in ${translation}`,
       )


### PR DESCRIPTION
- translator gave unnecessary errors on SSR because it didn't have the router instance yet, and it isn't needed there anyway