### PR TITLE
fix exercise consumer update

### DIFF
--- a/backend/bin/kafkaConsumer/exerciseConsumer/saveToDB.ts
+++ b/backend/bin/kafkaConsumer/exerciseConsumer/saveToDB.ts
@@ -31,7 +31,7 @@ export const saveToDatabase = async (
       AND: {
         course_id: message.course_id,
         service_id: message.service_id,
-        custom_id: { not: { in: message.data.map((p) => p.id) } },
+        custom_id: { not: { in: message.data.map((p) => p.id.toString()) } },
       },
     },
     data: {


### PR DESCRIPTION
Exercise `custom_id` is a string; message had ints