### PR TITLE
added /api/register-completions

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -16,6 +16,7 @@ import { wsListen } from "./wsServer"
 import server from "./server"
 import { PrismaClient } from "@prisma/client"
 import * as winston from "winston"
+import knex from "./services/knex"
 
 const logger = winston.createLogger({
   level: "info",
@@ -39,6 +40,7 @@ const prismaClient = new PrismaClient({
 const { express } = server({
   prisma: prismaClient,
   logger,
+  knexClient: knex,
 })
 
 /*prismaClient.on("query", (e) => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3049,7 +3049,7 @@
         "graphql-extensions": "^0.12.6",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
-        "graphql-upload": "^8.0.2",
+        "graphql-upload": "11.0.0",
         "loglevel": "^1.6.7",
         "lru-cache": "^5.0.0",
         "sha.js": "^2.4.11",
@@ -3064,23 +3064,7 @@
           "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
         },
         "graphql-upload": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-          "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
-          "requires": {
-            "busboy": "^0.3.1",
-            "fs-capacitor": "^6.1.0",
-            "http-errors": "^1.7.3",
-            "isobject": "^4.0.0",
-            "object-path": "^0.11.4"
-          },
-          "dependencies": {
-            "fs-capacitor": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
-              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
-            }
-          }
+          "version": "11.0.0"
         },
         "http-errors": {
           "version": "1.8.0",
@@ -5877,9 +5861,6 @@
       }
     },
     "graphql-upload": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-      "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^6.1.0",
@@ -5915,7 +5896,8 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
-      }
+      },
+      "version": "11.0.0"
     },
     "growly": {
       "version": "1.3.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11922,9 +11922,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "unc-path-regex": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -125,7 +125,7 @@
     "ts-jest": "^26.4.4",
     "ts-node": "^9.0.0",
     "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.2"
   },
   "resolutions": {
     "graphql-upload": "11.0.0"

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -371,8 +371,6 @@ const _express = ({ prisma, knex }: ExpressParams) => {
         .shape({
           completion_id: yup.string().min(32).max(36).required(),
           student_number: yup.string().required(),
-          eligible_for_ects: yup.boolean().nullable(),
-          tier: yup.number().nullable(),
         })
         .required(),
     )

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -392,7 +392,6 @@ const _express = ({ prisma, knex }: ExpressParams) => {
           })) ?? {}
 
         if (!course_id || !user_id) {
-          console.log("didn't find", course_id, user_id, entry)
           // TODO/FIXME: we now fail silently if course/user not found
           return Promise.resolve()
         }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,17 +1,21 @@
 const PRODUCTION = process.env.NODE_ENV === "production"
 
-import { UserInfo } from "./domain/UserInfo"
-import Knex from "./services/knex"
+import type knexType from "knex"
 import { redisify } from "./services/redis"
-import TmcClient from "./services/tmc"
-import { User, Completion, PrismaClient } from "@prisma/client"
+import { Completion, PrismaClient } from "@prisma/client"
 import cors from "cors"
 import morgan from "morgan"
-import { ok, err, Result } from "./util/result"
 import createExpress from "express"
 import schema from "./schema"
 import { ApolloServer } from "apollo-server-express"
 import * as winston from "winston"
+import {
+  getUser as _getUser,
+  getOrganization as _getOrganization,
+} from "./util/server-functions"
+import * as yup from "yup"
+import { chunk } from "lodash"
+import bodyParser from "body-parser"
 
 const JSONStream = require("JSONStream")
 const helmet = require("helmet")
@@ -42,8 +46,16 @@ interface ExerciseCompletionResult {
   quizzes_id: string
 }
 
+interface ExpressParams {
+  prisma: PrismaClient
+  knex: knexType
+}
+
 // wrapped so that the context isn't cached between test instances
-const _express = () => {
+const _express = ({ prisma, knex }: ExpressParams) => {
+  const getUser = _getUser(knex)
+  const getOrganization = _getOrganization(knex)
+
   const express = createExpress()
 
   express.use(cors())
@@ -51,30 +63,30 @@ const _express = () => {
   if (!TEST) {
     express.use(morgan("combined"))
   }
+  express.use(bodyParser.json())
 
   express.get("/api/completions/:course", async function (req: any, res: any) {
-    const rawToken = req.get("Authorization")
-    const secret: string = rawToken?.split(" ")[1] ?? ""
+    const organizationResult = await getOrganization(req, res)
+
+    if (organizationResult.isErr()) {
+      return organizationResult.error
+    }
+
+    // TODO/FIXME? organization value not used
 
     let course_id: string
-    const org = (
-      await Knex.select("*")
-        .from("organization")
-        .where({ secret_key: secret })
-        .limit(1)
-    )[0]
-    if (!org) {
-      return res.status(401).json({ message: "Access denied." })
-    }
+
     const course = (
-      await Knex.select("id")
+      await knex
+        .select("id")
         .from("course")
         .where({ slug: req.params.course })
         .limit(1)
     )[0]
     if (!course) {
       const course_alias = (
-        await Knex.select("course_id")
+        await knex
+          .select("course_id")
           .from("course_alias")
           .where({ course_code: req.params.course })
       )[0]
@@ -85,7 +97,7 @@ const _express = () => {
     } else {
       course_id = course.id
     }
-    const sql = Knex.select("*").from("completion").where({
+    const sql = knex.select("*").from("completion").where({
       course_id,
       eligible_for_ects: true,
     })
@@ -114,7 +126,8 @@ const _express = () => {
 
           const { id } =
             (
-              await Knex.select("course.id")
+              await knex
+                .select("course.id")
                 .from("course")
                 .join("user_course_settings_visibility", {
                   "course.id": "user_course_settings_visibility.course_id",
@@ -128,7 +141,8 @@ const _express = () => {
 
           if (!id) {
             const courseAlias = (
-              await Knex.select("course_alias.course_id")
+              await knex
+                .select("course_alias.course_id")
                 .from("course_alias")
                 .join("course", { "course_alias.course_id": "course.id" })
                 .join("user_course_settings_visibility", {
@@ -149,7 +163,8 @@ const _express = () => {
           }
 
           let { count } = (
-            await Knex.countDistinct("id as count")
+            await knex
+              .countDistinct("id as count")
               .from("user_course_setting")
               .where({ course_id, language: language })
           )?.[0]
@@ -201,19 +216,17 @@ const _express = () => {
 
     const { user } = getUserResult.value
 
-    const exercise_completions = await Knex.select<
-      any,
-      ExerciseCompletionResult[]
-    >(
-      "user_id",
-      "exercise_id",
-      "n_points",
-      "part",
-      "section",
-      "max_points",
-      "completed",
-      "custom_id as quizzes_id",
-    )
+    const exercise_completions = await knex
+      .select<any, ExerciseCompletionResult[]>(
+        "user_id",
+        "exercise_id",
+        "n_points",
+        "part",
+        "section",
+        "max_points",
+        "completed",
+        "custom_id as quizzes_id",
+      )
       .from("exercise_completion")
       .join("exercise", { "exercise_completion.exercise_id": "exercise.id" })
       .where("exercise.course_id", id)
@@ -250,31 +263,31 @@ const _express = () => {
 
     const { user } = getUserResult.value
 
-    const exercise_completions = await Knex.select<
-      any,
-      ExerciseCompletionResult[]
-    >(
-      "user_id",
-      "exercise_id",
-      "n_points",
-      "part",
-      "section",
-      "max_points",
-      "completed",
-      "custom_id as quizzes_id",
-    )
+    const exercise_completions = await knex
+      .select<any, ExerciseCompletionResult[]>(
+        "user_id",
+        "exercise_id",
+        "n_points",
+        "part",
+        "section",
+        "max_points",
+        "completed",
+        "custom_id as quizzes_id",
+      )
       .from("exercise_completion")
       .join("exercise", { "exercise_completion.exercise_id": "exercise.id" })
       .where("exercise.course_id", id)
       .andWhere("exercise_completion.user_id", user.id)
     const { completions_handled_by_id = id } =
       (
-        await Knex.select("completions_handled_by_id")
+        await knex
+          .select("completions_handled_by_id")
           .from("course")
           .where("id", id)
       )[0] ?? {}
 
-    const completions = await Knex.select<any, Completion[]>("*")
+    const completions = await knex
+      .select<any, Completion[]>("*")
       .from("completion")
       .where("course_id", completions_handled_by_id)
       .andWhere("user_id", user.id)
@@ -315,7 +328,8 @@ const _express = () => {
 
     const { user } = getUserResult.value
 
-    const data = await Knex.select<any, any>("course_id", "extra")
+    const data = await knex
+      .select<any, any>("course_id", "extra")
       .from("user_course_progress")
       .where("user_course_progress.course_id", id)
       .andWhere("user_course_progress.user_id", user.id)
@@ -328,90 +342,102 @@ const _express = () => {
     })
   })
 
-  interface GetUserReturn {
-    user: User
-    details: UserInfo
+  interface RegisterCompletion {
+    completion_id: string
+    student_number: string
+    eligible_for_ects?: boolean
+    tier?: number
   }
 
-  async function getUser(
-    req: any,
-    res: any,
-  ): Promise<Result<GetUserReturn, any>> {
-    const rawToken = req.get("Authorization")
+  express.post("/api/register-completions", async (req: any, res: any) => {
+    const organizationResult = await getOrganization(req, res)
 
-    if (!rawToken || !(rawToken ?? "").startsWith("Bearer")) {
-      return err(res.status(400).json({ message: "not logged in" }))
+    if (organizationResult.isErr()) {
+      return organizationResult.error
     }
 
-    let details: UserInfo | null = null
+    const org = organizationResult.value
+
+    const { completions }: { completions: RegisterCompletion[] } =
+      req.body ?? {}
+
+    if (!completions) {
+      return res.status(400).json({ message: "must provide completions" })
+    }
+
+    const registerCompletionSchema = yup.array().of(
+      yup
+        .object()
+        .shape({
+          completion_id: yup.string().min(32).max(36).required(),
+          student_number: yup.string().required(),
+          eligible_for_ects: yup.boolean().nullable(),
+          tier: yup.number().nullable(),
+        })
+        .required(),
+    )
+
     try {
-      const client = new TmcClient(rawToken)
-      details = await redisify<UserInfo>(
-        async () => await client.getCurrentUserDetails(),
-        {
-          prefix: "userdetails",
-          expireTime: 3600,
-          key: rawToken,
-        },
-      )
-    } catch (e) {
-      console.log("error", e)
+      await registerCompletionSchema.validate(completions)
+    } catch (error) {
+      return res.status(403).json({ message: "malformed data", error })
     }
 
-    if (!details) {
-      return err(res.status(400).json({ message: "invalid credentials" }))
-    }
+    const buildPromises = (data: RegisterCompletion[]) => {
+      return data.map(async (entry) => {
+        const { course_id, user_id } =
+          (await prisma.completion.findUnique({
+            where: { id: entry.completion_id },
+            select: { course_id: true, user_id: true },
+          })) ?? {}
 
-    let user = (
-      await Knex.select<any, User[]>("id")
-        .from("user")
-        .where("upstream_id", details.id)
-    )?.[0]
-
-    if (!user) {
-      try {
-        user = (
-          await Knex("user")
-            .insert({
-              upstream_id: details.id,
-              administrator: details.administrator,
-              email: details.email.trim(),
-              first_name: details.user_field.first_name.trim(),
-              last_name: details.user_field.last_name.trim(),
-              username: details.username,
-            })
-            .returning("*")
-        )?.[0]
-      } catch {
-        // race condition or something
-        user = (
-          await Knex.select<any, User[]>("id")
-            .from("user")
-            .where("upstream_id", details.id)
-        )?.[0]
-
-        if (!user) {
-          return err(res.status(500).json({ message: "error creating user" }))
+        if (!course_id || !user_id) {
+          console.log("didn't find", course_id, user_id, entry)
+          // TODO/FIXME: we now fail silently if course/user not found
+          return Promise.resolve()
         }
-      }
+
+        return prisma.completionRegistered.create({
+          data: {
+            completion: {
+              connect: { id: entry.completion_id },
+            },
+            organization: {
+              connect: { id: org?.id },
+            },
+            course: { connect: { id: course_id } },
+            real_student_number: entry.student_number,
+            user: { connect: { id: user_id } },
+          },
+        })
+      })
     }
 
-    return ok({
-      user,
-      details,
-    })
-  }
+    const queue = chunk(completions, 500)
+    for (const completionChunk of queue) {
+      const promises = buildPromises(completionChunk)
+      await Promise.all(promises)
+    }
+
+    return res.status(200).json({ message: "success" })
+  })
 
   return express
 }
 
 interface ServerParams {
   prisma: PrismaClient
+  knexClient: knexType
   logger: winston.Logger
   extraContext?: Record<string, any>
 }
 
-export default ({ prisma, logger, extraContext = {} }: ServerParams) => {
+export default ({
+  prisma,
+  knexClient,
+  logger,
+  extraContext = {},
+}: ServerParams) => {
   const apollo = new ApolloServer({
     context: (ctx) => ({
       ...ctx,
@@ -427,7 +453,7 @@ export default ({ prisma, logger, extraContext = {} }: ServerParams) => {
     logger,
     debug: DEBUG,
   })
-  const express = _express()
+  const express = _express({ prisma, knex: knexClient })
 
   apollo.applyMiddleware({ app: express, path: PRODUCTION ? "/api" : "/" })
 

--- a/backend/tests/__helpers.ts
+++ b/backend/tests/__helpers.ts
@@ -42,6 +42,7 @@ export type TestContext = {
   knexClient: knex
   user?: User
   version: number
+  port: number
 }
 
 export type TestContextContainer = {
@@ -61,9 +62,10 @@ export function getTestContext(): TestContext {
 
   // beforeEach
   beforeAll(async (done) => {
-    const { prisma, client, knexClient } = await ctx.before()
+    const { port, prisma, client, knexClient } = await ctx.before()
 
     Object.assign(testContext, {
+      port,
       prisma,
       client,
       knexClient,
@@ -100,6 +102,7 @@ function createTestContext() {
 
       const { apollo, express } = server({
         prisma,
+        knexClient,
         logger: logger.createLogger(),
         extraContext: {
           version: version++,
@@ -114,6 +117,7 @@ function createTestContext() {
           DEBUG && console.log(`got port ${port}`)
 
           return {
+            port,
             client: new GraphQLClient(`http://localhost:${port}`),
             prisma,
             knexClient,

--- a/backend/tests/__snapshots__/server.test.ts.snap
+++ b/backend/tests/__snapshots__/server.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`server /api/register-completions creates registered completions 1`] = `
+Array [
+  Object {
+    "completion_id": "30000000-0000-0000-0000-000000000102",
+    "course_id": "00000000-0000-0000-0000-000000000002",
+    "created_at": Any<Date>,
+    "id": Any<String>,
+    "organization_id": "10000000-0000-0000-0000-000000000102",
+    "real_student_number": "12345",
+    "updated_at": Any<Date>,
+    "user_id": "20000000-0000-0000-0000-000000000102",
+  },
+  Object {
+    "completion_id": "30000000-0000-0000-0000-000000000103",
+    "course_id": "00000000-0000-0000-0000-000000000001",
+    "created_at": Any<Date>,
+    "id": Any<String>,
+    "organization_id": "10000000-0000-0000-0000-000000000102",
+    "real_student_number": "12345",
+    "updated_at": Any<Date>,
+    "user_id": "20000000-0000-0000-0000-000000000102",
+  },
+]
+`;

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -49,6 +49,14 @@ export const adminUserDetails = {
   extra_fields: {},
 }
 
+export const organizations: Prisma.OrganizationCreateInput[] = [
+  {
+    id: "10000000000000000000000000000102",
+    secret_key: "kissa",
+    slug: "test",
+  },
+]
+
 export const study_modules: Prisma.StudyModuleCreateInput[] = [
   {
     id: "00000000000000000000000000000102",
@@ -154,5 +162,30 @@ export const courses: Prisma.CourseCreateInput[] = [
     study_modules: {
       connect: { id: "00000000000000000000000000000102" },
     },
+  },
+]
+
+export const users: Prisma.UserCreateInput[] = [
+  {
+    id: "20000000000000000000000000000102",
+    administrator: false,
+    email: "e@mail.com",
+    upstream_id: 1,
+    username: "existing_user",
+  },
+]
+
+export const completions: Prisma.CompletionCreateInput[] = [
+  {
+    id: "30000000-0000-0000-0000-000000000102",
+    course: { connect: { id: "00000000000000000000000000000002" } },
+    user: { connect: { id: "20000000000000000000000000000102" } },
+    email: "e@mail.com",
+  },
+  {
+    id: "30000000-0000-0000-0000-000000000103",
+    course: { connect: { id: "00000000000000000000000000000001" } },
+    user: { connect: { id: "20000000000000000000000000000102" } },
+    email: "e@mail.com",
   },
 ]

--- a/backend/tests/data/seed.ts
+++ b/backend/tests/data/seed.ts
@@ -1,27 +1,29 @@
 import type { PrismaClient } from "@prisma/client"
-import { courses, study_modules } from "."
+import { courses, study_modules, organizations, users, completions } from "."
 
 export const seed = async (prisma: PrismaClient) => {
-  const seededModules = await Promise.all(
-    study_modules.map(
-      async (module) =>
-        await prisma.studyModule.create({
-          data: module,
-        }),
-    ),
-  )
+  const create = async <T>(key: keyof PrismaClient, data: T[]) =>
+    Promise.all(
+      data.map(
+        async (datum) =>
+          // @ts-ignore: key
+          await prisma[key].create({
+            data: datum,
+          }),
+      ),
+    )
 
-  const seededCourses = await Promise.all(
-    courses.map(
-      async (course) =>
-        await prisma.course.create({
-          data: course,
-        }),
-    ),
-  )
+  const seededModules = await create("studyModule", study_modules)
+  const seededCourses = await create("course", courses)
+  const seededOrganizations = await create("organization", organizations)
+  const seededUsers = await create("user", users)
+  const seededCompletions = await create("completion", completions)
 
   return {
     courses: seededCourses,
     study_modules: seededModules,
+    organizations: seededOrganizations,
+    users: seededUsers,
+    completions: seededCompletions,
   }
 }

--- a/backend/tests/server.test.ts
+++ b/backend/tests/server.test.ts
@@ -69,8 +69,6 @@ describe("server", () => {
           {
             completion_id: "30000000-0000-0000-0000-000000000103",
             student_number: "12345",
-            tier: 2,
-            eligible_for_ects: true,
           },
         ],
       })

--- a/backend/tests/server.test.ts
+++ b/backend/tests/server.test.ts
@@ -1,0 +1,100 @@
+import { getTestContext } from "./__helpers"
+import { seed } from "./data/seed"
+import axios from "axios"
+
+const ctx = getTestContext()
+
+describe("server", () => {
+  const post = (route: string = "", defaultHeaders: any) => async (
+    data: any,
+    headers: any = defaultHeaders,
+  ) =>
+    await axios.post(`http://localhost:${ctx.port}${route}`, data, { headers })
+
+  describe("/api/register-completions", () => {
+    const defaultHeaders = {
+      Authorization: "Basic kissa",
+    }
+    const postCompletions = post("/api/register-completions", defaultHeaders)
+
+    beforeEach(async () => {
+      await seed(ctx.prisma)
+    })
+
+    it("errors on wrong authorization", async () => {
+      return postCompletions({ foo: 1 }, { Authorization: "foo" })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(401)
+        })
+    })
+
+    it("errors on non-existent secret", async () => {
+      return postCompletions({ foo: 1 }, { Authorization: "Basic koira" })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(401)
+        })
+    })
+
+    it("errors on no completions", async () => {
+      return postCompletions({ foo: 1 })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(400)
+        })
+    })
+
+    it("errors on malformed completion", async () => {
+      return postCompletions({
+        completions: [
+          {
+            foo: 1,
+          },
+        ],
+      })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(403)
+        })
+    })
+
+    it("creates registered completions", async () => {
+      const res = await postCompletions({
+        completions: [
+          {
+            completion_id: "30000000-0000-0000-0000-000000000102",
+            student_number: "12345",
+          },
+          {
+            completion_id: "30000000-0000-0000-0000-000000000103",
+            student_number: "12345",
+            tier: 2,
+            eligible_for_ects: true,
+          },
+        ],
+      })
+
+      expect(res.status).toBe(200)
+
+      const addedCompletions = await ctx.prisma.completionRegistered.findMany({
+        where: {
+          user_id: "20000000000000000000000000000102",
+        },
+      })
+
+      expect(addedCompletions).toMatchSnapshot([
+        {
+          id: expect.any(String),
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
+        {
+          id: expect.any(String),
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
+      ])
+    })
+  })
+})

--- a/backend/util/server-functions.ts
+++ b/backend/util/server-functions.ts
@@ -1,0 +1,119 @@
+import { UserInfo } from "../domain/UserInfo"
+import TmcClient from "../services/tmc"
+import { Organization, User } from "@prisma/client"
+import { ok, err, Result } from "../util/result"
+import type knexType from "knex"
+import { redisify } from "../services/redis"
+
+interface GetUserReturn {
+  user: User
+  details: UserInfo
+}
+
+export function getUser(knex: knexType) {
+  return async function (
+    req: any,
+    res: any,
+  ): Promise<Result<GetUserReturn, any>> {
+    const rawToken = req.get("Authorization")
+
+    if (!rawToken || !(rawToken ?? "").startsWith("Bearer")) {
+      return err(res.status(400).json({ message: "not logged in" }))
+    }
+
+    let details: UserInfo | null = null
+    try {
+      const client = new TmcClient(rawToken)
+      details = await redisify<UserInfo>(
+        async () => await client.getCurrentUserDetails(),
+        {
+          prefix: "userdetails",
+          expireTime: 3600,
+          key: rawToken,
+        },
+      )
+    } catch (e) {
+      console.log("error", e)
+    }
+
+    if (!details) {
+      return err(res.status(400).json({ message: "invalid credentials" }))
+    }
+
+    let user = (
+      await knex
+        .select<any, User[]>("id")
+        .from("user")
+        .where("upstream_id", details.id)
+    )?.[0]
+
+    if (!user) {
+      try {
+        user = (
+          await knex("user")
+            .insert({
+              upstream_id: details.id,
+              administrator: details.administrator,
+              email: details.email.trim(),
+              first_name: details.user_field.first_name.trim(),
+              last_name: details.user_field.last_name.trim(),
+              username: details.username,
+            })
+            .returning("*")
+        )?.[0]
+      } catch {
+        // race condition or something
+        user = (
+          await knex
+            .select<any, User[]>("id")
+            .from("user")
+            .where("upstream_id", details.id)
+        )?.[0]
+
+        if (!user) {
+          return err(res.status(500).json({ message: "error creating user" }))
+        }
+      }
+    }
+
+    return ok({
+      user,
+      details,
+    })
+  }
+}
+
+export function getOrganization(knex: knexType) {
+  return async function (
+    req: any,
+    res: any,
+  ): Promise<Result<Organization, any>> {
+    const rawToken = req.get("Authorization")
+
+    if (!rawToken || !(rawToken ?? "").startsWith("Basic")) {
+      return err(res.status(401).json({ message: "Access denied." }))
+    }
+
+    const secret_key = rawToken.split(" ")[1]
+
+    if (!secret_key) {
+      return err(
+        res.status(400).json({ message: "Malformed authorization token" }),
+      )
+    }
+
+    const org = (
+      await knex
+        .select<any, Organization[]>("*")
+        .from("organization")
+        .where({ secret_key })
+        .limit(1)
+    )[0]
+
+    if (!org) {
+      return err(res.status(401).json({ message: "Access denied." }))
+    }
+
+    return ok(org)
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20670,9 +20670,9 @@
       "integrity": "sha512-YXvbd3a1QTREoD+FJoEkl0VQNJoEjewR2H11IjVv4bp6ahuIcw0yyw/3udC4vJkHw3T3cUh85FTg8eWef3pSaw=="
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "uglify-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,7 +114,7 @@
     "istanbul-lib-coverage": "^2.0.5",
     "nyc": "^14.1.1",
     "source-map-support": "^0.5.19",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.2"
   },
   "nyc": {
     "exclude": [

--- a/frontend/translations/index.ts
+++ b/frontend/translations/index.ts
@@ -20,7 +20,7 @@ const getTranslator = <T extends Translation>(dicts: Record<string, T>) => (
   }
 
   return Array.isArray(translation)
-    ? translation.map((t) =>
+    ? (translation as T[keyof T][]).map((t) =>
         substitute<T>({ translation: t, variables, router }),
       )
     : substitute<T>({ translation, variables, router })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,9 +1860,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "husky": "^4.3.0",
     "jest-junit": "^12.0.0",
     "prettier": "^2.1.2",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.2"
   },
   "scripts": {
     "prettier": "prettier --write \"**/*.js\" \"**/*.ts\" \"**/*.tsx\"",


### PR DESCRIPTION
POST `/api/register-completions` now accepts completions in the same form as `registerCompletion` GraphQL endpoint. Needs an organization auth.

`{
  completions: [{
    completion_id,
    student_number,
  }, ...]
}`