### PR TITLE
now registers new TMC user with random password on SAML signup

### DIFF
--- a/auth/src/handlers/__test__/signup.test.ts
+++ b/auth/src/handlers/__test__/signup.test.ts
@@ -25,6 +25,7 @@ describe("signup", () => {
       user: {},
       verified_user: {},
       tmc_user: undefined,
+      tmc_id: 1,
       message: "User created",
     },
   }
@@ -40,6 +41,7 @@ describe("signup", () => {
         },
         verified_user: {},
         tmc_user: undefined,
+        tmc_id: 1,
         message: "User or verified user already exists",
       },
     },
@@ -82,6 +84,32 @@ describe("signup", () => {
       }
 
       return okRegisterResponse
+    })
+    await handler(req, res, next)(undefined, testProfile)
+
+    expect(req.login).toHaveBeenCalledWith(testProfile, expect.any(Function))
+    expect(req.logout).toHaveBeenCalled()
+    expect(res.setMOOCCookies).toHaveBeenCalledWith({
+      access_token: "access_token",
+      mooc_token: "access_token",
+      admin: false,
+    })
+    expect(res.redirect).toHaveBeenCalledWith(`${FRONTEND_URL}/fi/`)
+  })
+
+  it("redirects to edit user details on non-successful TMC user creation", async () => {
+    mockedAxios.post.mockImplementation(async (url: string) => {
+      if (url.includes("token")) {
+        return okTokenResponse
+      }
+
+      return {
+        ...okRegisterResponse,
+        data: {
+          ...okRegisterResponse.data,
+          tmc_id: -1,
+        },
+      }
     })
     await handler(req, res, next)(undefined, testProfile)
 

--- a/backend/services/tmc.ts
+++ b/backend/services/tmc.ts
@@ -207,7 +207,7 @@ export const updateUser = async (
 export const getUsersByEmail = async (
   emails: string[],
 ): Promise<UserInfo[]> => {
-  return await axios.post(
+  const res = await axios.post(
     `${BASE_URL}/api/v8/users/basic_info_by_emails`,
     { emails },
     {
@@ -218,4 +218,5 @@ export const getUsersByEmail = async (
       },
     },
   )
+  return res?.data
 }


### PR DESCRIPTION
If that doesn't succeed, it'll prompt for the user details to register from frontend (which could fail again, though)  