### PR TITLE
fixed websocket subscriber - node-redis api change

### DIFF
--- a/backend/wsServer.ts
+++ b/backend/wsServer.ts
@@ -106,7 +106,7 @@ const createSubscriber = async () => {
   const subscriber = redisClient?.duplicate()
   await subscriber?.connect()
 
-  subscriber?.subscribe("websocket", (_channel: any, message: any) => {
+  subscriber?.subscribe("websocket", (message: any) => {
     const data = JSON.parse(message)
     if (data instanceof Object && data.userId && data.courseId && data.type) {
       const userId = data.userId


### PR DESCRIPTION
`node-redis` apparently had switched the subscriber function parameters around, so it always got `webserver` as the message, which in turn crashed when something was using it, ie. `points` consumers. 