### PR TITLE
add composite indexes to oft-queried tables

### DIFF
--- a/backend/migrations/20210419103940_alter-table-add-user-course-progress-composite-index.ts
+++ b/backend/migrations/20210419103940_alter-table-add-user-course-progress-composite-index.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.raw(
+    `CREATE INDEX IF NOT EXISTS "user_course_progress.course_id_user_id" ON user_course_progress USING btree(course_id, user_id);`,
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.raw(
+    `DROP INDEX IF EXISTS "user_course_progress.course_id_user_id";`,
+  )
+}

--- a/backend/migrations/20210419111606_alter-table-add-completion-composite-index.ts
+++ b/backend/migrations/20210419111606_alter-table-add-completion-composite-index.ts
@@ -1,0 +1,11 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.raw(
+    `CREATE INDEX IF NOT EXISTS "completion.course_id_user_id" ON completion USING btree(course_id, user_id);`,
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.raw(`DROP INDEX IF EXISTS "completion.course_id_user_id;`)
+}

--- a/backend/migrations/20210419112036_alter-table-add-user-course-service-progress-composite-index.ts
+++ b/backend/migrations/20210419112036_alter-table-add-user-course-service-progress-composite-index.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.raw(
+    `CREATE INDEX IF NOT EXISTS "user_course_service_progress.service_id_course_id_user_id" ON user_course_service_progress USING btree(service_id, course_id, user_id);`,
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.raw(
+    `DROP INDEX IF EXISTS "user_course_service_progress.service_id_course_id_user_id";`,
+  )
+}


### PR DESCRIPTION
- `(course_id, user_id)` on `user_course_progress`
- `(service_id, course_id, user_id)` on `user_course_service_progress`
- `(course_id, user_id)` on `completion`