### PR TITLE
Add user course settings endpoints

### DIFF
--- a/backend/bin/__test__/syncTMCUsers.test.ts
+++ b/backend/bin/__test__/syncTMCUsers.test.ts
@@ -32,7 +32,7 @@ const changes: Array<Change> = [
     new_value: "new@mail.com",
     created_at: "2018-11-08T20:13:58.443+02:00",
     updated_at: "2020-11-08T20:13:58.443+02:00",
-    username: "second_user",
+    username: "second_user_admin",
     email: null,
   },
   {
@@ -43,7 +43,7 @@ const changes: Array<Change> = [
     new_value: "newer@mail.com",
     created_at: "2018-11-08T20:13:58.443+02:00",
     updated_at: "2020-11-09T20:13:58.443+02:00",
-    username: "second_user",
+    username: "second_user_admin",
     email: null,
   },
   {
@@ -135,7 +135,7 @@ describe("syncTMCUsers", () => {
 
       const secondUser = await ctx.prisma.user.findFirst({
         where: {
-          username: "second_user",
+          username: "second_user_admin",
         },
       })
       const thirdUser = await ctx.prisma.user.findFirst({

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,7 +1,7 @@
 const PRODUCTION = process.env.NODE_ENV === "production"
 
 import { redisify } from "./services/redis"
-import { Completion, PrismaClient, UserCourseSetting } from "@prisma/client"
+import { Completion, PrismaClient } from "@prisma/client"
 import cors from "cors"
 import morgan from "morgan"
 import createExpress, { Request, Response } from "express"

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -522,7 +522,6 @@ const _express = ({ prisma, knex }: ExpressParams) => {
 
       const updatedSetting = Object.entries(body).reduce<Record<string, any>>(
         (acc, [key, value]) => {
-          console.log("key", key, "value", value)
           if (permittedFields.includes(key)) {
             return { ...acc, [key]: value }
           }

--- a/backend/tests/__helpers.ts
+++ b/backend/tests/__helpers.ts
@@ -52,7 +52,7 @@ export function getTestContext(): TestContext {
     logger: logger.createLogger() as winston.Logger,
   } as TestContext
 
-  const ctx = createTestContext()
+  const ctx = createTestContext(testContext)
 
   // beforeEach
   beforeAll(async (done) => {
@@ -83,7 +83,7 @@ export function getTestContext(): TestContext {
 const wait = async (time: number) =>
   new Promise((resolve) => setTimeout(resolve, time))
 
-function createTestContext() {
+function createTestContext(testContext: TestContext) {
   let apolloInstance: ApolloServer | null = null
   let serverInstance: Server | null = null
   let port: number | null = null
@@ -97,7 +97,7 @@ function createTestContext() {
       const { apollo, express } = server({
         prisma,
         knex: knexClient,
-        logger: logger.createLogger(),
+        logger: testContext.logger,
         extraContext: {
           version: version++,
         },

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -198,10 +198,10 @@ export const users: Prisma.UserCreateInput[] = [
   },
   {
     id: "20000000000000000000000000000103",
-    administrator: false,
+    administrator: true,
     email: "f@mail.com",
     upstream_id: 2,
-    username: "second_user",
+    username: "second_user_admin",
   },
   {
     id: "20000000000000000000000000000104",
@@ -242,6 +242,12 @@ export const userCourseSettings: Prisma.UserCourseSettingCreateInput[] = [
     course: { connect: { id: "00000000000000000000000000000002" } },
     user: { connect: { id: "20000000000000000000000000000103" } },
     language: "en",
+    country: "en",
+    marketing: false,
+    research: true,
+    other: {
+      hasWings: true,
+    },
   },
 ]
 

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -247,6 +247,7 @@ export const userCourseSettings: Prisma.UserCourseSettingCreateInput[] = [
     research: true,
     other: {
       hasWings: true,
+      isCat: false,
     },
   },
 ]

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -250,6 +250,20 @@ export const userCourseSettings: Prisma.UserCourseSettingCreateInput[] = [
       isCat: false,
     },
   },
+  {
+    id: "40000000-0000-0000-0000-000000000999",
+    course: { connect: { id: "00000000000000000000000000000001" } },
+    user: { connect: { id: "20000000000000000000000000000103" } },
+    language: "en",
+    country: "en",
+    marketing: false,
+    research: true,
+    other: {
+      research: false,
+      country: "fi",
+      okField: true,
+    },
+  },
 ]
 
 export const services: Prisma.ServiceCreateInput[] = [

--- a/backend/tests/server.test.ts
+++ b/backend/tests/server.test.ts
@@ -1,15 +1,36 @@
-import { getTestContext } from "./__helpers"
+import { fakeTMC, getTestContext } from "./__helpers"
+import { normalUserDetails, adminUserDetails } from "./data"
 import { seed } from "./data/seed"
-import axios from "axios"
+import axios, { Method } from "axios"
 
 const ctx = getTestContext()
 
 describe("server", () => {
-  const post = (route: string = "", defaultHeaders: any) => async (
-    data: any,
-    headers: any = defaultHeaders,
-  ) =>
-    await axios.post(`http://localhost:${ctx.port}${route}`, data, { headers })
+  interface RequestParams {
+    data?: any
+    headers?: any
+    params?: Record<string, any>
+  }
+  const request = (method: Method) => (
+    route: string = "",
+    defaultHeaders: any,
+  ) => async ({
+    data = null,
+    headers = defaultHeaders,
+    params = {},
+  }: RequestParams) =>
+    await axios({
+      method,
+      url: `http://localhost:${ctx.port}${route}`,
+      data,
+      headers,
+      params,
+    })
+
+  const get = (route: string = "", defaultHeaders: any) =>
+    request("GET")(route, defaultHeaders)
+  const post = (route: string = "", defaultHeaders: any) =>
+    request("POST")(route, defaultHeaders)
 
   describe("/api/register-completions", () => {
     const defaultHeaders = {
@@ -22,7 +43,10 @@ describe("server", () => {
     })
 
     it("errors on wrong authorization", async () => {
-      return postCompletions({ foo: 1 }, { Authorization: "foo" })
+      return postCompletions({
+        data: { foo: 1 },
+        headers: { Authorization: "foo" },
+      })
         .then(() => fail())
         .catch(({ response }) => {
           expect(response.status).toBe(401)
@@ -30,7 +54,10 @@ describe("server", () => {
     })
 
     it("errors on non-existent secret", async () => {
-      return postCompletions({ foo: 1 }, { Authorization: "Basic koira" })
+      return postCompletions({
+        data: { foo: 1 },
+        headers: { Authorization: "Basic koira" },
+      })
         .then(() => fail())
         .catch(({ response }) => {
           expect(response.status).toBe(401)
@@ -38,7 +65,7 @@ describe("server", () => {
     })
 
     it("errors on no completions", async () => {
-      return postCompletions({ foo: 1 })
+      return postCompletions({ data: { foo: 1 } })
         .then(() => fail())
         .catch(({ response }) => {
           expect(response.status).toBe(400)
@@ -47,11 +74,13 @@ describe("server", () => {
 
     it("errors on malformed completion", async () => {
       return postCompletions({
-        completions: [
-          {
-            foo: 1,
-          },
-        ],
+        data: {
+          completions: [
+            {
+              foo: 1,
+            },
+          ],
+        },
       })
         .then(() => fail())
         .catch(({ response }) => {
@@ -61,16 +90,18 @@ describe("server", () => {
 
     it("creates registered completions", async () => {
       const res = await postCompletions({
-        completions: [
-          {
-            completion_id: "30000000-0000-0000-0000-000000000102",
-            student_number: "12345",
-          },
-          {
-            completion_id: "30000000-0000-0000-0000-000000000103",
-            student_number: "12345",
-          },
-        ],
+        data: {
+          completions: [
+            {
+              completion_id: "30000000-0000-0000-0000-000000000102",
+              student_number: "12345",
+            },
+            {
+              completion_id: "30000000-0000-0000-0000-000000000103",
+              student_number: "12345",
+            },
+          ],
+        },
       })
 
       expect(res.status).toBe(200)
@@ -93,6 +124,67 @@ describe("server", () => {
           updated_at: expect.any(Date),
         },
       ])
+    })
+  })
+
+  describe("/api/user-course-settings", () => {
+    const tmc = fakeTMC({
+      "Bearer normal": [200, normalUserDetails],
+      "Bearer admin": [200, adminUserDetails],
+    })
+    const getSettings = (slug: string) =>
+      get(`/api/user-course-settings/${slug}`, {})
+
+    beforeAll(() => tmc.setup())
+    afterAll(() => tmc.teardown())
+
+    beforeEach(async () => {
+      await seed(ctx.prisma)
+    })
+
+    it("errors without slug", async () => {
+      return getSettings("")({})
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(400)
+        })
+    })
+
+    it("errors without auth", async () => {
+      return getSettings("course1")({})
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(401)
+        })
+    })
+
+    it("returns null with user with no settings", async () => {
+      return getSettings("course1")({
+        headers: { Authorization: "Bearer normal" },
+      }).then((res) => {
+        expect(res.data).toBeNull()
+      })
+    })
+
+    it("returns null with course with no settings", async () => {
+      return getSettings("course2")({
+        headers: { Authorization: "Bearer normal" },
+      }).then((res) => {
+        expect(res.data).toBeNull()
+      })
+    })
+
+    it("returns settings correctly", async () => {
+      return getSettings("course1")({
+        headers: { Authorization: "Bearer admin" },
+      }).then(async (res) => {
+        const expected = await ctx.prisma.userCourseSetting.findFirst({
+          where: {
+            id: "40000000-0000-0000-0000-000000000102",
+          },
+        })
+        expect(res.data).toEqual(JSON.parse(JSON.stringify(expected)))
+      })
     })
   })
 })


### PR DESCRIPTION
`/api/user-course-settings/:slug` now accepts GET and POST requests:

- GET returns the user course settings for the current user for the provided course. `other` will be flattened; on key clashes (ie. `other` has keys with same names as settings) a warning should be shown.
- POST updates the user course settings for the current user for the provided course, given in body. 
~~Currently accepted: `language`, `country`, `marketing`, `research`. Will error on other given fields. Does accept any string (or number, for that matter) for language and country -- probably should have the accepted values checked somehow from somewhere~~. 
Now updates `country`, `course_variant`, `language`, `marketing` and `research`. Other fields (ids, updated/created at) stripped, what's left is shoved to `other`, which should also retain existing values.