### PR TITLE
set cookie path to /; retry zapping shib cookies after success

### DIFF
--- a/backend/middlewares/fetchUser.ts
+++ b/backend/middlewares/fetchUser.ts
@@ -3,7 +3,7 @@ import TmcClient from "../services/tmc"
 import { Role } from "../accessControl"
 import { redisify } from "../services/redis"
 import { UserInfo } from "/domain/UserInfo"
-import { PrismaClient } from "@prisma/client"
+// import { PrismaClient } from "@prisma/client"
 import { Context } from "../context"
 import { plugin } from "nexus"
 import { convertUpdate } from "../util/db-functions"
@@ -101,7 +101,7 @@ const getUser = async (ctx: Context, rawToken: string) => {
 }
 
 // this is the one suitable for context, not used for now
-export const contextUser = async (
+/*export const contextUser = async (
   req: any, // was: IncomingMessage, but somehow it's wrapped in req
   prisma: PrismaClient,
 ) => {
@@ -177,4 +177,4 @@ export const contextUser = async (
     organization: undefined,
     user,
   }
-}
+}*/

--- a/frontend/packages/moocfi-auth/index.ts
+++ b/frontend/packages/moocfi-auth/index.ts
@@ -58,10 +58,12 @@ const setCookies = ({
     })
     cookies.set("access_token", tmcToken, {
       domain,
+      path: "/",
     })
   } else {
     cookies.set("access_token", accessToken, {
       domain,
+      path: "/",
     })
     cookies.set("tmc_token", tmcToken, {
       domain,
@@ -162,7 +164,7 @@ export const removeToken = async (priority: string, domain: string) => {
   })
     .then((response) => response.data)
     .then((json) => {
-      cookies.remove("access_token", { domain })
+      cookies.remove("access_token", { domain, path: "/" })
       cookies.remove("tmc_token", { domain })
       cookies.remove("mooc_token", { domain })
       cookies.remove("admin", { domain })

--- a/shibbo/src/server.ts
+++ b/shibbo/src/server.ts
@@ -83,7 +83,7 @@ const VERIFIED_USER_MUTATION = gql`
   }
 `
 
-// const shibCookies = ["_shibstate", "_opensaml", "_shibsession"]
+const shibCookies = ["_shibstate", "_opensaml", "_shibsession"]
 
 const handler = async (req: Request, res: Response) => {
   const headers =
@@ -128,13 +128,13 @@ const handler = async (req: Request, res: Response) => {
     })
     console.log(result)
 
-    /*Object.keys(res.locals.cookie).forEach((key) => {
+    Object.keys(res.locals.cookie).forEach((key) => {
       shibCookies.forEach((prefix) => {
         if (key.startsWith(prefix)) {
           res.clearCookie(key)
         }
       })
-    })*/
+    })
 
     res.redirect(
       `${FRONTEND_URL}/${language}/profile/connect/success?id=${result.addVerifiedUser.id}`,


### PR DESCRIPTION
- try setting the path to / on access_token to see if it affects
- check if zapping the _shib* cookies will actually delete the session or not