### PR TITLE
Fix: template creation from course dashboard if another type existed

### DIFF
--- a/backend/graphql/Course/input.ts
+++ b/backend/graphql/Course/input.ts
@@ -39,7 +39,7 @@ export const CourseCreateArg = inputObjectType({
     t.int("points_needed")
     t.boolean("automatic_completions")
     t.boolean("automatic_completions_eligible_for_ects")
-    t.nullable.id("completion_email")
+    t.nullable.id("completion_email_id")
     t.nullable.id("inherit_settings_from")
     t.nullable.id("completions_handled_by")
     t.nullable.boolean("has_certificate")
@@ -50,7 +50,7 @@ export const CourseCreateArg = inputObjectType({
     t.int("tier")
     t.int("exercise_completions_needed")
     t.int("points_needed")
-    t.nullable.id("course_stats_email")
+    t.nullable.id("course_stats_email_id")
   },
 })
 
@@ -96,7 +96,7 @@ export const CourseUpsertArg = inputObjectType({
     t.int("points_needed")
     t.boolean("automatic_completions")
     t.boolean("automatic_completions_eligible_for_ects")
-    t.nullable.id("completion_email")
+    t.nullable.id("completion_email_id")
     t.nullable.id("inherit_settings_from")
     t.nullable.id("completions_handled_by")
     t.nullable.boolean("has_certificate")
@@ -107,6 +107,6 @@ export const CourseUpsertArg = inputObjectType({
     t.int("tier")
     t.int("exercise_completions_needed")
     t.int("points_needed")
-    t.nullable.id("course_stats_email")
+    t.nullable.id("course_stats_email_id")
   },
 })

--- a/backend/graphql/Course/mutations.ts
+++ b/backend/graphql/Course/mutations.ts
@@ -40,8 +40,8 @@ export const CourseMutations = extendType({
           inherit_settings_from,
           completions_handled_by,
           user_course_settings_visibilities,
-          completion_email,
-          course_stats_email,
+          completion_email_id,
+          course_stats_email_id,
         } = course
 
         let photo = null
@@ -62,7 +62,12 @@ export const CourseMutations = extendType({
 
         const newCourse = await ctx.prisma.course.create({
           data: {
-            ...omit(course, ["base64", "new_photo"]),
+            ...omit(course, [
+              "base64",
+              "new_photo",
+              "completion_email_id",
+              "course_stats_email_id",
+            ]),
             name: course.name ?? "",
             photo: !!photo ? { connect: { id: photo } } : undefined,
             course_translations: {
@@ -90,11 +95,11 @@ export const CourseMutations = extendType({
               create: user_course_settings_visibilities?.filter(isNotNull),
             },
             // don't think these will be passed by parameter, but let's be sure
-            completion_email: !!completion_email
-              ? { connect: { id: completion_email } }
+            completion_email: !!completion_email_id
+              ? { connect: { id: completion_email_id } }
               : undefined,
-            course_stats_email: !!course_stats_email
-              ? { connect: { id: course_stats_email } }
+            course_stats_email: !!course_stats_email_id
+              ? { connect: { id: course_stats_email_id } }
               : undefined,
           },
         })
@@ -134,13 +139,13 @@ export const CourseMutations = extendType({
           course_variants,
           course_aliases,
           study_modules,
-          completion_email,
+          completion_email_id,
           status,
           delete_photo,
           inherit_settings_from,
           completions_handled_by,
           user_course_settings_visibilities,
-          course_stats_email,
+          course_stats_email_id,
         } = course
         let { end_date } = course
 
@@ -299,6 +304,8 @@ export const CourseMutations = extendType({
               "new_slug",
               "new_photo",
               "delete_photo",
+              "completion_email_id",
+              "course_stats_email_id",
             ]),
             slug: new_slug ? new_slug : slug,
             end_date,
@@ -309,11 +316,11 @@ export const CourseMutations = extendType({
             open_university_registration_links: registrationLinkMutation,
             course_variants: courseVariantMutation,
             course_aliases: courseAliasMutation,
-            completion_email: completion_email
-              ? { connect: { id: completion_email } }
+            completion_email: completion_email_id
+              ? { connect: { id: completion_email_id } }
               : undefined,
-            course_stats_email: course_stats_email
-              ? { connect: { id: course_stats_email } }
+            course_stats_email: course_stats_email_id
+              ? { connect: { id: course_stats_email_id } }
               : undefined,
             inherit_settings_from: inheritMutation,
             completions_handled_by: handledMutation,

--- a/frontend/components/Profile/VerifiedUsers/VerifiedUser.tsx
+++ b/frontend/components/Profile/VerifiedUsers/VerifiedUser.tsx
@@ -1,11 +1,14 @@
-import { Card, Typography } from "@mui/material"
-import styled from "@emotion/styled"
-import { ProfileUserOverView_currentUser_verified_users } from "/static/types/generated/ProfileUserOverView"
+// import { ProfileUserOverView_currentUser_verified_users } from "/static/types/generated/ProfileUserOverView"
 import React from "react"
+
 import { CardTitle } from "/components/Text/headers"
 
+import styled from "@emotion/styled"
+import { Card, Typography } from "@mui/material"
+
+// FIXME/DELETE: we don't have the verified user thing implemented for now so these types aren't generated
 interface VerifiedUserProps {
-  data: ProfileUserOverView_currentUser_verified_users
+  data: any // ProfileUserOverView_currentUser_verified_users
 }
 
 const VerifiedUserCard = styled(Card)`

--- a/frontend/components/Profile/VerifiedUsers/VerifiedUsers.tsx
+++ b/frontend/components/Profile/VerifiedUsers/VerifiedUsers.tsx
@@ -1,4 +1,4 @@
-import { ProfileUserOverView_currentUser_verified_users } from "/static/types/generated/ProfileUserOverView"
+// import { ProfileUserOverView_currentUser_verified_users } from "/static/types/generated/ProfileUserOverView"
 import Link from "next/link"
 import { useRouter } from "next/router"
 
@@ -13,8 +13,9 @@ import VerifiedUser from "./VerifiedUser"
 
 const isProduction = process.env.NODE_ENV === "production"
 
+// FIXME/DELETE: we don't have the verified user thing implemented for now so these types aren't generated
 interface VerifiedUsersProps {
-  data?: ProfileUserOverView_currentUser_verified_users[]
+  data?: any[] // ProfileUserOverView_currentUser_verified_users[]
 }
 
 const Container = styled(Paper)`

--- a/frontend/static/types/generated/ProfileUserOverView.ts
+++ b/frontend/static/types/generated/ProfileUserOverView.ts
@@ -7,27 +7,6 @@
 // GraphQL query operation: ProfileUserOverView
 // ====================================================
 
-export interface ProfileUserOverView_currentUser_verified_users_organization_organization_translations {
-  __typename: "OrganizationTranslation"
-  language: string
-  name: string
-}
-
-export interface ProfileUserOverView_currentUser_verified_users_organization {
-  __typename: "Organization"
-  slug: string
-  organization_translations: ProfileUserOverView_currentUser_verified_users_organization_organization_translations[]
-}
-
-export interface ProfileUserOverView_currentUser_verified_users {
-  __typename: "VerifiedUser"
-  id: string
-  organization: ProfileUserOverView_currentUser_verified_users_organization | null
-  created_at: any | null
-  personal_unique_code: string
-  display_name: string | null
-}
-
 export interface ProfileUserOverView_currentUser_completions_course_photo {
   __typename: "Image"
   uncompressed: string
@@ -75,7 +54,6 @@ export interface ProfileUserOverView_currentUser {
   last_name: string | null
   student_number: string | null
   email: string
-  verified_users: ProfileUserOverView_currentUser_verified_users[]
   completions: ProfileUserOverView_currentUser_completions[] | null
   research_consent: boolean | null
 }

--- a/frontend/static/types/generated/globalTypes.ts
+++ b/frontend/static/types/generated/globalTypes.ts
@@ -34,10 +34,10 @@ export interface CourseCreateArg {
   automatic_completions?: boolean | null
   automatic_completions_eligible_for_ects?: boolean | null
   base64?: boolean | null
-  completion_email?: string | null
+  completion_email_id?: string | null
   completions_handled_by?: string | null
   course_aliases?: (CourseAliasCreateInput | null)[] | null
-  course_stats_email?: string | null
+  course_stats_email_id?: string | null
   course_translations?: (CourseTranslationCreateInput | null)[] | null
   course_variants?: (CourseVariantCreateInput | null)[] | null
   ects?: string | null
@@ -95,10 +95,10 @@ export interface CourseUpsertArg {
   automatic_completions?: boolean | null
   automatic_completions_eligible_for_ects?: boolean | null
   base64?: boolean | null
-  completion_email?: string | null
+  completion_email_id?: string | null
   completions_handled_by?: string | null
   course_aliases?: (CourseAliasUpsertInput | null)[] | null
-  course_stats_email?: string | null
+  course_stats_email_id?: string | null
   course_translations?: (CourseTranslationUpsertInput | null)[] | null
   course_variants?: (CourseVariantUpsertInput | null)[] | null
   delete_photo?: boolean | null


### PR DESCRIPTION
Apparently if one type of email template (course stats, completion) already existed for a course, then creating another type errored. This was due to erroneous data passed on to the mutation, which, in turn, was _kind of_ due to unwisely selected mutation parameters.