### PR TITLE
Fix: prisma erroring on distinct

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["selectRelationCount"]
+  previewFeatures = ["selectRelationCount", "distinct"]
 }
 
 datasource db {


### PR DESCRIPTION
Add `distinct` to prisma preview features as we're using a _really old_ version.