### PR TITLE
simplify user search query

### DIFF
--- a/backend/graphql/User/queries.ts
+++ b/backend/graphql/User/queries.ts
@@ -1,5 +1,5 @@
 import { UserInputError, ForbiddenError } from "apollo-server-core"
-import { buildSearch, convertPagination } from "../../util/db-functions"
+import { convertPagination, buildUserSearch } from "../../util/db-functions"
 import { extendType, idArg, stringArg, intArg } from "nexus"
 import { isAdmin } from "../../accessControl"
 
@@ -37,10 +37,7 @@ export const UserQueries = extendType({
 
         const user = await ctx.prisma.user.findFirst({
           where: {
-            OR: buildSearch(
-              ["first_name", "last_name", "username", "email"],
-              search ?? "",
-            ),
+            ...buildUserSearch(search),
             id: id ?? undefined,
             upstream_id: upstream_id ?? undefined,
           },
@@ -67,12 +64,7 @@ export const UserQueries = extendType({
 
         return ctx.prisma.user.findMany({
           ...convertPagination({ first, last, before, after, skip }),
-          where: {
-            OR: buildSearch(
-              ["first_name", "last_name", "username", "email"],
-              search ?? "",
-            ),
-          },
+          where: buildUserSearch(search),
         })
       },
       extendConnection(t) {
@@ -82,12 +74,7 @@ export const UserQueries = extendType({
           },
           resolve: async (_, { search }, ctx) => {
             return ctx.prisma.user.count({
-              where: {
-                OR: buildSearch(
-                  ["first_name", "last_name", "username", "email"],
-                  search ?? "",
-                ),
-              },
+              where: buildUserSearch(search),
             })
           },
         })

--- a/backend/graphql/UserCourseSetting.ts
+++ b/backend/graphql/UserCourseSetting.ts
@@ -1,5 +1,5 @@
 import { UserInputError, ForbiddenError } from "apollo-server-core"
-import { buildSearch /*, convertPagination*/ } from "../util/db-functions"
+import { buildUserSearch /*, convertPagination*/ } from "../util/db-functions"
 import { isAdmin } from "../accessControl"
 import {
   objectType,
@@ -127,13 +127,9 @@ export const UserCourseSettingQueries = extendType({
 
         const orCondition: Prisma.UserWhereInput[] = []
 
-        if (search)
-          orCondition.push({
-            OR: buildSearch(
-              ["first_name", "last_name", "username", "email"],
-              search ?? "",
-            ),
-          })
+        if (search) {
+          orCondition.push(buildUserSearch(search))
+        }
 
         if (user_id) orCondition.push({ id: user_id })
         if (user_upstream_id)

--- a/backend/util/db-functions.ts
+++ b/backend/util/db-functions.ts
@@ -1,10 +1,45 @@
 import { notEmpty } from "./notEmpty"
+import { isNullOrUndefined } from "./isNullOrUndefined"
+import { Prisma } from "@prisma/client"
 
 const flatten = (arr: any[]) => arr.reduce((acc, val) => acc.concat(val), [])
 const titleCase = (s?: string) =>
   s && s.length > 0
     ? s.toLowerCase()[0].toUpperCase() + s.toLowerCase().slice(1)
     : undefined
+
+export const buildUserSearch = (
+  search?: string | null,
+): Prisma.UserWhereInput => {
+  if (isNullOrUndefined(search)) {
+    return {}
+  }
+  return {
+    OR: [
+      {
+        first_name: { contains: search, mode: "insensitive" },
+      },
+      {
+        last_name: { contains: search, mode: "insensitive" },
+      },
+      {
+        username: { contains: search, mode: "insensitive" },
+      },
+      {
+        email: { contains: search, mode: "insensitive" },
+      },
+      {
+        student_number: { contains: search },
+      },
+      {
+        real_student_number: { contains: search },
+      },
+      {
+        upstream_id: Number(search) || undefined,
+      },
+    ],
+  }
+}
 
 export const buildSearch = (fields: string[], search?: string) =>
   search


### PR DESCRIPTION
Utilize the `insensitive` option instead of building a zillion of variations of the search string