### PR TITLE
fix user course summary to show handled course progress

### DIFF
--- a/backend/graphql/UserCourseSummary.ts
+++ b/backend/graphql/UserCourseSummary.ts
@@ -6,6 +6,9 @@ export const UserCourseSummary = objectType({
   definition(t) {
     t.id("course_id")
     t.id("user_id")
+    t.id("inherit_settings_from_id")
+    t.id("completions_handled_by_id")
+
     t.field("course", {
       type: "Course",
       resolve: async ({ course_id }, _, ctx) => {
@@ -20,13 +23,17 @@ export const UserCourseSummary = objectType({
     })
     t.field("completion", {
       type: "Completion",
-      resolve: async ({ user_id, course_id }, _, ctx) => {
+      resolve: async (
+        { user_id, course_id, completions_handled_by_id },
+        _,
+        ctx,
+      ) => {
         if (!user_id || !course_id) {
           throw new UserInputError("need to specify user_id and course_id")
         }
         const completions = await ctx.prisma.course
           .findUnique({
-            where: { id: course_id },
+            where: { id: completions_handled_by_id ?? course_id },
           })
           .completions({
             where: {


### PR DESCRIPTION
Main beef here - if we get the courses shown in the summary from `user_course_settings` and those are set up to utilize settings from some other course, then we don't get the correct progresses and all that, since they still reside in the language versions.

Changed to query all different courses that user has in the `exercise_completions`. This will probably mean there are multiple entries for one course if a user has, for some reason, completed exercises in different languages.