### PR TITLE
added api endpoint for user course progress

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,4 @@ env.json
 .watchmanconfig
 coverage/
 sourcemap/
+config/*.pem

--- a/backend/api/__test__/api.test.ts
+++ b/backend/api/__test__/api.test.ts
@@ -624,4 +624,62 @@ describe("API", () => {
       }
     })
   })
+
+  describe("/user-course-progress", () => {
+    const tmc = fakeTMCCurrent({
+      "Bearer normal": [200, normalUserDetails],
+      "Bearer third": [200, { ...normalUserDetails, id: 3 }],
+    })
+
+    beforeAll(() => tmc.setup())
+    afterAll(() => tmc.teardown())
+
+    beforeEach(async () => {
+      await seed(ctx.prisma)
+    })
+
+    const getUserCourseProgress = (slug: string) =>
+      get(`/api/user-course-progress/${slug}`, {})
+
+    it("errors on no auth", async () => {
+      return getUserCourseProgress("course1")({})
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(401)
+        })
+    })
+
+    it("returns data", async () => {
+      const ucpResponse = await getUserCourseProgress("course1")({
+        headers: {
+          Authorization: "Bearer normal",
+        },
+      })
+
+      expect(ucpResponse.status).toBe(200)
+      expect(ucpResponse.data).not.toBeNull()
+
+      expect(ucpResponse.data.data.progress).toEqual([
+        { group: "week1", max_points: 3, n_points: 0 },
+      ])
+    })
+
+    it("returns only the oldest instance", async () => {
+      const ucpResponse = await getUserCourseProgress("course1")({
+        headers: {
+          Authorization: "Bearer third",
+        },
+      })
+
+      expect(ucpResponse.status).toBe(200)
+      expect(ucpResponse.data).not.toBeNull()
+
+      expect(ucpResponse.data.data.progress).toEqual([
+        { group: "week1", max_points: 3, n_points: 3 },
+      ])
+      expect(ucpResponse.data.data.created_at).toEqual(
+        "1900-01-01T08:00:00.000Z",
+      )
+    })
+  })
 })

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -16,6 +16,7 @@ import {
   userCourseSettingsPost,
 } from "./userCourseSettings"
 import { abEnrollmentRouter, abStudiesRouter } from "./abStudio"
+import { userCourseProgress } from "./userCourseProgress"
 
 import * as winston from "winston"
 
@@ -42,4 +43,5 @@ export function apiRouter(ctx: ApiContext) {
     .post("/user-course-settings/:slug", userCourseSettingsPost(ctx))
     .use("/ab-studies", abStudiesRouter(ctx))
     .use("/ab-enrollments", abEnrollmentRouter(ctx))
+    .get("/user-course-progress/:slug", userCourseProgress(ctx))
 }

--- a/backend/api/progress.ts
+++ b/backend/api/progress.ts
@@ -15,8 +15,8 @@ interface ExerciseCompletionResult {
 }
 
 export function progress({ knex }: ApiContext) {
-  return async (req: any, res: any) => {
-    const { id }: { id: string } = req.params
+  return async (req: Request<{ id: string }>, res: any) => {
+    const { id } = req.params
 
     if (!id) {
       return res.status(400).json({ message: "must provide id" })

--- a/backend/api/userCourseProgress.ts
+++ b/backend/api/userCourseProgress.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from "express"
+import { ApiContext } from "."
+import { getUser } from "../util/server-functions"
+
+export function userCourseProgress({ knex, prisma }: ApiContext) {
+  return async (req: Request<{ slug: string }>, res: Response) => {
+    const { slug } = req.params
+
+    const getUserResult = await getUser(knex)(req, res)
+
+    if (getUserResult.isErr()) {
+      return getUserResult.error
+    }
+
+    const { user } = getUserResult.value
+
+    const userCourseProgresses = await prisma.userCourseProgress.findFirst({
+      where: {
+        user_id: user.id,
+        course: {
+          slug,
+        },
+      },
+      orderBy: {
+        created_at: "asc",
+      },
+    })
+
+    res.json({
+      data: userCourseProgresses,
+    })
+  }
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4665,6 +4665,9 @@
       }
     },
     "graphql-upload": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-12.0.0.tgz",
+      "integrity": "sha512-ovZ3Q7sZ17Bmn8tYl22MfrpNR7nYM/DUszXWgkue7SFIlI9jtqszHAli8id8ZcnGBc9GF0gUTNSskYWW+5aNNQ==",
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^6.2.0",
@@ -4695,8 +4698,7 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
-      },
-      "version": "11.0.0"
+      }
     },
     "gtoken": {
       "version": "5.2.1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4665,9 +4665,6 @@
       }
     },
     "graphql-upload": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-12.0.0.tgz",
-      "integrity": "sha512-ovZ3Q7sZ17Bmn8tYl22MfrpNR7nYM/DUszXWgkue7SFIlI9jtqszHAli8id8ZcnGBc9GF0gUTNSskYWW+5aNNQ==",
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^6.2.0",
@@ -4698,7 +4695,8 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
-      }
+      },
+      "version": "11.0.0"
     },
     "gtoken": {
       "version": "5.2.1",

--- a/shibbo/.gitignore
+++ b/shibbo/.gitignore
@@ -1,4 +1,5 @@
 shibboleth/*
+shibboleth-staging/*
 docs/*
 node_modules
 build


### PR DESCRIPTION
`/api/user-course-progress/:slug` returns the current user progress for the course given by slug. Does not return service progresses for now - those can be added if they're needed, as can other joinable stuff such as user, course etc.

Example return:

```
{
    "data": {
        "course_id": "80a74f70-c128-4f46-b4c0-9368cd63fd7c",
        "created_at": "2021-01-29T12:56:36.020Z",
        "id": "fbd3bd1a-26b5-4183-a02f-17fe8cf3688e",
        "max_points": 3,
        "n_points": 1,
        "progress": [
          { group: "week1", max_points: 1: n_points: 0 }, 
          { group: "week2": max_points: 2, n_points: 1 }
        ],
        "extra": null,
        "updated_at": "2021-01-29T12:56:36.020Z",
        "user_id": "0ced1b0b-e59e-4958-9418-fbf707df2180"
    }
}
```