### PR TITLE
only validate on blur; only enumerate anchor if not exist

### DIFF
--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -153,7 +153,6 @@ const renderForm = ({ courses, studyModules }: RenderFormProps) => () => {
               autoComplete="off"
               component={StyledTextField}
               required={true}
-              validateOnChange={true}
               helperText={t("courseSlugHelper")}
             />
             <StyledFieldWithAnchor

--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -153,6 +153,7 @@ const renderForm = ({ courses, studyModules }: RenderFormProps) => () => {
               autoComplete="off"
               component={StyledTextField}
               required={true}
+              validateOnChange={true}
               helperText={t("courseSlugHelper")}
             />
             <StyledFieldWithAnchor
@@ -493,7 +494,12 @@ const CourseEditForm = React.memo(
     }, [])
 
     return (
-      <Formik initialValues={course} validate={validate} onSubmit={onSubmit}>
+      <Formik
+        initialValues={course}
+        validate={validate}
+        onSubmit={onSubmit}
+        validateOnChange={false}
+      >
         <FormWrapper<CourseFormValues>
           renderForm={renderForm({
             initialValues: course,

--- a/frontend/lib/with-enumerating-anchors.tsx
+++ b/frontend/lib/with-enumerating-anchors.tsx
@@ -4,7 +4,11 @@ import AnchorContext from "/contexes/AnchorContext"
 const withEnumeratingAnchors = <T,>(Component: any) => (props: any) => {
   let anchorId = 0
   const anchors: Record<string, number> = {}
-  const addAnchor = (anchor: string) => (anchors[anchor] = anchorId++)
+  const addAnchor = (anchor: string) => {
+    if (!anchors[anchor]) {
+      anchors[anchor] = anchorId++
+    }
+  }
 
   return (
     <AnchorContext.Provider value={{ anchors, addAnchor }}>


### PR DESCRIPTION
- course edit form now only validates on blur, not change
- don't enumerate anchors again on each rerender