### PR TITLE
Fix: update BAI extra information on the parent progress

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -34,6 +34,10 @@ export function apiRouter(ctx: ApiContext) {
     .get("/progress/:id", progressController.progress)
     .get("/progressv2/:idOrSlug", progressController.progressV2)
     .get("/tierprogress/:id", progressController.tierProgress)
+    .get(
+      "/recheck-bai-progresses",
+      progressController.recheckBAIUserCourseProgresses,
+    )
     .get("/user-course-progress/:slug", progressController.userCourseProgress)
     .get("/user-course-settings/:slug", userCourseSettingsController.get)
     .post("/user-course-settings/:slug", userCourseSettingsController.post)

--- a/backend/bin/kafkaConsumer/common/userCourseProgress/BAI/completion.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/BAI/completion.ts
@@ -57,9 +57,13 @@ export const checkBAICompletion = async ({
   )
 
   // TODO: update project completion to all tier progresses?
+  // TODO/FIXME: BAI should check progress from the _handler_ here,
+  // even though the handler is in this case the completion handler course.
+  // Add a separate progress_handled_by, even though that would only apply here
+  // as the tiers have their own progress?
   const existingProgresses = await prisma.course
     .findUnique({
-      where: { id: course.id },
+      where: { id: handler?.id ?? course.id },
     })
     .user_course_progresses({
       where: {
@@ -73,7 +77,7 @@ export const checkBAICompletion = async ({
     await prisma.userCourseProgress.create({
       data: {
         course: {
-          connect: { id: course.id },
+          connect: { id: handler?.id ?? course.id },
         },
         user: { connect: { id: user.id } },
         ...newProgress,

--- a/backend/bin/kafkaConsumer/common/userCourseProgress/generateUserCourseProgress.ts
+++ b/backend/bin/kafkaConsumer/common/userCourseProgress/generateUserCourseProgress.ts
@@ -55,7 +55,7 @@ export const generateUserCourseProgress = async ({
     context,
   })
 
-  await context.prisma.userCourseProgress.update({
+  return await context.prisma.userCourseProgress.update({
     where: { id: userCourseProgress.id },
     data: {
       progress: combined.progress as any, // errors unless typed as any


### PR DESCRIPTION
It was updating the `extra` field in the tier progresses, but as the course expects the newest information to be in the parent, this caused stale progresses.

Also created an endpoint to recheck BAI progresses, which is untested. Fixed the stale progresses manually in the database.