### PR TITLE
fixed visual bug with front page courses

### DIFF
--- a/frontend/components/Home/CourseCard.tsx
+++ b/frontend/components/Home/CourseCard.tsx
@@ -15,7 +15,7 @@ const Background = styled(ClickableButtonBase)<{ component: any }>`
   flex-direction: column;
   height: 100%;
   width: 100%;
-  @media (max-width: 960px) {
+  @media (max-width: 959px) {
     flex-direction: row;
   }
 `
@@ -29,7 +29,7 @@ const ResponsiveCourseImageBase = styled(CourseImageBase)`
     width: 45%;
     height: 235px;
   }
-  @media (min-width: 600px) and (max-width: 960px) {
+  @media (min-width: 600px) and (max-width: 959px) {
     width: 40%;
     height: 240px;
   }
@@ -49,7 +49,7 @@ const TextArea = styled.div`
     text-align: left;
     width: 65%;
   }
-  @media (min-width: 600px) and (max-width: 960px) {
+  @media (min-width: 600px) and (max-width: 959px) {
     text-align: left;
     width: 60%;
   }

--- a/frontend/components/Home/ModuleSmallCourseCard.tsx
+++ b/frontend/components/Home/ModuleSmallCourseCard.tsx
@@ -56,7 +56,7 @@ const Background = styled(ClickableButtonBase)<BackgroundProps>`
     }
   `
       : undefined}
-  @media (max-width: 960px) {
+  @media (min-width: 960px) {
     min-height: 150px;
   }
   @media (min-width: 600px) and (max-width: 960px) {


### PR DESCRIPTION
When viewpoint is exactly 960px wide, the course cards and their images looked wrong. I guess we're having some other styling clashes (with Grid?) so let's just hack it so it doesn't happen.