### PR TITLE
redirect to 404

### DIFF
--- a/frontend/pages/404.tsx
+++ b/frontend/pages/404.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { Typography } from "@material-ui/core"
+
+const FourOhFour = () => {
+  return (
+    <section>
+      <Typography
+        component="h1"
+        variant="h2"
+        gutterBottom={true}
+        align="center"
+      >
+        404
+      </Typography>
+      <Typography variant="body1" gutterBottom={true} align="center">
+        Hups. Tätä sivua ei ole olemassa.
+      </Typography>
+      <Typography variant="body1" gutterBottom={true} align="center">
+        Uh oh. You've reached a non-existent page.
+      </Typography>
+      <Typography variant="body1" gutterBottom={true} align="center">
+        Hoppsan. Sidan finns inte.
+      </Typography>
+    </section>
+  )
+}
+
+export default FourOhFour

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -112,6 +112,8 @@ class MyApp extends App {
 // We're probably not supposed to do this
 const originalGetInitialProps = MyApp.getInitialProps
 
+const languages = ["en", "fi", "se"]
+
 function createPath(originalUrl) {
   let url = ""
   /*   if (originalUrl === "/") {
@@ -136,21 +138,29 @@ function createPath(originalUrl) {
   return url
 }
 
-MyApp.getInitialProps = async arg => {
-  const { ctx } = arg
+MyApp.getInitialProps = async props => {
+  const { ctx } = props
   let lng = "fi"
   let url = "/"
   let hrefUrl = "/"
 
   if (typeof window !== "undefined") {
-    if (["fi", "en", "se"].includes(ctx?.asPath?.substring(1, 3) ?? "")) {
+    if (languages.includes(ctx?.asPath?.substring(1, 3) ?? "")) {
       lng = ctx.asPath.substring(1, 3)
     }
 
     url = ctx.asPath
     hrefUrl = ctx.pathname
   } else {
-    lng = ctx.query.lng || "fi"
+    const maybeLng = ctx.query.lng ?? "fi"
+
+    if (languages.includes(maybeLng)) {
+      lng = maybeLng
+    } else {
+      ctx?.res.writeHead(302, { location: "/404" })
+      ctx?.res.end()
+    }
+
     url = ctx.req.originalUrl
     hrefUrl = ctx.pathname //.req.path
   }
@@ -158,7 +168,7 @@ MyApp.getInitialProps = async arg => {
   let originalProps = {}
 
   if (originalGetInitialProps) {
-    originalProps = (await originalGetInitialProps(arg)) || {}
+    originalProps = (await originalGetInitialProps(props)) || {}
   }
 
   if (hrefUrl !== "/" && !hrefUrl.startsWith("/[lng]")) {

--- a/frontend/pages/_layout.tsx
+++ b/frontend/pages/_layout.tsx
@@ -19,7 +19,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
 
   const isHomePage = !!router?.asPath?.match(/^\/(\[lng\])?\/?$/)
-  console.log("path", router?.asPath)
 
   return (
     <div>

--- a/frontend/pages/_layout.tsx
+++ b/frontend/pages/_layout.tsx
@@ -19,6 +19,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
 
   const isHomePage = !!router?.asPath?.match(/^\/(\[lng\])?\/?$/)
+  console.log("path", router?.asPath)
 
   return (
     <div>


### PR DESCRIPTION
Redirects to 404 if the first component of the url is not a language (or empty) -- next.js seems to handle the special `register-completion` path okay. If going to paths like `/fi/nonexistent`, though, it shows the breadcrumb, which isn't optimal.