### PR TITLE
Add sp logout redirect page

### DIFF
--- a/frontend/pages/sp-logout.tsx
+++ b/frontend/pages/sp-logout.tsx
@@ -1,0 +1,16 @@
+import { NextPageContext } from "next"
+
+const SPLogout = () => {
+  return <div>You are logged out. You should not be able to see this page.</div>
+}
+
+SPLogout.getInitialProps = (ctx: NextPageContext) => {
+  if (ctx.query.return) {
+    ctx?.res?.writeHead(302, { location: ctx.query.return })
+    ctx?.res?.end()
+  }
+
+  return {}
+}
+
+export default SPLogout


### PR DESCRIPTION
Shibbo logout shows the IdP "you are logged out" page unless a specific notify address is specified; now it should go to that and redirect wherever we want it to