### PR TITLE
Fix UUID ossp extension

### DIFF
--- a/backend/migrations/20210610093434_alter-table-ab-studies-ids.ts
+++ b/backend/migrations/20210610093434_alter-table-ab-studies-ids.ts
@@ -2,9 +2,9 @@ import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
   try {
-    // await knex.raw(`CREATE SCHEMA IF NOT EXISTS "extensions";`)
+    await knex.raw(`CREATE SCHEMA IF NOT EXISTS "extensions";`)
     await knex.raw(
-      `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`, // SCHEMA "extensions";`,
+      `CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA "extensions";`,
     )
   } catch {
     console.warn(
@@ -12,8 +12,15 @@ export async function up(knex: Knex): Promise<void> {
     )
   }
 
+  try {
+    // if uuid-ossp already exists, but in another schema
+    await knex.raw(`ALTER EXTENSION "uuid-ossp" SET SCHEMA "extensions";`)
+  } catch {
+    // we can probably ignore this
+  }
+
   await knex.raw(
-    `ALTER TABLE "ab_study" ALTER COLUMN "id" SET DEFAULT uuid_generate_v4();`,
+    `ALTER TABLE "ab_study" ALTER COLUMN "id" SET DEFAULT extensions.uuid_generate_v4();`,
   )
 }
 

--- a/backend/migrations/20210610093434_alter-table-ab-studies-ids.ts
+++ b/backend/migrations/20210610093434_alter-table-ab-studies-ids.ts
@@ -2,9 +2,9 @@ import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
   try {
-    await knex.raw(`CREATE SCHEMA IF NOT EXISTS "extensions";`)
+    // await knex.raw(`CREATE SCHEMA IF NOT EXISTS "extensions";`)
     await knex.raw(
-      `CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA "extensions";`,
+      `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`, // SCHEMA "extensions";`,
     )
   } catch {
     console.warn(
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
   }
 
   await knex.raw(
-    `ALTER TABLE "ab_study" ALTER COLUMN "id" SET DEFAULT extensions.uuid_generate_v4();`,
+    `ALTER TABLE "ab_study" ALTER COLUMN "id" SET DEFAULT uuid_generate_v4();`,
   )
 }
 


### PR DESCRIPTION
I checked how the extensions were now in the production DB and seems that uuid-ossp was in `moocfi$production` schema anyway. Let's try moving it to `extensions` just in case that would help. 