### PR TITLE
creating email template doesn't zap course info

### DIFF
--- a/backend/datamodel.prisma
+++ b/backend/datamodel.prisma
@@ -268,9 +268,9 @@ type ExerciseCompletion @db(name: "exercise_completion") {
 }
 
 type ExerciseCompletionRequiredActions @db(name: "exercise_completion_required_actions") {
-   id: UUID! @id
-   value: String!
-   exercise_completion: ExerciseCompletion! @relation(link: INLINE, name: "ExerciseCompletionToRequiredActions")
+  id: UUID! @id
+  value: String!
+  exercise_completion: ExerciseCompletion! @relation(link: INLINE, name: "ExerciseCompletionToRequiredActions")
 }
 
 type Image @db(name: "image") {

--- a/frontend/components/CreateEmailTemplateDialog.tsx
+++ b/frontend/components/CreateEmailTemplateDialog.tsx
@@ -17,12 +17,18 @@ import LanguageContext from "/contexes/LanguageContext"
 import CustomSnackbar from "/components/CustomSnackbar"
 import { updateCourse } from "/static/types/generated/updateCourse"
 import { UpdateCourseMutation } from "/graphql/mutations/courses"
+import { CourseDetailsFromSlugQuery_course } from "/static/types/generated/CourseDetailsFromSlugQuery"
+import omit from "lodash/omit"
 
 interface CreateEmailTemplateDialogParams {
-  course?: string
+  course?: CourseDetailsFromSlugQuery_course
   buttonText: string
 }
-const CreateEmailTemplateDialog = (props: CreateEmailTemplateDialogParams) => {
+
+const CreateEmailTemplateDialog = ({
+  course,
+  buttonText,
+}: CreateEmailTemplateDialogParams) => {
   const [openDialog, setOpenDialog] = React.useState(false)
   const [nameInput, setNameInput] = React.useState("")
   const [isErrorSnackbarOpen, setIsErrorSnackbarOpen] = React.useState(false)
@@ -38,7 +44,7 @@ const CreateEmailTemplateDialog = (props: CreateEmailTemplateDialogParams) => {
   return (
     <div>
       <Button color="primary" onClick={handleDialogClickOpen}>
-        {props.buttonText}
+        {buttonText}
       </Button>
       <Dialog
         open={openDialog}
@@ -73,14 +79,16 @@ const CreateEmailTemplateDialog = (props: CreateEmailTemplateDialogParams) => {
                   try {
                     const { data } = await client.mutate<AddEmailTemplate>({
                       mutation: AddEmailTemplateMutation,
-                      variables: { name: nameInput },
+                      variables: {
+                        name: nameInput,
+                      },
                     })
-                    if (props.course) {
+                    if (course) {
                       await client.mutate<updateCourse>({
                         mutation: UpdateCourseMutation,
                         variables: {
                           course: {
-                            slug: props.course,
+                            ...omit(course, "__typename", "id"),
                             completion_email: data?.addEmailTemplate.id,
                           },
                         },

--- a/frontend/pages/[lng]/courses/[id]/index.tsx
+++ b/frontend/pages/[lng]/courses/[id]/index.tsx
@@ -25,6 +25,7 @@ export const CourseDetailsFromSlugQuery = gql`
   query CourseDetailsFromSlugQuery($slug: String) {
     course(slug: $slug) {
       id
+      slug
       name
       completion_email {
         name
@@ -95,7 +96,7 @@ const Course = () => {
         ) : (
           <CreateEmailTemplateDialog
             buttonText="Create completion email"
-            course={slug}
+            course={data.course}
           />
         )}
         <CourseDashboard />


### PR DESCRIPTION
Should fix things without breaking other stuff. Previously it did basically what it was told to -- it updated the course to whatever it was sent, in this case, just the course name and the completion email and deleted all the connected stuff.

Can one email template be in use in many courses? If not, then updating the course wouldn't be necessary as we could link the template to the course.