### PR TITLE
Refactor consumer duplicate code

### DIFF
--- a/backend/bin/kafkaConsumer/common/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/common/kafkaConsumer.ts
@@ -23,7 +23,11 @@ export const createKafkaConsumer = (logger: winston.Logger) => {
       offset_commit_cb: logCommit(logger),
       "enable.auto.commit": false,
       "partition.assignment.strategy": "roundrobin",
-      debug: process.env.KAFKA_DEBUG_CONTEXTS ?? undefined,
+      ...(process.env.KAFKA_DEBUG_CONTEXTS
+        ? {
+            debug: process.env.KAFKA_DEBUG_CONTEXTS,
+          }
+        : {}),
     },
     { "auto.offset.reset": "earliest" },
   )

--- a/backend/bin/kafkaConsumer/exerciseConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/exerciseConsumer/kafkaConsumer.ts
@@ -16,7 +16,6 @@ import { createKafkaConsumer } from "../common/kafkaConsumer"
 import { KafkaError } from "../../lib/errors"
 import { LibrdKafkaError } from "node-rdkafka"
 import knex from "../../../services/knex"
-import checkConnectionInInterval from "../common/connectedChecker"
 
 const TOPIC_NAME = [config.exercise_consumer.topic_name]
 
@@ -37,6 +36,7 @@ const context = {
 }
 
 consumer.on("ready", () => {
+  logger.info("Ready to consume")
   consumer.subscribe(TOPIC_NAME)
   const consumerImpl = async (error: LibrdKafkaError, messages: any) => {
     if (error) {
@@ -61,20 +61,3 @@ consumer.on("ready", () => {
   }
   consumer.consume(1, consumerImpl)
 })
-
-consumer.on("event.error", (error) => {
-  logger.error(new KafkaError("Error", error))
-  throw error
-})
-
-consumer.on("event.log", function (log) {
-  console.log(log)
-})
-
-consumer.on("connection.failure", (err, metrics) => {
-  logger.info("Connection failed with " + err)
-  logger.info("Metrics: " + JSON.stringify(metrics))
-  consumer.connect()
-})
-
-checkConnectionInInterval(consumer)

--- a/backend/bin/kafkaConsumer/userCourseProgressConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userCourseProgressConsumer/kafkaConsumer.ts
@@ -18,7 +18,6 @@ import { KafkaError } from "../../lib/errors"
 import { LibrdKafkaError, Message as KafkaMessage } from "node-rdkafka"
 import { KafkaContext } from "../common/kafkaContext"
 import knex from "../../../services/knex"
-import checkConnectionInInterval from "../common/connectedChecker"
 
 const mutex = new Mutex()
 const TOPIC_NAME = [config.user_course_progress_consumer.topic_name]
@@ -37,6 +36,7 @@ const context: KafkaContext = {
 consumer.connect()
 
 consumer.on("ready", () => {
+  logger.info("Ready to consume")
   consumer.subscribe(TOPIC_NAME)
   const consumerImpl = async (
     error: LibrdKafkaError,
@@ -65,20 +65,3 @@ consumer.on("ready", () => {
   }
   consumer.consume(1, consumerImpl)
 })
-
-consumer.on("event.error", (error) => {
-  logger.error(new KafkaError("Error", error))
-  process.exit(-1)
-})
-
-consumer.on("event.log", function (log) {
-  console.log(log)
-})
-
-consumer.on("connection.failure", (err, metrics) => {
-  logger.info("Connection failed with " + err)
-  logger.info("Metrics: " + JSON.stringify(metrics))
-  consumer.connect()
-})
-
-checkConnectionInInterval(consumer)

--- a/backend/bin/kafkaConsumer/userCourseProgressRealtimeConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userCourseProgressRealtimeConsumer/kafkaConsumer.ts
@@ -17,7 +17,6 @@ import { createKafkaConsumer } from "../common/kafkaConsumer"
 import { KafkaError } from "../../lib/errors"
 import { LibrdKafkaError, Message as KafkaMessage } from "node-rdkafka"
 import knex from "../../../services/knex"
-import checkConnectionInInterval from "../common/connectedChecker"
 
 const mutex = new Mutex()
 const TOPIC_NAME = [config.user_course_progress_realtime_consumer.topic_name]
@@ -38,6 +37,7 @@ const context = {
 }
 
 consumer.on("ready", () => {
+  logger.info("Ready to consume")
   consumer.subscribe(TOPIC_NAME)
   const consumerImpl = async (
     error: LibrdKafkaError,
@@ -66,20 +66,3 @@ consumer.on("ready", () => {
   }
   consumer.consume(1, consumerImpl)
 })
-
-consumer.on("event.error", (error) => {
-  logger.error(new KafkaError("Error", error))
-  process.exit(-1)
-})
-
-consumer.on("event.log", function (log) {
-  console.log(log)
-})
-
-consumer.on("connection.failure", (err, metrics) => {
-  logger.info("Connection failed with " + err)
-  logger.info("Metrics: " + JSON.stringify(metrics))
-  consumer.connect()
-})
-
-checkConnectionInInterval(consumer)

--- a/backend/bin/kafkaConsumer/userPointsConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userPointsConsumer/kafkaConsumer.ts
@@ -14,7 +14,6 @@ import { createKafkaConsumer } from "../common/kafkaConsumer"
 import { LibrdKafkaError } from "node-rdkafka"
 import { KafkaError } from "../../lib/errors"
 import knex from "../../../services/knex"
-import checkConnectionInInterval from "../common/connectedChecker"
 
 const TOPIC_NAME = [config.user_points_consumer.topic_name]
 
@@ -34,6 +33,7 @@ const context = {
 }
 
 consumer.on("ready", () => {
+  logger.info("Ready to consume")
   consumer.subscribe(TOPIC_NAME)
   const consumerImpl = async (error: LibrdKafkaError, messages: any) => {
     if (error) {
@@ -58,20 +58,3 @@ consumer.on("ready", () => {
   }
   consumer.consume(1, consumerImpl)
 })
-
-consumer.on("event.error", (error) => {
-  logger.error(new KafkaError("Error", error))
-  process.exit(-1)
-})
-
-consumer.on("event.log", function (log) {
-  console.log(log)
-})
-
-consumer.on("connection.failure", (err, metrics) => {
-  logger.info("Connection failed with " + err)
-  logger.info("Metrics: " + JSON.stringify(metrics))
-  consumer.connect()
-})
-
-checkConnectionInInterval(consumer)

--- a/backend/bin/kafkaConsumer/userPointsRealtimeConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userPointsRealtimeConsumer/kafkaConsumer.ts
@@ -14,7 +14,6 @@ import { createKafkaConsumer } from "../common/kafkaConsumer"
 import { LibrdKafkaError } from "node-rdkafka"
 import { KafkaError } from "../../lib/errors"
 import knex from "../../../services/knex"
-import checkConnectionInInterval from "../common/connectedChecker"
 
 const TOPIC_NAME = [config.user_points_realtime_consumer.topic_name]
 
@@ -34,6 +33,7 @@ const context = {
 }
 
 consumer.on("ready", () => {
+  logger.info("Ready to consume")
   consumer.subscribe(TOPIC_NAME)
   const consumerImpl = async (error: LibrdKafkaError, messages: any) => {
     if (error) {
@@ -58,20 +58,3 @@ consumer.on("ready", () => {
   }
   consumer.consume(1, consumerImpl)
 })
-
-consumer.on("event.error", (error) => {
-  logger.error(new KafkaError("Error", error))
-  process.exit(-1)
-})
-
-consumer.on("event.log", function (log) {
-  console.log(log)
-})
-
-consumer.on("connection.failure", (err, metrics) => {
-  logger.info("Connection failed with " + err)
-  logger.info("Metrics: " + JSON.stringify(metrics))
-  consumer.connect()
-})
-
-checkConnectionInInterval(consumer)


### PR DESCRIPTION
Moved common events to consumer creation. Also log when we're ready so at least we know it's not stuck or anything.