### PR TITLE
add requesting user tierprogress to api needed for certificates

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -28,6 +28,7 @@ export function apiRouter(ctx: ApiContext) {
     .get("/progress/:idOrSlug", progressController.progress)
     .get("/progressv2/:idOrSlug", progressController.progressV2)
     .get("/tierprogress/:idOrSlug", progressController.tierProgress)
+    .get("/tierProgress/:idOrSlug/:user_id", progressController.tierProgress)
     .get(
       "/recheck-bai-progresses",
       progressController.recheckBAIUserCourseProgresses,

--- a/backend/api/routes/progress.ts
+++ b/backend/api/routes/progress.ts
@@ -179,21 +179,41 @@ export class ProgressController extends Controller {
     })
   }
 
-  tierProgress = async (req: Request<{ idOrSlug: string }>, res: Response) => {
-    const { idOrSlug } = req.params
+  tierProgress = async (
+    req: Request<{ idOrSlug: string; user_id?: string }>,
+    res: Response,
+  ) => {
+    const { idOrSlug, user_id } = req.params
     const { knex } = this.ctx
 
     if (!idOrSlug) {
       return res.status(400).json({ message: "must provide course id or slug" })
     }
 
-    const getUserResult = await this.getUser(req, res)
+    let user: User | null = null
 
-    if (getUserResult.isErr()) {
-      return getUserResult.error
+    if (user_id) {
+      const adminRes = await this.requireAdmin(req, res)
+
+      if (adminRes !== true) {
+        return adminRes
+      }
+      user = (
+        await knex("user")
+          .select<any, User[]>("id")
+          .where("upstream_id", user_id)
+      )?.[0]
+      if (!user) {
+        return res.status(404).json({ message: "user not found" })
+      }
+    } else {
+      const getUserResult = await this.getUser(req, res)
+
+      if (getUserResult.isErr()) {
+        return getUserResult.error
+      }
+      user = getUserResult.value.user
     }
-
-    const { user } = getUserResult.value
 
     let id = isId(idOrSlug) ? idOrSlug : undefined
 

--- a/backend/bin/fetchUserAppDatum.ts
+++ b/backend/bin/fetchUserAppDatum.ts
@@ -231,7 +231,7 @@ const saveOther = async (p: any) => {
   })
 }
 
-const getUserFromTmcAndSaveToDB = async (user_id: Number, tmc: TmcClient) => {
+const getUserFromTmcAndSaveToDB = async (user_id: number, tmc: TmcClient) => {
   let details: UserInfo | undefined
 
   try {

--- a/backend/bin/fetchUserFieldValues.ts
+++ b/backend/bin/fetchUserFieldValues.ts
@@ -96,7 +96,7 @@ const fetcUserFieldValues = async () => {
   process.exit(0)
 }
 
-const getUserFromTmcAndSaveToDB = async (user_id: Number, tmc: TmcClient) => {
+const getUserFromTmcAndSaveToDB = async (user_id: number, tmc: TmcClient) => {
   let details: UserInfo | undefined
 
   try {

--- a/backend/services/tmc.ts
+++ b/backend/services/tmc.ts
@@ -99,7 +99,7 @@ export default class TmcClient {
     return userInfo
   }
 
-  async getUserDetailsById(id: Number): Promise<UserInfo> {
+  async getUserDetailsById(id: number): Promise<UserInfo> {
     const res = await axios.get(
       `${TMC_HOST}/api/v8/users/${id}?show_user_fields=1&extra_fields=1`,
       {


### PR DESCRIPTION
Certificates server asks MOOC.fi for user tier progress through `/api/tierprogress/:idOrSlug`, which currently only returns the current user data.

To facilitate admins querying user data, added `/api/tierprogress/:idOrSlug/:user_id`.