### PR TITLE
Fix AbEnrollment group randomization

### DIFF
--- a/backend/api/abStudio/abEnrollments.ts
+++ b/backend/api/abStudio/abEnrollments.ts
@@ -38,7 +38,7 @@ export function abEnrollmentRouter({ knex, prisma }: ApiContext) {
       WITH cte AS (
         INSERT INTO "ab_enrollment" (user_id, ab_study_id, "group")
         VALUES (:user_id, :ab_study_id, (
-          SELECT floor(random() * (group_count - 1)) + 1 FROM ab_study WHERE id = :ab_study_id
+          SELECT floor(random() * group_count) + 1 FROM ab_study WHERE id = :ab_study_id
         ))
         ON CONFLICT (user_id, ab_study_id) DO NOTHING
         RETURNING user_id, ab_study_id, "group", created_at, updated_at


### PR DESCRIPTION
Current randomization excludes the highest possible value for group since floor rounds to nearest lower int and random()-function returns a value between 0 and 0.999...

E.g. with group_count=2, randomized value is always at most 0.999... which floors to 0, thus the only possible randomized group value is 1, never 2.