### PR TITLE
check existing tier in psql and update only if larger; fixed creation bug

### DIFF
--- a/backend/bin/kafkaConsumer/common/userCourseProgress/__test__/userFunctions.test.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/__test__/userFunctions.test.ts
@@ -1,0 +1,176 @@
+import { getTestContext } from "../../../../../tests/__helpers"
+import { seed } from "../../../../../tests/data/seed"
+import { KafkaContext } from "../../kafkaContext"
+import { createCompletion } from "../userFunctions"
+import { Completion, Course, User } from "@prisma/client"
+
+const ctx = getTestContext()
+
+describe("createCompletion", () => {
+  const kafkaContext = {} as KafkaContext
+
+  beforeEach(async () => {
+    await seed(ctx.prisma)
+    Object.assign(kafkaContext, {
+      prisma: ctx.prisma,
+      knex: ctx.knex,
+      logger: ctx.logger,
+      consumer: null as any,
+      mutex: null as any,
+    })
+  })
+
+  describe("create new completion", () => {
+    it("create new one when no existing is found", async () => {
+      const course = await ctx.prisma.course.findFirst({
+        where: {
+          slug: "course1",
+        },
+      })
+      const user = await ctx.prisma.user.findFirst({
+        where: {
+          upstream_id: 2,
+        },
+      })
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+        tier: 1,
+      })
+      const createdCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          course_id: course!.id,
+          user_id: user!.id,
+        },
+      })
+      expect(createdCompletion).not.toBeNull()
+      expect(createdCompletion!.tier).toEqual(1)
+      expect(createdCompletion!.completion_language).toEqual("en_US")
+    })
+  })
+
+  describe("update completion", () => {
+    let course: Course | null
+    let user: User | null
+    let existingCompletion: Completion | null
+
+    beforeEach(async () => {
+      course = await ctx.prisma.course.findFirst({
+        where: {
+          slug: "course1",
+        },
+      })
+      user = await ctx.prisma.user.findFirst({
+        where: {
+          upstream_id: 1,
+        },
+      })
+      existingCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+    })
+
+    it("should update when no existing tier", async () => {
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+        tier: 3,
+      })
+      const updatedCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      expect(updatedCompletion).not.toBeNull()
+      expect(updatedCompletion!.tier).toEqual(3)
+      expect(
+        updatedCompletion!.updated_at! > existingCompletion!.updated_at!,
+      ).toEqual(true)
+    })
+    it("should update when existing tier is not defined", async () => {
+      course = await ctx.prisma.course.findFirst({
+        where: {
+          slug: "course2",
+        },
+      })
+      existingCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+        tier: 1,
+      })
+      const updatedCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      expect(updatedCompletion!.tier).toEqual(1)
+      expect(
+        updatedCompletion!.updated_at! > existingCompletion!.updated_at!,
+      ).toEqual(true)
+    })
+    it("should not update when tier is not defined", async () => {
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+      })
+      const updatedCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      expect(existingCompletion).toEqual(updatedCompletion)
+    })
+    it("should not update when existing tier is equivalent", async () => {
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+        tier: 2,
+      })
+      const updatedCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      expect(existingCompletion).toEqual(updatedCompletion)
+    })
+    it("should not update when existing tier is larger", async () => {
+      await createCompletion({
+        user: user!,
+        course_id: course!.id,
+        handlerCourse: course!,
+        context: kafkaContext,
+        tier: 1,
+      })
+      const updatedCompletion = await ctx.prisma.completion.findFirst({
+        where: {
+          user_id: user!.id,
+          course_id: course!.id,
+        },
+      })
+      expect(existingCompletion).toEqual(updatedCompletion)
+    })
+  })
+})

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3215,23 +3215,7 @@
           "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
         },
         "graphql-upload": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-          "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
-          "requires": {
-            "busboy": "^0.3.1",
-            "fs-capacitor": "^6.1.0",
-            "http-errors": "^1.7.3",
-            "isobject": "^4.0.0",
-            "object-path": "^0.11.4"
-          },
-          "dependencies": {
-            "fs-capacitor": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
-              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
-            }
-          }
+          "version": "11.0.0"
         },
         "http-errors": {
           "version": "1.8.0",
@@ -6043,9 +6027,6 @@
       }
     },
     "graphql-upload": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
-      "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^6.1.0",
@@ -6081,7 +6062,8 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
-      }
+      },
+      "version": "11.0.0"
     },
     "growly": {
       "version": "1.3.0",

--- a/backend/tests/__helpers.ts
+++ b/backend/tests/__helpers.ts
@@ -49,7 +49,7 @@ let version = 1
 
 export function getTestContext(): TestContext {
   let testContext = {
-    logger: logger as any,
+    logger: logger.createLogger() as winston.Logger,
   } as TestContext
 
   const ctx = createTestContext()

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -220,12 +220,28 @@ export const completions: Prisma.CompletionCreateInput[] = [
     course: { connect: { id: "00000000000000000000000000000002" } },
     user: { connect: { id: "20000000000000000000000000000102" } },
     email: "e@mail.com",
+    user_upstream_id: 1,
+    tier: 2,
+    created_at: "1900-01-01T10:00:00.00+02:00",
+    updated_at: "1900-01-01T10:00:00.00+02:00",
   },
   {
     id: "30000000-0000-0000-0000-000000000103",
     course: { connect: { id: "00000000000000000000000000000001" } },
     user: { connect: { id: "20000000000000000000000000000102" } },
     email: "e@mail.com",
+    user_upstream_id: 1,
+    created_at: "1900-01-01T10:00:00.00+02:00",
+    updated_at: "1900-01-01T10:00:00.00+02:00",
+  },
+]
+
+export const userCourseSettings: Prisma.UserCourseSettingCreateInput[] = [
+  {
+    id: "40000000-0000-0000-0000-000000000102",
+    course: { connect: { id: "00000000000000000000000000000002" } },
+    user: { connect: { id: "20000000000000000000000000000103" } },
+    language: "en",
   },
 ]
 

--- a/backend/tests/data/seed.ts
+++ b/backend/tests/data/seed.ts
@@ -6,18 +6,23 @@ import {
   users,
   completions,
   services,
+  userCourseSettings,
 } from "."
 
+type ExcludeInternalKeys<K> = K extends `$${string}` ? never : K
+
 export const seed = async (prisma: PrismaClient) => {
-  const create = async <T>(key: keyof PrismaClient, data: T[]) =>
+  const create = async <K extends ExcludeInternalKeys<keyof PrismaClient>, T>(
+    key: K,
+    data: T[],
+  ) =>
     Promise.all(
-      data.map(
-        async (datum) =>
-          // @ts-ignore: key
-          await prisma[key].create({
-            data: datum,
-          }),
-      ),
+      data.map(async (datum) => {
+        // @ts-ignore: key
+        return await prisma[key].create({
+          data: datum,
+        })
+      }),
     )
 
   const seededModules = await create("studyModule", study_modules)
@@ -26,6 +31,10 @@ export const seed = async (prisma: PrismaClient) => {
   const seededUsers = await create("user", users)
   const seededCompletions = await create("completion", completions)
   const seededServices = await create("service", services)
+  const seededUserCourseSettings = await create(
+    "userCourseSetting",
+    userCourseSettings,
+  )
 
   return {
     courses: seededCourses,
@@ -34,5 +43,6 @@ export const seed = async (prisma: PrismaClient) => {
     users: seededUsers,
     completions: seededCompletions,
     services: seededServices,
+    userCourseSettings: seededUserCourseSettings,
   }
 }


### PR DESCRIPTION
I think the original bug was in creating a completion, where the tier was left undefined when it should not have been.

Anyway, the update query should now be okay. Didn't test the `eligible_for_ects` fow now.