### PR TITLE
by default, don't show deleted exercises in exercise_completion

### DIFF
--- a/backend/graphql/User/model.ts
+++ b/backend/graphql/User/model.ts
@@ -1,4 +1,11 @@
-import { objectType, stringArg, idArg, nonNull, nullable } from "@nexus/schema"
+import {
+  objectType,
+  stringArg,
+  idArg,
+  nonNull,
+  nullable,
+  booleanArg,
+} from "@nexus/schema"
 
 export const User = objectType({
   name: "User",
@@ -195,10 +202,16 @@ export const User = objectType({
 
     t.list.field("exercise_completions", {
       type: "ExerciseCompletion",
-      resolve: async (parent, _, ctx) => {
+      args: {
+        includeDeleted: nullable(booleanArg()),
+      },
+      resolve: async (parent, { includeDeleted = false }, ctx) => {
         return ctx.prisma.exerciseCompletion.findMany({
           where: {
             user_id: parent.id,
+            ...(!includeDeleted
+              ? { exercise: { deleted: { not: true } } }
+              : {}),
           },
         })
       },


### PR DESCRIPTION
Through `user` in graphql and `progressv2` api endpoint. 

If you _want_ to include the deleted, `exerciseCompletions` in graphql now has `includeDeleted` boolean; `progressv2` now has `deleted` query parameter, ie. `/api/progressv2/[courseId]/?deleted=true`.