### PR TITLE
add stored data; post endpoint

### DIFF
--- a/backend/api/__test__/api.test.ts
+++ b/backend/api/__test__/api.test.ts
@@ -1,8 +1,9 @@
-import { fakeTMCCurrent, getTestContext } from "../../tests/__helpers"
-import { normalUserDetails, adminUserDetails } from "../../tests/data"
-import { seed } from "../../tests/data/seed"
 import axios, { Method } from "axios"
 import { omit, orderBy } from "lodash"
+
+import { fakeTMCCurrent, getTestContext } from "../../tests/__helpers"
+import { adminUserDetails, normalUserDetails } from "../../tests/data"
+import { seed } from "../../tests/data/seed"
 
 const ctx = getTestContext()
 
@@ -680,6 +681,91 @@ describe("API", () => {
       expect(ucpResponse.data.data.created_at).toEqual(
         "1900-01-01T08:00:00.000Z",
       )
+    })
+  })
+
+  describe("/stored-data", () => {
+    const tmc = fakeTMCCurrent({
+      "Bearer normal": [200, normalUserDetails],
+      "Bearer third": [200, { ...normalUserDetails, id: 3 }],
+    })
+
+    beforeAll(() => tmc.setup())
+    afterAll(() => tmc.teardown())
+
+    beforeEach(async () => {
+      await seed(ctx.prisma)
+    })
+
+    const postStoredData = (slug: string) =>
+      post(`/api/stored-data/${slug}`, {})
+
+    it("errors on no auth", async () => {
+      return postStoredData("course1")({
+        data: { data: "foo" },
+      })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(401)
+        })
+    })
+
+    it("errors on no data", async () => {
+      return postStoredData("course1")({
+        headers: { Authorization: "Bearer normal" },
+      })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(400)
+        })
+    })
+
+    it("creates stored data", async () => {
+      const existing = await ctx.prisma.storedData.findFirst({
+        where: {
+          user_id: "20000000000000000000000000000102",
+          course_id: "00000000000000000000000000000002",
+        },
+      })
+
+      expect(existing).toBeNull()
+
+      const res = await postStoredData("course1")({
+        data: { data: "foo foo" },
+        headers: { Authorization: "Bearer normal" },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.data.message).toContain("stored data created")
+
+      const created = await ctx.prisma.storedData.findFirst({
+        where: {
+          user_id: "20000000000000000000000000000102",
+          course_id: "00000000000000000000000000000002",
+        },
+      })
+
+      expect(created?.data).toEqual("foo foo")
+    })
+
+    it("errors when data already exists", async () => {
+      const existing = await ctx.prisma.storedData.findFirst({
+        where: {
+          user_id: "20000000000000000000000000000102",
+          course_id: "00000000000000000000000000000001",
+        },
+      })
+
+      expect(existing?.data).toEqual("user1_foo")
+
+      return postStoredData("course2")({
+        data: { data: "foo foo" },
+        headers: { Authorization: "Bearer normal" },
+      })
+        .then(() => fail())
+        .catch(({ response }) => {
+          expect(response.status).toBe(500)
+        })
     })
   })
 })

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -1,24 +1,25 @@
-import type { PrismaClient } from "@prisma/client"
-import { Knex } from "knex"
 import { Router } from "express"
+import { Knex } from "knex"
+import * as winston from "winston"
 
+import type { PrismaClient } from "@prisma/client"
+
+import { abEnrollmentRouter, abStudiesRouter } from "./abStudio"
 import {
+  completionInstructions,
   completions,
   completionTiers,
-  completionInstructions,
 } from "./completions"
-import { userCourseSettingsCount } from "./userCourseSettingsCount"
 import { progress, progressV2 } from "./progress"
-import { tierProgress } from "./tierProgress"
 import { registerCompletions } from "./registerCompletions"
+import { postStoredData } from "./storedData"
+import { tierProgress } from "./tierProgress"
+import { userCourseProgress } from "./userCourseProgress"
 import {
   userCourseSettingsGet,
   userCourseSettingsPost,
 } from "./userCourseSettings"
-import { abEnrollmentRouter, abStudiesRouter } from "./abStudio"
-import { userCourseProgress } from "./userCourseProgress"
-
-import * as winston from "winston"
+import { userCourseSettingsCount } from "./userCourseSettingsCount"
 
 export interface ApiContext {
   prisma: PrismaClient
@@ -44,4 +45,5 @@ export function apiRouter(ctx: ApiContext) {
     .use("/ab-studies", abStudiesRouter(ctx))
     .use("/ab-enrollments", abEnrollmentRouter(ctx))
     .get("/user-course-progress/:slug", userCourseProgress(ctx))
+    .post("/stored-data/:slug", postStoredData(ctx))
 }

--- a/backend/api/storedData.ts
+++ b/backend/api/storedData.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from "express-serve-static-core"
+
+import { getUser } from "../util/server-functions"
+import { ApiContext } from "./"
+
+export function postStoredData({ knex, prisma }: ApiContext) {
+  return async function (
+    req: Request<{ slug: string }, {}, { data: string }>,
+    res: Response,
+  ) {
+    const getUserResult = await getUser(knex)(req, res)
+
+    if (getUserResult.isErr()) {
+      return getUserResult.error
+    }
+
+    const { user } = getUserResult.value
+    const { slug } = req.params
+    const { data } = req.body
+
+    if (!data) {
+      return res.status(400).json({ message: "must provide data" })
+    }
+
+    try {
+      // @ts-ignore: return value not used for now
+      const newStoredData = await prisma.storedData.create({
+        data: {
+          user: { connect: { id: user.id } },
+          course: { connect: { slug } },
+          data,
+        },
+      })
+
+      return res.status(200).json({ message: "stored data created" })
+    } catch (error: any) {
+      return res
+        .status(500)
+        .json({ message: "error creating stored data", error })
+    }
+  }
+}

--- a/backend/graphql/Course/__test__/Course.test.ts
+++ b/backend/graphql/Course/__test__/Course.test.ts
@@ -1,21 +1,16 @@
 import { createReadStream } from "fs"
 import { gql } from "graphql-request"
-import { getTestContext, fakeTMCCurrent } from "../../../tests/__helpers"
-import {
-  //normalUser,
-  normalUserDetails,
-  //adminUser,
-  adminUserDetails,
-} from "../../../tests/data"
-import { seed } from "../../../tests/data/seed"
+import { omit, orderBy } from "lodash"
+import { mocked } from "ts-jest/utils"
 
 import { Course } from "@prisma/client"
-import { orderBy } from "lodash"
-import { mocked } from "ts-jest/utils"
-import { omit } from "lodash"
+
+import KafkaProducer from "../../../services/kafkaProducer"
+import { fakeTMCCurrent, getTestContext } from "../../../tests/__helpers"
+import { adminUserDetails, normalUserDetails } from "../../../tests/data"
+import { seed } from "../../../tests/data/seed"
 
 jest.mock("../../../services/kafkaProducer")
-import KafkaProducer from "../../../services/kafkaProducer"
 
 const ctx = getTestContext()
 const tmc = fakeTMCCurrent({

--- a/backend/graphql/StoredData.ts
+++ b/backend/graphql/StoredData.ts
@@ -1,0 +1,12 @@
+import { objectType } from "nexus"
+
+export const StoredData = objectType({
+  name: "StoredData",
+  definition(t) {
+    t.model.user_id()
+    t.model.course_id()
+    t.model.data()
+    t.model.created_at()
+    t.model.updated_at()
+  },
+})

--- a/backend/migrations/20211011074830_create-table-stored-data.ts
+++ b/backend/migrations/20211011074830_create-table-stored-data.ts
@@ -1,0 +1,41 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS "stored_data" (
+      created_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      data TEXT,
+      course_id uuid,
+      user_id uuid
+    );
+  `)
+
+  await knex.raw(`
+    ALTER TABLE ONLY stored_data
+      ADD CONSTRAINT stored_data_pkey PRIMARY KEY (course_id, user_id);
+  `)
+
+  await knex.raw(`
+    ALTER TABLE ONLY stored_data
+      ADD CONSTRAINT stored_data_user FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE SET NULL;
+  `)
+  await knex.raw(`
+    ALTER TABLE ONLY stored_data
+      ADD CONSTRAINT stored_data_course FOREIGN KEY (course_id) REFERENCES course(id) ON DELETE SET NULL;
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "stored_data.course_id_user_id._UNIQUE"
+      ON stored_data USING btree (course_id, user_id);
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS "stored_data.course_id_user_id._UNIQUE";
+  `)
+  await knex.raw(`
+    DROP TABLE stored_data;
+  `)
+}

--- a/backend/migrations/20211011074830_create-table-stored-data.ts
+++ b/backend/migrations/20211011074830_create-table-stored-data.ts
@@ -18,11 +18,11 @@ export async function up(knex: Knex): Promise<void> {
 
   await knex.raw(`
     ALTER TABLE ONLY stored_data
-      ADD CONSTRAINT stored_data_user FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE SET NULL;
+      ADD CONSTRAINT stored_data FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE;
   `)
   await knex.raw(`
     ALTER TABLE ONLY stored_data
-      ADD CONSTRAINT stored_data_course FOREIGN KEY (course_id) REFERENCES course(id) ON DELETE SET NULL;
+      ADD CONSTRAINT stored_data_course FOREIGN KEY (course_id) REFERENCES course(id) ON DELETE CASCADE;
   `)
 
   await knex.raw(`

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -123,6 +123,7 @@ model Course {
   study_modules                                      StudyModule[]                       @relation("study_module_to_course", references: [id])
   upcoming_active_link                               Boolean?
   tier                                               Int?
+  stored_data                                        StoredData[]                        
 
   @@map("course")
 }
@@ -354,6 +355,19 @@ model Service {
   @@map("service")
 }
 
+model StoredData {
+  created_at                     DateTime?                      @default(now())
+  updated_at                     DateTime?                      @updatedAt
+  data                           String
+  course_id                      String
+  user_id                        String
+  course                         Course?                        @relation(fields: [course_id], references: [id])
+  user                           User?                          @relation(fields: [user_id], references: [id])
+
+  @@id([user_id, course_id])
+  @@map("stored_data")
+}
+
 model StudyModule {
   created_at                DateTime?                  @default(now())
   id                        String                     @id @default(uuid())
@@ -405,6 +419,7 @@ model User {
   user_organizations             UserOrganization[]
   verified_users                 VerifiedUser[]
   ab_enrollments                 AbEnrollment[]
+  stored_data                    StoredData[]
 
   @@map("user")
 }

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@prisma/client"
+
 import { UserInfo } from "../../domain/UserInfo"
 
 export const normalUser = {
@@ -612,5 +613,20 @@ export const openUniversityRegistrationLink: Prisma.OpenUniversityRegistrationLi
     course: { connect: { id: "00000000000000000000000000000666" } },
     link: "avoin-link",
     tiers: null,
+  },
+]
+
+export const storedData: Prisma.StoredDataCreateInput[] = [
+  {
+    // user1, course2
+    user: { connect: { id: "20000000000000000000000000000102" } },
+    course: { connect: { id: "00000000000000000000000000000001" } },
+    data: "user1_foo",
+  },
+  {
+    // user3, course1
+    user: { connect: { id: "20000000000000000000000000000104" } },
+    course: { connect: { id: "00000000000000000000000000000002" } },
+    data: "user3_foo",
   },
 ]

--- a/backend/tests/data/seed.ts
+++ b/backend/tests/data/seed.ts
@@ -1,23 +1,25 @@
 import type { PrismaClient } from "@prisma/client"
+
 import {
-  courses,
-  study_modules,
-  organizations,
-  users,
-  completions,
-  services,
-  userCourseSettings,
-  abStudies,
   abEnrollments,
-  exercises,
-  exerciseCompletions,
-  userCourseProgresses,
-  userCourseServiceProgresses,
-  emailTemplateThresholds,
+  abStudies,
+  completions,
   completionsRegistered,
   courseAliases,
+  courses,
+  emailTemplateThresholds,
+  exerciseCompletions,
+  exercises,
   openUniversityRegistrationLink,
-} from "."
+  organizations,
+  services,
+  storedData,
+  study_modules,
+  userCourseProgresses,
+  userCourseServiceProgresses,
+  userCourseSettings,
+  users,
+} from "./"
 
 type ExcludeInternalKeys<K> = K extends `$${string}` ? never : K
 
@@ -73,6 +75,7 @@ export const seed = async (prisma: PrismaClient) => {
     "openUniversityRegistrationLink",
     openUniversityRegistrationLink,
   )
+  const seededStoredData = await create("storedData", storedData)
 
   return {
     courses: seededCourses,
@@ -92,5 +95,6 @@ export const seed = async (prisma: PrismaClient) => {
     completionsRegistered: seededCompletionsRegistered,
     courseAliases: seededCourseAliases,
     openUniversityRegistrationLink: seededOpenUniversityRegistrationLink,
+    storedData: seededStoredData,
   }
 }


### PR DESCRIPTION
Unique for user/course combination. Can only POST now - `/api/stored-data/:slug` with user auth with `{ data: "data to post" }` as body.