### PR TITLE
Feat: add email template for emails for started/not completed users

### DIFF
--- a/backend/bin/kafkaConsumer/common/EmailTemplater/EmailTemplater.ts
+++ b/backend/bin/kafkaConsumer/common/EmailTemplater/EmailTemplater.ts
@@ -14,6 +14,8 @@ export class EmailTemplater {
     started_course_count: Templates.StartedCourseCount,
     completed_course_count: Templates.CompletedCourseCount,
     at_least_one_exercise_count: Templates.AtLeastOneExerciseCount,
+    at_least_one_exercise_but_not_completed_emails:
+      Templates.AtLeastOneExerciseButNotCompletedEmails,
     current_date: Templates.CurrentDate,
   }
   emailTemplate: EmailTemplate

--- a/backend/bin/kafkaConsumer/common/EmailTemplater/sendEmailTemplate.ts
+++ b/backend/bin/kafkaConsumer/common/EmailTemplater/sendEmailTemplate.ts
@@ -27,12 +27,15 @@ export async function sendEmailTemplateToUser(
     },
   }
   let transporter = nodemailer.createTransport(options)
+
+  const text = await ApplyTemplate(template, user)
+
   // send mail with defined transport object
   let info = await transporter.sendMail({
     from: SMTP_FROM, // sender address
     to: user.email, // list of receivers
     subject: template.title ?? undefined, // Subject line
-    text: await ApplyTemplate(template, user), // plain text body
+    text, // plain text body
     html: template.html_body ?? undefined, // html body
   })
   console.log("Message sent: %s", info.messageId)

--- a/backend/bin/kafkaConsumer/common/EmailTemplater/templates/CourseStats.ts
+++ b/backend/bin/kafkaConsumer/common/EmailTemplater/templates/CourseStats.ts
@@ -103,3 +103,55 @@ export class AtLeastOneExerciseCount extends Template {
     return atLeastOneExercise
   }
 }
+
+export class AtLeastOneExerciseButNotCompletedEmails extends Template {
+  async resolve() {
+    const course = await this.prisma.course.findFirst({
+      where: { course_stats_email: { id: this.emailTemplate.id } },
+    })
+
+    if (!course) {
+      return ""
+    }
+
+    const courseOwnership = await this.prisma.courseOwnership.findFirst({
+      where: {
+        course_id: course.id,
+        user_id: this.user.id,
+      },
+    })
+
+    if (!courseOwnership) {
+      throw new Error("no permission - user is not the owner of this course")
+    }
+
+    const atLeastOneExerciseButNotCompletedEmails = await redisify<string>(
+      async () => {
+        const result = await this.prisma.$queryRaw<Array<{ email: string }>>`
+            SELECT DISTINCT u.email
+              FROM exercise_completion ec
+              JOIN exercise e ON ec.exercise_id = e.id
+              JOIN "user" u ON ec.user_id = u.id
+              WHERE 
+                e.course_id = ${course.id} 
+              AND
+                u.id NOT IN (
+                  SELECT DISTINCT(user_id)
+                    FROM completion c
+                    WHERE c.course_id = ${course.id}
+                    AND user_id IS NOT NULL
+                );
+          `
+
+        return result?.map((entry) => entry.email).join("\n")
+      },
+      {
+        prefix: "atleastoneexercisebutnotcompletedemails",
+        expireTime: 60 * 60, // hour,
+        key: `${course.id}`,
+      },
+    )
+
+    return atLeastOneExerciseButNotCompletedEmails
+  }
+}

--- a/frontend/pages/email-templates/[id].tsx
+++ b/frontend/pages/email-templates/[id].tsx
@@ -4,7 +4,7 @@ import CollapseButton from "/components/Buttons/CollapseButton"
 import { WideContainer } from "/components/Container"
 import CustomSnackbar from "/components/CustomSnackbar"
 import Spinner from "/components/Spinner"
-import { SubtitleNoBackground } from "/components/Text/headers"
+import { CardTitle, SubtitleNoBackground } from "/components/Text/headers"
 import {
   DeleteEmailTemplateMutation,
   UpdateEmailTemplateMutation,
@@ -21,17 +21,72 @@ import Router from "next/router"
 import { DeleteEmailTemplate } from "static/types/generated/DeleteEmailTemplate"
 
 import { useApolloClient, useQuery } from "@apollo/client"
-import { Button, Collapse, Paper, TextField } from "@mui/material"
+import styled from "@emotion/styled"
+import {
+  Button,
+  Card,
+  CardContent,
+  Collapse,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material"
 
-const templateValues = [
-  "grade",
-  "completion_link",
-  "started_course_count",
-  "completed_course_count",
-  "at_least_one_exercise_count",
-  "at_least_one_exercise_but_not_completed_emails",
-  "current_date",
+interface TemplateType {
+  name: string
+  description?: string
+  types?: string[]
+}
+
+const templateNames: Record<string, string> = {
+  "course-stats": "Course stats",
+  completion: "Completion",
+  threshold: "Threshold",
+}
+
+const templateValues: Array<TemplateType> = [
+  {
+    name: "grade",
+    description: "Grade given to student, taken from the completion",
+  },
+  {
+    name: "completion_link",
+    description: "Link to register the completion for the course",
+  },
+  {
+    name: "started_course_count",
+    description:
+      "Number of distinct students that have started this course, ie. have settings attached to them - not necessarily completed any exercises",
+    types: ["course-stats"],
+  },
+  {
+    name: "completed_course_count",
+    description: "Number of distinct students that have completed this course",
+    types: ["course-stats"],
+  },
+  {
+    name: "at_least_one_exercise_count",
+    description:
+      "Number of distinct students that have completed at least one exercise in this course",
+    types: ["course-stats"],
+  },
+  {
+    name: "at_least_one_exercise_but_not_completed_emails",
+    description:
+      "Emails of students that have completed at least one exercise in this course, but not completed the course. Requires ownership of the course to use.",
+    types: ["course-stats"],
+  },
+  {
+    name: "current_date",
+    description: "Current date",
+  },
 ]
+
+const TemplateList = styled.div`
+  * + * {
+    margin-top: 0.5rem;
+  }
+`
 
 const EmailTemplateView = () => {
   // TODO: Get rid of any
@@ -210,18 +265,52 @@ const EmailTemplateView = () => {
                 onClick={() => setIsHelpOpen((s) => !s)}
               />
               <Collapse in={isHelpOpen}>
-                <p>
-                  You can use template values in the email body by adding them
-                  inside double curly brackets, like <code>{`{{ this }}`}</code>
-                  . Available template values:
-                  <ul>
-                    {templateValues.map((value) => (
-                      <li>
-                        <code>{value}</code>
-                      </li>
-                    ))}
-                  </ul>
-                </p>
+                <div style={{ margin: "0.5rem", padding: "0.5rem" }}>
+                  <Typography variant="subtitle2">
+                    You can use these template values in the email:
+                  </Typography>
+                  <TemplateList>
+                    {templateValues
+                      .filter((value) => {
+                        if (value.types?.length && templateType) {
+                          return value.types.includes(templateType)
+                        }
+                        return true
+                      })
+                      .map((value) => (
+                        <Card key={value.name} style={{ padding: "0.5rem" }}>
+                          <CardTitle>
+                            <code>
+                              {`{{ `}
+                              {value.name}
+                              {` }}`}
+                            </code>
+                          </CardTitle>
+                          {(value.description || value.types?.length) && (
+                            <CardContent>
+                              <Typography variant="body1">
+                                {value.description}
+                              </Typography>
+                              {value.types?.length && (
+                                <p>
+                                  Limited to template type
+                                  {value.types.length > 1 ? "s" : ""}{" "}
+                                  {value.types.map((type, index) => (
+                                    <>
+                                      {index > 0 ? ", " : ""}
+                                      <strong>
+                                        {templateNames[type] ?? type}
+                                      </strong>
+                                    </>
+                                  ))}
+                                </p>
+                              )}
+                            </CardContent>
+                          )}
+                        </Card>
+                      ))}
+                  </TemplateList>
+                </div>
               </Collapse>
               <br></br>
               <br></br>

--- a/frontend/pages/email-templates/[id].tsx
+++ b/frontend/pages/email-templates/[id].tsx
@@ -29,6 +29,7 @@ const templateValues = [
   "started_course_count",
   "completed_course_count",
   "at_least_one_exercise_count",
+  "at_least_one_exercise_but_not_completed_emails",
   "current_date",
 ]
 


### PR DESCRIPTION
In course stats email, the template string `{{ at_least_one_exercise_but_not_completed_emails }}` now renders the list of emails of students that have started the course but have not completed. This is only available for those who are the owners of the course, ie. have an entry in the `CourseOwnership` table.