### PR TITLE
refactor some user course summary queries to raw sql

### DIFF
--- a/backend/graphql/Course/model.ts
+++ b/backend/graphql/Course/model.ts
@@ -108,7 +108,7 @@ export const Course = objectType({
             where: { id: parent.id },
           })
           .exercises({
-            ...(!includeDeleted ? { where: { deleted: { not: true } } } : {}),
+            ...(!includeDeleted && { where: { deleted: { not: true } } }),
           })
       },
     })


### PR DESCRIPTION
In hope this removes some redundancies - especially the `UserCourseProgress` `exercise_progress` queried too much. The current one could also be simplified since we don't actually care about the exercise completion, just if there are any for the given exercise.