### PR TITLE
enable introspection in prod; fix consumer object log

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -111,7 +111,12 @@ settings.change({
   server: {
     port: 4000,
     path: PRODUCTION ? "/api" : "/",
-    playground: true,
+    graphql: {
+      introspection: true,
+    },
+    playground: {
+      enabled: true,
+    },
   },
   schema: {
     generateGraphQLSDLFile: "./generated/schema.graphql",

--- a/backend/bin/kafkaConsumer/exerciseConsumer/saveToDB.ts
+++ b/backend/bin/kafkaConsumer/exerciseConsumer/saveToDB.ts
@@ -70,7 +70,7 @@ const handleExercise = async (
     ) {
       logger.error(
         "Timestamp is older than on existing exercise on " +
-          exercise +
+          JSON.stringify(exercise) +
           "skipping this exercise",
       )
       return


### PR DESCRIPTION
Playground introspection was disabled in production by default; enabled to make things easier.