### PR TITLE
prevent some heavy queries

### DIFF
--- a/backend/graphql/Course/model.ts
+++ b/backend/graphql/Course/model.ts
@@ -1,5 +1,6 @@
 // import { prismaObjectType } from "nexus-prisma"
 import { schema } from "nexus"
+import { isAdmin } from "../../accessControl"
 
 schema.objectType({
   name: "Course",
@@ -37,17 +38,17 @@ schema.objectType({
     t.model.teacher_in_charge_email()
     t.model.teacher_in_charge_name()
     t.model.updated_at()
-    t.model.completions()
-    t.model.completions_registered()
+    // t.model.completions()
+    // t.model.completions_registered()
     t.model.course_aliases()
     t.model.course_organizations()
     t.model.course_variants()
     t.model.exercises()
     t.model.open_university_registration_links()
-    t.model.user_course_progresses()
-    t.model.user_course_service_progresses()
-    t.model.user_course_settings()
-    t.model.user_course_settings_visibilities()
+    // t.model.user_course_progresses()
+    // t.model.user_course_service_progresses()
+    // t.model.user_course_settings()
+    // t.model.user_course_settings_visibilities()
     t.model.services()
     t.model.study_modules()
     t.model.automatic_completions_eligible_for_ects()
@@ -57,5 +58,32 @@ schema.objectType({
 
     t.string("description")
     t.string("link")
+
+    t.field("completions", {
+      type: "Completion",
+      list: true,
+      args: {
+        user_id: schema.stringArg({ required: false }),
+        user_upstream_id: schema.intArg({ required: false }),
+      },
+      authorize: isAdmin,
+      resolve: async (parent, args, ctx) => {
+        const { user_id, user_upstream_id } = args
+
+        if (!user_id && !user_upstream_id) {
+          throw new Error("needs user_id or user_upstream_id")
+        }
+
+        return ctx.db.completion.findMany({
+          where: {
+            user: {
+              id: user_id ?? undefined,
+              upstream_id: user_upstream_id ?? undefined,
+            },
+            course_id: parent.id,
+          },
+        })
+      },
+    })
   },
 })

--- a/backend/graphql/Exercise.ts
+++ b/backend/graphql/Exercise.ts
@@ -1,6 +1,7 @@
 import { schema } from "nexus"
 import { isAdmin } from "../accessControl"
 import { filterNull } from "../util/db-functions"
+import { AuthenticationError } from "apollo-server-core"
 
 schema.objectType({
   name: "Exercise",
@@ -34,6 +35,10 @@ schema.objectType({
       },
       resolve: async (parent, args, ctx: NexusContext) => {
         const { orderBy } = args
+
+        if (!ctx?.user?.id) {
+          throw new AuthenticationError("not logged in")
+        }
 
         return ctx.db.exercise
           .findOne({ where: { id: parent.id } })

--- a/backend/graphql/Organization.ts
+++ b/backend/graphql/Organization.ts
@@ -31,7 +31,9 @@ schema.objectType({
     t.model.website()
     t.model.creator_id()
     t.model.creator()
-    t.model.completions_registered()
+    t.model.completions_registered({
+      authorize: isAdmin, // TODO: should this be something else?
+    })
     t.model.courses()
     t.model.course_organizations()
     t.model.organization_translations()
@@ -48,7 +50,7 @@ const organizationPermission = (
 ) => {
   if (args.hidden) return ctx.role === Role.ADMIN
 
-  return true
+  return true // TODO: should this check if organization?
 }
 
 schema.extendType({

--- a/backend/graphql/User/model.ts
+++ b/backend/graphql/User/model.ts
@@ -15,7 +15,7 @@ schema.objectType({
     t.model.upstream_id()
     t.model.username()
     // t.model.completions()
-    t.model.completions_registered()
+    // t.model.completions_registered()
     t.model.email_deliveries()
     t.model.exercise_completions()
     t.model.organizations()
@@ -55,6 +55,45 @@ schema.objectType({
         return ctx.db.completion.findMany({
           where: {
             user_id: parent.id,
+            course:
+              course_id || course_slug
+                ? { id: course_id ?? undefined, slug: course_slug ?? undefined }
+                : undefined,
+          },
+        })
+      },
+    })
+
+    t.field("completions_registered", {
+      type: "CompletionRegistered",
+      list: true,
+      nullable: false,
+      args: {
+        course_id: schema.stringArg({ required: false }),
+        course_slug: schema.stringArg({ required: false }),
+        organization_id: schema.stringArg({ required: false }),
+      },
+      resolve: async (parent, args, ctx) => {
+        let { course_id, course_slug, organization_id } = args
+
+        if (course_id || course_slug) {
+          const handlerCourse = await ctx.db.course
+            .findOne({
+              where: {
+                id: args.course_id ?? undefined,
+                slug: args.course_slug ?? undefined,
+              },
+            })
+            .completions_handled_by()
+          if (handlerCourse) {
+            course_id = handlerCourse.id
+            course_slug = undefined
+          }
+        }
+        return ctx.db.completionRegistered.findMany({
+          where: {
+            user_id: parent.id,
+            organization_id: organization_id ?? undefined,
             course:
               course_id || course_slug
                 ? { id: course_id ?? undefined, slug: course_slug ?? undefined }


### PR DESCRIPTION
- disabled some fields from `course` + `completions` authorized
- `exercise_completions` were visible without auth

Should `completions_registered` be visible without auth through `organization`? 