### PR TITLE
register-completion/[slug] should now show correct tier registration links

### DIFF
--- a/backend/api/completions.ts
+++ b/backend/api/completions.ts
@@ -1,12 +1,12 @@
 import {
   Completion,
-  OpenUniversityRegistrationLink,
-  CourseTranslation,
   Course,
+  CourseTranslation,
+  OpenUniversityRegistrationLink,
 } from "@prisma/client"
-import { ApiContext } from "."
-import { getOrganization } from "../util/server-functions"
-import { getUser } from "../util/server-functions"
+
+import { getOrganization, getUser } from "../util/server-functions"
+import { ApiContext } from "./"
 
 const JSONStream = require("JSONStream")
 
@@ -131,6 +131,8 @@ export function completionTiers({ knex }: ApiContext) {
         .andWhere("user_id", user.id)
     )?.[0]
 
+    // TODO/FIXME: note - this now happily ignores completion_language and just gets the first one
+    // - as it's now only used in BAI, shouldn't be a problem?
     const tiers = (
       await knex
         .select<any, OpenUniversityRegistrationLink[]>("tiers")
@@ -143,7 +145,7 @@ export function completionTiers({ knex }: ApiContext) {
 
       for (let i = 0; i < t.length; i++) {
         if (t[i].tier === completion.tier) {
-          let tierRegister = (
+          const tierRegister = (
             await knex
               .select<any, OpenUniversityRegistrationLink[]>("link")
               .from("open_university_registration_link")
@@ -154,7 +156,7 @@ export function completionTiers({ knex }: ApiContext) {
 
           if (t[i].adjacent) {
             for (let j = 0; j < t[i].adjacent.length; j++) {
-              let adjRegister = (
+              const adjRegister = (
                 await knex
                   .select<any, OpenUniversityRegistrationLink[]>("link")
                   .from("open_university_registration_link")

--- a/backend/graphql/Completion/model.ts
+++ b/backend/graphql/Completion/model.ts
@@ -80,6 +80,11 @@ export const Completion = objectType({
           throw new Error("course not found")
         }
 
+        // TODO/FIXME:
+        // - register-completion/[slug] uses /api/completionTiers if there are tiers
+        // - this _always_ returns the parent course registration link, regardless of the tier
+        // - should this return the tier registration link?
+
         let filter
         if (
           !parent.completion_language ||

--- a/backend/tests/data/index.ts
+++ b/backend/tests/data/index.ts
@@ -603,7 +603,7 @@ export const openUniversityRegistrationLink: Prisma.OpenUniversityRegistrationLi
     course_code: "alias2",
     language: "en_US",
     course: { connect: { id: "00000000000000000000000000000001" } },
-    link: "avoin-link",
+    link: "avoin-link-alias2",
     tiers: null,
   },
   {
@@ -611,7 +611,7 @@ export const openUniversityRegistrationLink: Prisma.OpenUniversityRegistrationLi
     course_code: "alias3",
     language: "en_US",
     course: { connect: { id: "00000000000000000000000000000666" } },
-    link: "avoin-link",
+    link: "avoin-link-alias3",
     tiers: null,
   },
 ]

--- a/frontend/components/RegisterCompletionText.tsx
+++ b/frontend/components/RegisterCompletionText.tsx
@@ -118,7 +118,10 @@ function RegisterCompletionText({
             <Typography variant="body1" paragraph align="center">
               {tier.name}
             </Typography>
-            <LinkButton link={link} onRegistrationClick={onRegistrationClick} />
+            <LinkButton
+              link={tier.link}
+              onRegistrationClick={onRegistrationClick}
+            />
           </div>
         ))
       ) : (


### PR DESCRIPTION
Previously all the tier links were pointing to the parent course registration link.