### PR TITLE
Add completion tier

### DIFF
--- a/backend/bin/kafkaConsumer/common/userCourseProgress/generateBAIUserCourseProgress.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/generateBAIUserCourseProgress.ts
@@ -115,6 +115,7 @@ export const checkBAICompletion = async (
     course_id: highestTierCourseId,
     handlerCourse,
     logger,
+    tier: highestTier,
   })
 }
 

--- a/backend/bin/kafkaConsumer/common/userCourseProgress/userFunctions.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/userFunctions.ts
@@ -180,6 +180,7 @@ interface CreateCompletion {
   course_id: string
   handlerCourse: Course
   logger: winston.Logger
+  tier?: number
 }
 
 export const createCompletion = async ({
@@ -187,6 +188,7 @@ export const createCompletion = async ({
   course_id,
   handlerCourse,
   logger,
+  tier,
 }: CreateCompletion) => {
   const userCourseSettings = await getUserCourseSettings(user, course_id)
   const completions = await prisma.completion.findMany({
@@ -224,6 +226,22 @@ export const createCompletion = async ({
     if (template) {
       await sendEmailTemplateToUser(user, template)
     }
+  } else if (
+    tier !== null &&
+    tier !== undefined &&
+    completions[0]?.tier &&
+    tier > completions[0]!.tier
+  ) {
+    logger?.info("Existing completion found, updating tier...")
+    await prisma.completion.update({
+      where: {
+        id: completions[0]!.id,
+      },
+      data: {
+        ...completions[0],
+        tier,
+      },
+    })
   }
 }
 

--- a/backend/bin/kafkaConsumer/common/userCourseProgress/userFunctions.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/userFunctions.ts
@@ -229,8 +229,7 @@ export const createCompletion = async ({
   } else if (
     tier !== null &&
     tier !== undefined &&
-    completions[0]?.tier &&
-    tier > completions[0]!.tier
+    tier > (completions[0]!.tier ?? 0)
   ) {
     logger?.info("Existing completion found, updating tier...")
     await prisma.completion.update({

--- a/backend/graphql/Completion/input.ts
+++ b/backend/graphql/Completion/input.ts
@@ -6,6 +6,7 @@ schema.inputObjectType({
     t.string("completion_id", { required: true })
     t.string("student_number", { required: true })
     t.boolean("eligible_for_ects", { required: false })
+    t.int("tier", { required: false })
   },
 })
 
@@ -15,5 +16,6 @@ schema.inputObjectType({
     t.string("user_id", { required: true })
     t.string("grade", { required: false })
     t.field("completion_date", { type: "DateTime", required: false })
+    t.int("tier", { required: false })
   },
 })

--- a/backend/graphql/Completion/model.ts
+++ b/backend/graphql/Completion/model.ts
@@ -18,6 +18,8 @@ schema.objectType({
     t.model.eligible_for_ects()
     t.model.course()
     t.model.completion_date()
+    t.model.tier()
+
     // we're not querying completion course languages for now, and this was buggy
     /*     t.field("course", {
       type: "Course",

--- a/backend/graphql/Completion/mutations.ts
+++ b/backend/graphql/Completion/mutations.ts
@@ -17,6 +17,7 @@ schema.extendType({
         user: schema.idArg({ required: true }),
         course: schema.idArg({ required: true }),
         completion_language: schema.stringArg(),
+        tier: schema.intArg({ required: false }),
       },
       authorize: isAdmin,
       resolve: (_, args, ctx) => {
@@ -27,6 +28,7 @@ schema.extendType({
           user,
           course,
           completion_language,
+          tier,
         } = args
 
         return ctx.db.completion.create({
@@ -37,6 +39,7 @@ schema.extendType({
             student_number,
             completion_language,
             user_upstream_id,
+            tier,
           },
         })
       },

--- a/backend/migrations/20201026102610_alter-table-completion-add-tier.ts
+++ b/backend/migrations/20201026102610_alter-table-completion-add-tier.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE completion
+    ADD COLUMN IF NOT EXISTS tier INTEGER;
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE completion
+    DROP COLUMN tier;
+  `)
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,7 +24,8 @@ model Completion {
   user                      User?                   @relation(fields: [user_id], references: [id])
   completions_registered    CompletionRegistered[]
   completion_date           DateTime?
-  
+  tier                      Int?
+
   @@map("completion")
 }
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -3,7 +3,7 @@ import { UserInfo } from "./domain/UserInfo"
 import Knex from "./services/knex"
 import { redisify } from "./services/redis"
 import TmcClient from "./services/tmc"
-import { User } from "@prisma/client"
+import { User, Completion } from "@prisma/client"
 import cors from "cors"
 import morgan from "morgan"
 import { ok, err, Result } from "./util/result"
@@ -189,7 +189,10 @@ export function setupServer(server: typeof nexusServer) {
 
     const { user } = getUserResult.value
 
-    const completions = await Knex.select<any, ExerciseCompletionResult[]>(
+    const exercise_completions = await Knex.select<
+      any,
+      ExerciseCompletionResult[]
+    >(
       "user_id",
       "exercise_id",
       "n_points",
@@ -204,7 +207,7 @@ export function setupServer(server: typeof nexusServer) {
       .where("exercise.course_id", id)
       .andWhere("exercise_completion.user_id", user.id)
 
-    const resObject = (completions ?? []).reduce(
+    const resObject = (exercise_completions ?? []).reduce(
       (acc, curr) => ({
         ...acc,
         [curr.exercise_id]: {
@@ -217,6 +220,69 @@ export function setupServer(server: typeof nexusServer) {
 
     res.json({
       data: resObject,
+    })
+  })
+
+  server.express.get("/api/progress/:id/v2", async (req: any, res: any) => {
+    const { id }: { id: string } = req.params
+
+    if (!id) {
+      return res.status(400).json({ message: "must provide id" })
+    }
+
+    const getUserResult = await getUser(req, res)
+
+    if (getUserResult.isErr()) {
+      return getUserResult.error
+    }
+
+    const { user } = getUserResult.value
+
+    const exercise_completions = await Knex.select<
+      any,
+      ExerciseCompletionResult[]
+    >(
+      "user_id",
+      "exercise_id",
+      "n_points",
+      "part",
+      "section",
+      "max_points",
+      "completed",
+      "custom_id as quizzes_id",
+    )
+      .from("exercise_completion")
+      .join("exercise", { "exercise_completion.exercise_id": "exercise.id" })
+      .where("exercise.course_id", id)
+      .andWhere("exercise_completion.user_id", user.id)
+    const handlerCourseId = (
+      await Knex.select("completions_handled_by_id")
+        .from("course")
+        .where("id", id)
+    )[0]
+    console.log(handlerCourseId)
+
+    const completions = await Knex.select<any, Completion[]>("*")
+      .from("completion")
+      .where("course_id", handlerCourseId ?? id)
+      .andWhere("user_id", user.id)
+
+    const exercise_completions_map = (exercise_completions ?? []).reduce(
+      (acc, curr) => ({
+        ...acc,
+        [curr.exercise_id]: {
+          ...curr,
+          // tier: baiCourseTiers[curr.quizzes_id],
+        },
+      }),
+      {},
+    )
+
+    res.json({
+      data: {
+        exercise_completions: exercise_completions_map,
+        completion: completions[0] ?? {},
+      },
     })
   })
 


### PR DESCRIPTION
- added tier field to completion
- (BAI) parent completion updated if tier is greater than existing

New endpoint: `/api/progressv2/:course_id` 
- course_id _can_ be parent course as well, but as that one does not have exercise_completions, it's not probably what's expected
- returns parent course completion if parent course exists

Returns: 
```
data: {
  course_id: <course_id>,
  user_id: <user_id>
  exercise_completions: [{ exercise_completion1 }, ...],
  completion: <completion>
}
``` 
