### PR TITLE
Fix possible miscalculation of exercise_progress

### DIFF
--- a/backend/graphql/UserCourseProgress.ts
+++ b/backend/graphql/UserCourseProgress.ts
@@ -95,7 +95,6 @@ export const UserCourseProgress = objectType({
 
         const courseProgress = normalizeProgress(progress)
 
-        // TODO: this should probably also only count completed exercises!
         const exercises = await ctx.prisma.course
           .findUnique({
             where: {
@@ -107,6 +106,7 @@ export const UserCourseProgress = objectType({
               NOT: {
                 deleted: true,
               },
+              max_points: { gt: 0 },
             },
             select: {
               id: true,
@@ -116,6 +116,7 @@ export const UserCourseProgress = objectType({
                   user_id,
                 },
                 take: 1,
+                orderBy: [{ timestamp: "desc" }, { updated_at: "desc" }],
               },
             },
           })


### PR DESCRIPTION
Under `user_course_progress`, that is. Don't count exercises that are either deleted or don't give any points; get the newest exercise completion only, even if we do prune these.