### PR TITLE
move viewport to _app

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -99,6 +99,10 @@ class MyApp extends App {
     return (
       <>
         <Head>
+          <meta
+            name="viewport"
+            content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
+          />
           <title>{title}</title>
         </Head>
         <StylesProvider injectFirst>

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -50,10 +50,6 @@ class MyDocument extends Document {
       <html lang="fi" dir="ltr">
         <Head>
           <meta charSet="utf-8" />
-          <meta
-            name="viewport"
-            content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
-          />
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link
             rel="shortcut icon"


### PR DESCRIPTION
viewport meta in _document was overridden by next; moved to _app to fix weird empty margins on narrow displays