### PR TITLE
Use codecov binary instead of bash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: "Upload coverage"
           command: |
-            curl https://uploader.codecov.io/latest/linux/codecov -os /tmp/codecov
+            curl https://uploader.codecov.io/latest/linux/codecov -o /tmp/codecov
             chmod +x /tmp/codecov
             /tmp/codecov -F backend
       #- run:
@@ -222,7 +222,7 @@ jobs:
       - run:
           name: "Upload coverage"
           command: |
-            curl https://uploader.codecov.io/latest/linux/codecov -os /tmp/codecov
+            curl https://uploader.codecov.io/latest/linux/codecov -o /tmp/codecov
             chmod +x /tmp/codecov
             cd ~/project/auth
             /tmp/codecov -F auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: "Upload coverage"
           command: |
-            curl --output-dir /tmp -Os https://uploader.codecov.io/latest/linux/codecov
+            curl https://uploader.codecov.io/latest/linux/codecov -os /tmp/codecov
             chmod +x /tmp/codecov
             /tmp/codecov -F backend
       #- run:
@@ -222,7 +222,7 @@ jobs:
       - run:
           name: "Upload coverage"
           command: |
-            curl --output-dir /tmp -Os https://uploader.codecov.io/latest/linux/codecov
+            curl https://uploader.codecov.io/latest/linux/codecov -os /tmp/codecov
             chmod +x /tmp/codecov
             cd ~/project/auth
             /tmp/codecov -F auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,13 @@ jobs:
             - coverage
       - run:
           name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash)
+          command: |
+            curl --output-dir /tmp -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x /tmp/codecov
+            /tmp/codecov -F backend
+      #- run:
+      #    name: "Upload coverage"
+      #    command: bash <(curl -s https://codecov.io/bash)
 
   # could combine the artifacts in this step if needed, now the codecov/junit stuff combines automatically
   # upload_backend_coverage:
@@ -215,7 +221,12 @@ jobs:
           destination: auth-tests
       - run:
           name: "Upload coverage"
-          command: "cd ~/project/auth && bash <(curl -s https://codecov.io/bash)"
+          command: |
+            curl --output-dir /tmp -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x /tmp/codecov
+            cd ~/project/auth
+            /tmp/codecov -F auth
+          # command: "cd ~/project/auth && bash <(curl -s https://codecov.io/bash)"
       - run:
           name: "Push image if on master"
           command: "bin/push-docker-auth-image.sh"  


### PR DESCRIPTION
codecov bash will be deprecated soon. Ideally we'd want to use the codecov orb, but that's 3rd party and needs to be enabled in CircleCI organizational settings.