### PR TITLE
Refactor: memoize frontend context values

### DIFF
--- a/frontend/components/CertificateButton.tsx
+++ b/frontend/components/CertificateButton.tsx
@@ -26,7 +26,6 @@ import {
   CurrentUserDocument,
   CurrentUserOverviewDocument,
   UpdateUserNameDocument,
-  UserOverviewFieldsFragment,
 } from "/graphql/generated"
 
 const StyledButton = styled(Button)`
@@ -133,7 +132,7 @@ const reducer = (state: CertificateState, action: Action): CertificateState => {
 
 const CertificateButton = ({ course }: CertificateProps) => {
   const t = useTranslator(CompletionsTranslations)
-  const { currentUser, updateUser } = useContext(LoginStateContext)
+  const { currentUser, updateUser, admin } = useContext(LoginStateContext)
   const { addAlert } = useContext(AlertContext)
 
   const [state, dispatch] = useReducer(reducer, initialState)
@@ -195,10 +194,9 @@ const CertificateButton = ({ course }: CertificateProps) => {
           },
         })
         updateUser({
-          ...(currentUser || { email: "", id: "" }),
-          first_name: firstName,
-          last_name: lastName,
-        } as UserOverviewFieldsFragment)
+          user: { ...currentUser!, first_name: firstName, last_name: lastName },
+          admin,
+        })
         dispatch({ type: "UPDATED_NAME", payload: res })
       }
 

--- a/frontend/components/CompletedCourseCard.tsx
+++ b/frontend/components/CompletedCourseCard.tsx
@@ -50,6 +50,7 @@ interface CourseCardProps {
 function formatDateTime(date: string) {
   const dateToFormat = new Date(date)
   const formattedDate = dateToFormat.toUTCString()
+
   return formattedDate
 }
 

--- a/frontend/components/CompletedCourseCard.tsx
+++ b/frontend/components/CompletedCourseCard.tsx
@@ -4,7 +4,10 @@ import Button from "@mui/material/Button"
 import Grid from "@mui/material/Grid"
 import Typography from "@mui/material/Typography"
 
-import { mapLangToLanguage } from "/components/DataFormatFunctions"
+import {
+  formatDateTime,
+  mapLangToLanguage,
+} from "/components/DataFormatFunctions"
 import { ClickableDiv } from "/components/Surfaces/ClickableCard"
 import CompletionsTranslations from "/translations/completions"
 import ProfileTranslations from "/translations/profile"
@@ -45,13 +48,6 @@ interface CourseCardProps {
   completion: CompletionDetailedFieldsFragment & {
     course: CourseWithPhotoCoreFieldsFragment
   }
-}
-
-function formatDateTime(date: string) {
-  const dateToFormat = new Date(date)
-  const formattedDate = dateToFormat.toUTCString()
-
-  return formattedDate
 }
 
 function CompletedCourseCard(props: CourseCardProps) {

--- a/frontend/components/Dashboard/CompletionCard.tsx
+++ b/frontend/components/Dashboard/CompletionCard.tsx
@@ -12,6 +12,8 @@ import {
   Typography,
 } from "@mui/material"
 
+import { formatDateTime } from "/components/DataFormatFunctions"
+
 import { CompletionsQueryNodeFieldsFragment } from "/graphql/generated"
 
 //map language code stored to database to human readable language
@@ -19,13 +21,6 @@ const MapLangToLanguage: Record<string, string> = {
   en_US: "English",
   fi_FI: "Finnish",
   sv_SE: "Swedish",
-}
-
-//format registration time stored to db to human readable text
-function formatDateTime(date: string) {
-  const dateToFormat = new Date(date)
-  const formattedDate = dateToFormat.toUTCString()
-  return formattedDate
 }
 
 const StyledIcon = styled(Icon)`

--- a/frontend/components/Dashboard/Editor2/Common/index.tsx
+++ b/frontend/components/Dashboard/Editor2/Common/index.tsx
@@ -3,6 +3,7 @@ import {
   PropsWithChildren,
   useCallback,
   useContext,
+  useMemo,
 } from "react"
 
 import { omit } from "lodash"
@@ -76,6 +77,8 @@ export const TabSection = ({
   ...props
 }: PropsWithChildren<TabSectionProps> &
   React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) => {
+  const contextValue = useMemo(() => ({ tab }), [tab])
+
   return (
     <section
       style={{
@@ -84,13 +87,7 @@ export const TabSection = ({
       }}
       {...omit(props, "style")}
     >
-      <TabContext.Provider
-        value={{
-          tab,
-        }}
-      >
-        {children}
-      </TabContext.Provider>
+      <TabContext.Provider value={contextValue}>{children}</TabContext.Provider>
     </section>
   )
 }

--- a/frontend/components/Dashboard/Editor2/Course/index.tsx
+++ b/frontend/components/Dashboard/Editor2/Course/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { FormProvider, SubmitErrorHandler, useForm } from "react-hook-form"
 
@@ -139,21 +139,24 @@ function CourseEditor({ course, courses, studyModules }: CourseEditProps) {
     await deleteCourse({ variables: { id } })
   }, [])
 
+  const contextValue = useMemo(
+    () => ({
+      status,
+      tab,
+      initialValues: defaultValues,
+      setStatus,
+      setTab,
+      onSubmit,
+      onError,
+      onCancel,
+      onDelete,
+    }),
+    [status, tab, defaultValues],
+  )
+
   return (
     <FormProvider {...methods}>
-      <EditorContext.Provider
-        value={{
-          status,
-          setStatus,
-          tab,
-          setTab,
-          onSubmit,
-          onError,
-          onCancel,
-          onDelete,
-          initialValues: defaultValues,
-        }}
-      >
+      <EditorContext.Provider value={contextValue}>
         <CourseEditForm
           course={course}
           courses={courses}

--- a/frontend/components/Dashboard/Editor2/StudyModule/index.tsx
+++ b/frontend/components/Dashboard/Editor2/StudyModule/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import Router from "next/router"
 import { FormProvider, SubmitErrorHandler, useForm } from "react-hook-form"
@@ -135,21 +135,24 @@ const StudyModuleEdit = ({ module }: StudyModuleEditProps) => {
     [],
   )
 
+  const contextValue = useMemo(
+    () => ({
+      status,
+      tab: 0,
+      initialValues: defaultValues,
+      setStatus,
+      setTab: () => {},
+      onSubmit,
+      onError,
+      onCancel,
+      onDelete,
+    }),
+    [status, defaultValues],
+  )
+
   return (
     <FormProvider {...methods}>
-      <EditorContext.Provider
-        value={{
-          tab: 0,
-          setTab: () => {},
-          status,
-          setStatus,
-          onSubmit,
-          onError,
-          onCancel,
-          onDelete,
-          initialValues: defaultValues,
-        }}
-      >
+      <EditorContext.Provider value={contextValue}>
         <StudyModuleEditForm />
       </EditorContext.Provider>
     </FormProvider>

--- a/frontend/components/DataFormatFunctions.tsx
+++ b/frontend/components/DataFormatFunctions.tsx
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon"
+import { useRouter } from "next/router"
 
 export const mapLangToLanguage: Record<string, string> = {
   en_US: "English",
@@ -6,7 +7,13 @@ export const mapLangToLanguage: Record<string, string> = {
   sv_SE: "Swedish",
 }
 
-export function formatDateTime(date: string) {
-  var dt = DateTime.fromISO(date)
-  return dt.toLocaleString()
+export function formatDateTime(date: string, overrideLocale?: string) {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { locale: routerLocale } = useRouter()
+  const locale = overrideLocale ?? routerLocale
+
+  return DateTime.fromISO(date).toLocaleString(
+    {},
+    locale ? { locale } : undefined,
+  )
 }

--- a/frontend/components/Profile/ProfileCompletionsDisplay.tsx
+++ b/frontend/components/Profile/ProfileCompletionsDisplay.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link"
 
+import { Typography } from "@mui/material"
+
 import { FormSubmitButton } from "/components/Buttons/FormSubmitButton"
 import { CompletionListItem } from "/components/Home/Completions"
 import ProfileTranslations from "/translations/profile"
@@ -20,6 +22,9 @@ const ProfileCompletionsDisplay = (props: CompletionsProps) => {
       {completions.slice(0, 10).map((c) => (
         <CompletionListItem course={c.course!} completion={c} key={c.id} />
       ))}
+      {completions.length === 0 && (
+        <Typography>{t("nocompletionsText")}</Typography>
+      )}
       <Link href={`/profile/completions`} passHref>
         <FormSubmitButton variant="text" fullWidth>
           {t("seeCompletions")}

--- a/frontend/components/User/Points/PointsList.tsx
+++ b/frontend/components/User/Points/PointsList.tsx
@@ -1,20 +1,20 @@
-import { useQuery } from "@apollo/client"
+import { ApolloError } from "@apollo/client"
 
 import NoPointsErrorMessage from "./NoPointsErrorMessage"
 import PointsListGrid from "./PointsListGrid"
 import ErrorMessage from "/components/ErrorMessage"
 import Spinner from "/components/Spinner"
 
-import { CurrentUserProgressesDocument } from "/graphql/generated"
+import { CurrentUserProgressesQuery } from "/graphql/generated"
 
 interface PointsListProps {
   showOnlyTen?: boolean
+  data?: CurrentUserProgressesQuery
+  loading: boolean
+  error?: ApolloError
 }
 
-function PointsList(props: PointsListProps) {
-  const { data, error, loading } = useQuery(CurrentUserProgressesDocument)
-  const { showOnlyTen } = props
-
+function PointsList({ data, error, loading, showOnlyTen }: PointsListProps) {
   if (error) {
     return <ErrorMessage />
   }

--- a/frontend/contexts/LoginStateContext.ts
+++ b/frontend/contexts/LoginStateContext.ts
@@ -1,13 +1,16 @@
 import { createContext } from "react"
 
-import { UserOverviewFieldsFragment } from "/graphql/generated"
+import { CurrentUserQuery } from "/graphql/generated"
 
 export interface LoginState {
   loggedIn: boolean
   logInOrOut: () => void
   admin: boolean
-  currentUser?: UserOverviewFieldsFragment
-  updateUser: (user: UserOverviewFieldsFragment) => void
+  currentUser?: CurrentUserQuery["currentUser"]
+  updateUser: (data: {
+    user: CurrentUserQuery["currentUser"]
+    admin?: boolean
+  }) => void
 }
 
 const LoginStateContext = createContext<LoginState>({

--- a/frontend/lib/with-enumerating-anchors.tsx
+++ b/frontend/lib/with-enumerating-anchors.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react"
+
 import AnchorContext, { Anchor } from "/contexts/AnchorContext"
 
 const withEnumeratingAnchors =
@@ -14,8 +16,10 @@ const withEnumeratingAnchors =
       }
     }
 
+    const contextValue = useMemo(() => ({ anchors, addAnchor }), [anchors])
+
     return (
-      <AnchorContext.Provider value={{ anchors, addAnchor }}>
+      <AnchorContext.Provider value={contextValue}>
         <Component {...(props as T)}>{props.children}</Component>
       </AnchorContext.Provider>
     )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23539,6 +23539,21 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
+      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -41521,6 +41536,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
       "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
+      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+      "optional": true
     }
   }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -72,7 +72,6 @@ type AppReducerAction =
 const reducer = (state: AppState, action: AppReducerAction) => {
   switch (action.type) {
     case "addAlert":
-      console.log("adding alert", action.payload)
       const nextAlertId = state.nextAlertId + 1
       return {
         ...state,
@@ -80,7 +79,6 @@ const reducer = (state: AppState, action: AppReducerAction) => {
         nextAlertId,
       }
     case "removeAlert":
-      console.log("removing alert", action.payload)
       return {
         ...state,
         alerts: state.alerts.filter((alert) => alert.id !== action.payload.id),

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -25,9 +25,7 @@ import theme from "/src/theme"
 import PagesTranslations from "/translations/pages"
 import { useTranslator } from "/util/useTranslator"
 
-import {
-  CurrentUserQuery,
-} from "/graphql/generated"
+import { CurrentUserQuery } from "/graphql/generated"
 
 fontAwesomeConfig.autoAddCss = false
 

--- a/frontend/pages/courses.tsx
+++ b/frontend/pages/courses.tsx
@@ -83,22 +83,22 @@ function useCourseSearch() {
   } = useQuery(HandlerCoursesDocument)
 
   useEffect(() => {
-    const params = []
+    const searchParams = new URLSearchParams()
 
     if (notEmptyOrEmptyString(searchVariables.search)) {
-      params.push(
-        `search=${encodeURIComponent(searchVariables.search.toString() ?? "")}`,
+      searchParams.set(
+        "search",
+        encodeURIComponent(searchVariables.search.toString() ?? ""),
       )
     }
     if (notEmptyOrEmptyString(searchVariables.handledBy)) {
-      params.push(
-        `handledBy=${encodeURIComponent(
-          searchVariables.handledBy.toString() ?? "",
-        )}`,
+      searchParams.set(
+        "handledBy",
+        encodeURIComponent(searchVariables.handledBy.toString() ?? ""),
       )
     }
     if (!searchVariables.hidden) {
-      params.push("hidden=false")
+      searchParams.set("hidden", "false")
     }
 
     // Active and Upcoming is the default status so if it's set, don't add it
@@ -110,11 +110,14 @@ function useCourseSearch() {
         searchVariables.status.includes(CourseStatus.Upcoming)
       )
     ) {
-      params.push(`status=${searchVariables.status.join(",")}`)
+      searchParams.set("status", searchVariables.status.join(","))
     }
 
-    const query = params.length ? `?${params.join("&")}` : ""
+    const query = searchParams.toString().length
+      ? `?${searchParams.toString()}`
+      : ""
     const href = `/courses/${query}`
+
     if (router?.asPath !== href) {
       router.push(href, undefined, { shallow: true })
     }

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useState } from "react"
+import React, { ChangeEvent, useCallback, useEffect, useState } from "react"
 
 import { useRouter } from "next/router"
 
@@ -40,6 +40,7 @@ const tabs: Record<string, number> = {
   completions: 1,
   settings: 2,
 }
+
 const tabsByNumber: Record<number, string> = Object.entries(tabs).reduce(
   (acc, [key, value]) => ({ ...acc, [value]: key }),
   {},
@@ -51,21 +52,27 @@ function Profile() {
 
   const [tab, setTab] = useState(tabs[_tab] ?? 0)
 
-  const handleTabChange = (_: ChangeEvent<{}>, newValue: number) => {
-    // setTab(newValue)
-    router.replace(
-      router.pathname,
-      `/profile${newValue > 0 ? `?tab=${tabsByNumber[newValue]}` : ""}`,
-      { shallow: true },
-    )
-  }
+  const handleTabChange = useCallback(
+    (_: ChangeEvent<{}>, newValue: number) => {
+      setTab(newValue)
+      router.replace(
+        router.pathname,
+        `/profile${newValue > 0 ? `?tab=${tabsByNumber[newValue]}` : ""}`,
+        { shallow: true },
+      )
+    },
+    [],
+  )
+
   useEffect(() => {
     if (tabs[_tab] !== tab) {
       setTab(tabs[_tab] ?? 0)
     }
   }, [_tab])
 
-  const { data, error, loading } = useQuery(CurrentUserOverviewDocument)
+  const { data, error, loading } = useQuery(CurrentUserOverviewDocument, {
+    ssr: false,
+  })
 
   useBreadcrumbs([
     {

--- a/frontend/pages/profile/points.tsx
+++ b/frontend/pages/profile/points.tsx
@@ -1,3 +1,5 @@
+import { useQuery } from "@apollo/client"
+
 import Container from "/components/Container"
 import { H1NoBackground } from "/components/Text/headers"
 import PointsList from "/components/User/Points/PointsList"
@@ -6,8 +8,11 @@ import withSignedIn from "/lib/with-signed-in"
 import CoursesTranslations from "/translations/courses"
 import { useTranslator } from "/util/useTranslator"
 
+import { CurrentUserProgressesDocument } from "/graphql/generated"
+
 function Points() {
   const t = useTranslator(CoursesTranslations)
+  const { data, error, loading } = useQuery(CurrentUserProgressesDocument)
 
   useBreadcrumbs([
     {
@@ -26,7 +31,7 @@ function Points() {
         <H1NoBackground variant="h1" component="h1" align="center">
           {t("points")}
         </H1NoBackground>
-        <PointsList />
+        <PointsList data={data} error={error} loading={loading} />
       </Container>
     </section>
   )

--- a/frontend/pages/users/[id]/summary.tsx
+++ b/frontend/pages/users/[id]/summary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState } from "react"
+import React, { useEffect, useMemo, useReducer, useState } from "react"
 
 import { useQuery } from "@apollo/client"
 import { Paper } from "@mui/material"
@@ -30,6 +30,7 @@ function UserSummaryView() {
   const id = useQueryParameter("id")
   const { loading, error, data } = useQuery(UserSummaryDocument, {
     variables: { upstream_id: Number(id) },
+    ssr: false,
   })
 
   useBreadcrumbs([
@@ -58,6 +59,8 @@ function UserSummaryView() {
     })
   }, [data])
 
+  const contextValue = useMemo(() => ({ state, dispatch }), [state])
+
   if (error) {
     return (
       <Container>
@@ -68,12 +71,7 @@ function UserSummaryView() {
 
   return (
     <Container>
-      <CollapseContext.Provider
-        value={{
-          state,
-          dispatch,
-        }}
-      >
+      <CollapseContext.Provider value={contextValue}>
         <Paper style={{ marginBottom: "0.5rem" }}>
           <FilterMenu
             searchVariables={searchVariables}

--- a/frontend/pages/users/search/index.tsx
+++ b/frontend/pages/users/search/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { useRouter } from "next/router"
 
@@ -19,7 +19,6 @@ const UserSearch = () => {
   const textParam = useQueryParameter("text", false)
   const pageParam = parseInt(useQueryParameter("page", false), 10) || 0
   const rowsParam = parseInt(useQueryParameter("rowsPerPage", false), 10) || 10
-
   const [searchVariables, setSearchVariables] = useState<SearchVariables>({
     search: textParam,
     first: rowsParam,
@@ -54,11 +53,15 @@ const UserSearch = () => {
   useBreadcrumbs(crumbs)
 
   useEffect(() => {
-    const params = [
-      rowsPerPage !== 10 ? `rowsPerPage=${rowsPerPage}` : "",
-      page > 0 ? `page=${page}` : "",
-    ].filter((v) => !!v)
-    const query = params.length ? `?${params.join("&")}` : ""
+    const searchParams = new URLSearchParams()
+    if (rowsPerPage !== 10) {
+      searchParams.append("rowsPerPage", rowsPerPage.toString())
+    }
+    if (page > 0) {
+      searchParams.append("page", page.toString())
+    }
+    const query =
+      searchParams.toString().length > 0 ? `?${searchParams.toString()}` : ""
     const href =
       searchVariables.search !== ""
         ? `/users/search/${encodeURIComponent(searchVariables.search)}${query}`
@@ -76,21 +79,23 @@ const UserSearch = () => {
     }
   }, [searchVariables, rowsPerPage, page])
 
+  const contextValue = useMemo(
+    () => ({
+      data,
+      loading,
+      page,
+      rowsPerPage,
+      searchVariables,
+      setPage,
+      setSearchVariables,
+      setRowsPerPage,
+    }),
+    [data, loading, page, rowsPerPage, searchVariables],
+  )
   return (
     <>
       <Container>
-        <UserSearchContext.Provider
-          value={{
-            data,
-            loading,
-            page,
-            rowsPerPage,
-            searchVariables,
-            setPage,
-            setSearchVariables,
-            setRowsPerPage,
-          }}
-        >
+        <UserSearchContext.Provider value={contextValue}>
           <SearchForm />
         </UserSearchContext.Provider>
       </Container>

--- a/frontend/util/useQueryParameter.tsx
+++ b/frontend/util/useQueryParameter.tsx
@@ -7,22 +7,7 @@ export function useQueryParameter(parameter: string, check: boolean = true) {
     return ""
   }
 
-  // combine params in the url with the dynamic params
-  const params: Record<string, any> = (
-    (router?.asPath?.split("?")[1] || "").split("&") || []
-  ).reduce(
-    (acc, curr) => {
-      const [key, val] = curr.split("=")
-
-      return {
-        ...acc,
-        [key]: val,
-      }
-    },
-    { ...router?.query },
-  )
-
-  const checkingParameter = params?.[parameter]
+  const checkingParameter = router?.query?.[parameter]
 
   if (checkingParameter === null || checkingParameter === undefined) {
     if (check) {


### PR DESCRIPTION
And other small fixes, like using `ssr: false` for some queries that need not be run on server, using `URLSearchParams` to build queries and removing alerts actually working.