### PR TITLE
remove Italian statistics for now

### DIFF
--- a/backend/bin/sendAiStatistics.ts
+++ b/backend/bin/sendAiStatistics.ts
@@ -110,12 +110,6 @@ const langArr: langProps[] = [
     country: "Croatia",
     langName: "Croatian",
   },
-  {
-    language: "it",
-    completion_language: "it_IT",
-    country: "Italy",
-    langName: "Italian",
-  },
 ]
 
 const getDataByLanguage = async (langProps: langProps) => {


### PR DESCRIPTION
Italian collaborators wish for no statistics reporting now that course is not yet launched, so I removed it for now.