### PR TITLE
allow course & course_exists query for user

### DIFF
--- a/backend/graphql/Course/queries.ts
+++ b/backend/graphql/Course/queries.ts
@@ -1,8 +1,9 @@
 import { schema } from "nexus"
 import { Course } from "@prisma/client"
 import { UserInputError } from "apollo-server-core"
-import { isAdmin } from "../../accessControl"
+import { isAdmin, isUser, or } from "../../accessControl"
 import { filterNull } from "../../util/db-functions"
+
 schema.extendType({
   type: "Query",
   definition(t) {
@@ -13,7 +14,7 @@ schema.extendType({
         id: schema.idArg(),
         language: schema.stringArg(),
       },
-      authorize: isAdmin,
+      authorize: or(isAdmin, isUser),
       nullable: true,
       resolve: async (_, args, ctx) => {
         const { slug, id, language } = args
@@ -125,7 +126,7 @@ schema.extendType({
       args: {
         slug: schema.stringArg({ required: true }),
       },
-      authorize: isAdmin,
+      authorize: or(isAdmin, isUser),
       resolve: async (_, args, ctx) => {
         const { slug } = args
 

--- a/backend/graphql/Course/queries.ts
+++ b/backend/graphql/Course/queries.ts
@@ -1,8 +1,8 @@
 import { schema } from "nexus"
-import { Course } from "@prisma/client"
 import { UserInputError } from "apollo-server-core"
-import { isAdmin, isUser, or } from "../../accessControl"
+import { isAdmin, isUser, or, Role } from "../../accessControl"
 import { filterNull } from "../../util/db-functions"
+import { Course } from "nexus-plugin-prisma/client"
 
 schema.extendType({
   type: "Query",
@@ -28,6 +28,15 @@ schema.extendType({
             slug: slug ?? undefined,
             id: id ?? undefined,
           },
+          ...(ctx.role !== Role.ADMIN
+            ? {
+                select: {
+                  id: true,
+                  slug: true,
+                  name: true,
+                },
+              }
+            : {}),
         })
 
         if (!course) {
@@ -130,7 +139,14 @@ schema.extendType({
       resolve: async (_, args, ctx) => {
         const { slug } = args
 
-        return (await ctx.db.course.findMany({ where: { slug } })).length > 0
+        return (
+          (
+            await ctx.db.course.findMany({
+              where: { slug },
+              select: { id: true },
+            })
+          ).length > 0
+        )
       },
     })
   },

--- a/backend/graphql/StudyModule/queries.ts
+++ b/backend/graphql/StudyModule/queries.ts
@@ -1,6 +1,6 @@
 import { schema } from "nexus"
 import { UserInputError } from "apollo-server-core"
-import { isAdmin } from "../../accessControl"
+import { isAdmin, or, isUser, Role } from "../../accessControl"
 import { filterNull } from "../../util/db-functions"
 
 schema.extendType({
@@ -13,7 +13,7 @@ schema.extendType({
         slug: schema.stringArg(),
         language: schema.stringArg(),
       },
-      authorize: isAdmin,
+      authorize: or(isAdmin, isUser),
       nullable: true,
       resolve: async (_, args, ctx) => {
         const { id, slug, language } = args
@@ -27,6 +27,15 @@ schema.extendType({
             id: id ?? undefined,
             slug: slug ?? undefined,
           },
+          ...(ctx.role !== Role.ADMIN
+            ? {
+                select: {
+                  id: true,
+                  slug: true,
+                  name: true,
+                },
+              }
+            : {}),
         })
 
         if (!study_module) {


### PR DESCRIPTION
Apparently we didn't allow users to query for course and course_exists (and same for study_modules). This also mean the breadcrumbs weren't working in production for non-admins. I allowed users to query course and study_module, but restricted the fields they can get. 