### PR TITLE
Refactor certificate checking; add endpoint to update certificate id

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -25,6 +25,10 @@ export function apiRouter(ctx: ApiContext) {
     )
     .post("/recheck-completion", completionController.recheckCompletion)
     .post("/register-completions", completionController.registerCompletions)
+    .post(
+      "/completions/:slug/certificate",
+      completionController.updateCertificateId,
+    )
     .get("/progress/:idOrSlug", progressController.progress)
     .get("/progressv2/:idOrSlug", progressController.progressV2)
     .get("/tierprogress/:idOrSlug", progressController.tierProgress)

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -61,6 +61,10 @@ export const UPDATE_USER_SECRET = process.env.UPDATE_USER_SECRET
 export const AVOIN_COURSE_URL = process.env.AVOIN_COURSE_URL
 export const AVOIN_TOKEN = process.env.AVOIN_TOKEN
 
+// certificates api
+export const CERTIFICATES_URL =
+  process.env.CERTIFICATES_URL || "https://certificates.mooc.fi"
+
 // userAppDatum related
 export const CONFIG_NAME = process.env.CONFIG_NAME
 

--- a/backend/graphql/CertificateAvailability.ts
+++ b/backend/graphql/CertificateAvailability.ts
@@ -1,0 +1,10 @@
+import { objectType } from "nexus"
+
+export const CertificateAvailability = objectType({
+  name: "CertificateAvailability",
+  definition(t) {
+    t.boolean("completed_course")
+    t.nullable.string("existing_certificate")
+    t.nullable.boolean("honors")
+  },
+})

--- a/backend/graphql/Completion/index.ts
+++ b/backend/graphql/Completion/index.ts
@@ -1,4 +1,4 @@
-// generated Thu Aug 11 2022 17:12:07 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Tue Sep 27 2022 11:23:58 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/Completion/model.ts
+++ b/backend/graphql/Completion/model.ts
@@ -4,6 +4,11 @@ import { objectType } from "nexus"
 import { UserCourseProgress } from "@prisma/client"
 
 import { BAIParentCourse, BAITierCourses } from "../../config/courseConfig"
+import {
+  checkCertificate,
+  checkCertificateForUser,
+} from "../../services/certificates"
+import { redisify } from "../../services/redis"
 
 export const Completion = objectType({
   name: "Completion",
@@ -141,6 +146,72 @@ export const Completion = objectType({
             (p: UserCourseProgress) => (p?.extra as any)?.projectCompletion,
           ) ?? false
         )
+      },
+    })
+
+    t.field("certificate_availability", {
+      type: "CertificateAvailability",
+      resolve: async ({ course_id, user_upstream_id }, _, ctx) => {
+        if (!course_id) {
+          return null
+        }
+
+        const course = await ctx.prisma.course.findUnique({
+          where: { id: course_id },
+        })
+
+        if (!course) {
+          return null
+        }
+
+        const accessToken =
+          ctx.req?.headers?.authorization?.replace("Bearer ", "") ?? ""
+
+        let certificate_availability
+        if (user_upstream_id !== ctx.user?.upstream_id) {
+          if (!ctx.user?.administrator) {
+            throw new ForbiddenError("Cannot query other users' certificates")
+          }
+
+          if (!user_upstream_id) {
+            return null
+          }
+
+          certificate_availability = await redisify(
+            async () =>
+              checkCertificateForUser(
+                course.slug,
+                user_upstream_id,
+                accessToken,
+              ),
+            {
+              prefix: "certificateavailability",
+              expireTime: 10,
+              key: `${course.slug}-${user_upstream_id}`,
+            },
+            {
+              logger: ctx.logger,
+            },
+          )
+        } else {
+          certificate_availability = await redisify(
+            async () => checkCertificate(course.slug, accessToken),
+            {
+              prefix: "certificateavailability",
+              expireTime: 10,
+              key: `${course.slug}-${ctx.user?.upstream_id}`,
+            },
+            {
+              logger: ctx.logger,
+            },
+          )
+        }
+
+        if (!certificate_availability) {
+          return null
+        }
+
+        return certificate_availability
       },
     })
   },

--- a/backend/graphql/Course/index.ts
+++ b/backend/graphql/Course/index.ts
@@ -1,4 +1,4 @@
-// generated Thu Aug 11 2022 17:12:07 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Tue Sep 27 2022 11:23:58 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/StudyModule/index.ts
+++ b/backend/graphql/StudyModule/index.ts
@@ -1,4 +1,4 @@
-// generated Thu Aug 11 2022 17:12:07 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Tue Sep 27 2022 11:23:58 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/User/index.ts
+++ b/backend/graphql/User/index.ts
@@ -1,4 +1,4 @@
-// generated Thu Aug 11 2022 17:12:07 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Tue Sep 27 2022 11:23:58 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -1,7 +1,8 @@
-// generated Thu Aug 11 2022 17:12:07 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Tue Sep 27 2022 11:23:58 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./ABEnrollment"
 export * from "./ABStudy"
+export * from "./CertificateAvailability"
 export * from "./Completion"
 export * from "./CompletionRegistered"
 export * from "./Course"

--- a/backend/services/certificates.ts
+++ b/backend/services/certificates.ts
@@ -1,13 +1,10 @@
 import axios from "axios"
 
-const BASE_URL = "https://certificates.mooc.fi"
+import { CERTIFICATES_URL } from "../config"
 
-export const checkCertificate = async (
-  courseId: string,
-  accessToken: string,
-) => {
+export const checkCertificate = async (slug: string, accessToken: string) => {
   const res = await axios.get(
-    `${BASE_URL}/certificate-availability/${courseId}`,
+    `${CERTIFICATES_URL}/certificate-availability/${slug}`,
     {
       headers: {
         "Content-Type": "application/json",
@@ -19,20 +16,41 @@ export const checkCertificate = async (
   return res?.data
 }
 
-export const createCertificate = async (
-  courseId: string,
+export const checkCertificateForUser = async (
+  slug: string,
+  upstream_id: number,
   accessToken: string,
 ) => {
-  try {
-    const res = await axios.post(`${BASE_URL}/create/${courseId}`, undefined, {
+  const res = await axios.get(
+    `${CERTIFICATES_URL}/admin/certificate-availability/${slug}/${upstream_id}`,
+    {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
-    })
+    },
+  )
+
+  return res?.data
+}
+
+export const createCertificate = async (slug: string, accessToken: string) => {
+  try {
+    const res = await axios.post(
+      `${CERTIFICATES_URL}/create/${slug}`,
+      undefined,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    )
     return res?.data
   } catch (e) {
     console.log(e)
     return null
   }
 }
+
+// TODO: create certificate for user, needs an endpoint in certificates as well

--- a/frontend/components/CertificateButton.tsx
+++ b/frontend/components/CertificateButton.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useContext, useState } from "react"
 
 import styled from "@emotion/styled"
+import WarningIcon from "@mui/icons-material/Warning"
 import {
   CircularProgress,
   DialogActions,
   DialogContentText,
+  Paper,
   TextField,
+  Typography,
 } from "@mui/material"
 import Button from "@mui/material/Button"
 import Dialog from "@mui/material/Dialog"
@@ -13,11 +16,17 @@ import DialogContent from "@mui/material/DialogContent"
 import DialogTitle from "@mui/material/DialogTitle"
 
 import AlertContext from "/contexts/AlertContext"
+import LoginStateContext from "/contexts/LoginStateContext"
 import { useCertificate } from "/hooks/useCertificate"
 import CompletionsTranslations from "/translations/completions"
 import { useTranslator } from "/util/useTranslator"
 
-import { CourseCoreFieldsFragment } from "/graphql/generated"
+import {
+  CompletionDetailedFieldsFragment,
+  CourseCoreFieldsFragment,
+} from "/graphql/generated"
+
+const CERTIFICATES_URL = "https://certificates.mooc.fi"
 
 const StyledButton = styled(Button)`
   margin: auto;
@@ -30,25 +39,36 @@ const StyledDialog = styled(Dialog)`
 const StyledTextField = styled(TextField)`
   margin-bottom: 1rem;
 `
-
+const NoCertificateGeneratedNote = styled(Paper)`
+  background-color: #f05361;
+  color: #ffffff;
+  padding: 0.5rem;
+  margin: auto;
+  gap: 0.5rem;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+`
 interface CertificateProps {
   course: CourseCoreFieldsFragment
+  completion: CompletionDetailedFieldsFragment
 }
 
-const CertificateButton = ({ course }: CertificateProps) => {
+const CertificateButton = ({ course, completion }: CertificateProps) => {
   const t = useTranslator(CompletionsTranslations)
+  const { currentUser } = useContext(LoginStateContext)
   const { addAlert } = useContext(AlertContext)
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const onCertificateCheckSuccess = useCallback(() => {
-    addAlert({
-      title: t("nameFormErrorTitle"),
-      message: t("nameFormErrorCheckCertificate"),
-      severity: "error",
-    })
-  }, [])
+  const isOtherUser = currentUser?.id !== completion.user_id
+
   const onReceiveGeneratedCertificateSuccess = useCallback(() => {
     setDialogOpen(false)
+    addAlert({
+      title: t("certificateGeneratedTitle"),
+      message: t("certificateGeneratedMessage"),
+      severity: "success",
+    })
   }, [])
   const onReceiveGeneratedCertificateError = useCallback(() => {
     setDialogOpen(false)
@@ -69,7 +89,7 @@ const CertificateButton = ({ course }: CertificateProps) => {
     isNameEmpty,
   } = useCertificate({
     course,
-    onCertificateCheckSuccess,
+    completion,
     onReceiveGeneratedCertificateSuccess,
     onReceiveGeneratedCertificateError,
   })
@@ -79,7 +99,7 @@ const CertificateButton = ({ course }: CertificateProps) => {
       <StyledButton
         onClick={() =>
           window.open(
-            `https://certificates.mooc.fi/validate/${state.certificateId}`,
+            `${CERTIFICATES_URL}/validate/${state.certificateId}`,
             "_blank",
           )
         }
@@ -89,10 +109,34 @@ const CertificateButton = ({ course }: CertificateProps) => {
     )
   }
 
+  // TODO: when admin is able to generate certificate for user, remove the following
+  if (
+    completion?.certificate_availability?.completed_course &&
+    !completion?.certificate_availability?.existing_certificate &&
+    isOtherUser
+  ) {
+    return (
+      <>
+        <NoCertificateGeneratedNote>
+          <WarningIcon />
+          <Typography variant="h4">
+            {t("eligibleForCertificateButNotGenerated")}
+          </Typography>
+        </NoCertificateGeneratedNote>
+      </>
+    )
+  }
   return (
     <>
-      <StyledButton onClick={() => setDialogOpen(true)}>
-        {t("createCertificate")}
+      <StyledButton
+        disabled={state.status !== "IDLE"}
+        onClick={() => setDialogOpen(true)}
+      >
+        {state.status !== "IDLE" ? (
+          <CircularProgress size={24} color="secondary" />
+        ) : (
+          t("createCertificate")
+        )}
       </StyledButton>
       <StyledDialog
         open={dialogOpen}

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -85,9 +85,9 @@ const RenderCards: FC<any> = () => {
 
   return (
     <>
-      {data?.userDetailsContains?.edges?.map((row) => (
+      {data?.userDetailsContains?.edges?.map((row, index) => (
         <DataCard
-          key={row?.node?.upstream_id || Math.random() * 9999999}
+          key={row?.node?.upstream_id ?? index}
           row={row?.node ?? undefined}
         />
       ))}

--- a/frontend/components/Dashboard/Users/Summary/UserPointsSummary.tsx
+++ b/frontend/components/Dashboard/Users/Summary/UserPointsSummary.tsx
@@ -84,12 +84,11 @@ export default function UserPointsSummary({
         />
       </Paper>
       {filteredData.length === 0 ? <div>No data</div> : null}
-      {sortBy(filteredData, (stats) => stats?.course?.name).map((entry) => (
-        <CourseEntry
-          key={entry.course?.id ?? Math.random() * 9999}
-          data={entry}
-        />
-      ))}
+      {sortBy(filteredData, (stats) => stats?.course?.name).map(
+        (entry, index) => (
+          <CourseEntry key={entry.course?.id ?? index} data={entry} />
+        ),
+      )}
       <Dialog
         fullWidth
         maxWidth="md"

--- a/frontend/components/Home/Completions/CompletionListItem.tsx
+++ b/frontend/components/Home/Completions/CompletionListItem.tsx
@@ -1,4 +1,3 @@
-import CertificateButton from "components/CertificateButton"
 import { CardSubtitle, CardTitle } from "components/Text/headers"
 import Link from "next/link"
 
@@ -6,12 +5,14 @@ import styled from "@emotion/styled"
 import DoneIcon from "@mui/icons-material/Done"
 import { Avatar, Button, Paper } from "@mui/material"
 
+import CertificateButton from "/components/CertificateButton"
 import {
   formatDateTime,
   mapLangToLanguage,
 } from "/components/DataFormatFunctions"
 import ProfileTranslations from "/translations/profile"
 import { addDomain } from "/util/imageUtils"
+import notEmpty from "/util/notEmpty"
 import { useTranslator } from "/util/useTranslator"
 
 import {
@@ -85,6 +86,7 @@ const ButtonColumn = styled(Column)`
     justify-content: flex-end;
   }
 `
+
 export const CompletionListItem = ({
   completion,
   course,
@@ -107,24 +109,28 @@ export const CompletionListItem = ({
                 <strong>{`${t("completedDate")}${formatDateTime(
                   completion.completion_date,
                 )}`}</strong>
-                {completion.completion_language ? (
-                  <CardSubtitle>
-                    {`${t("completionLanguage")} ${
-                      mapLangToLanguage[
-                        completion?.completion_language ?? ""
-                      ] || completion.completion_language
-                    }`}
-                  </CardSubtitle>
-                ) : null}
-                {completion.tier !== null && completion.tier !== undefined ? (
-                  <CardSubtitle>
-                    {`${t("completionTier")} ${t(
-                      // @ts-ignore: tier
-                      `completionTier-${completion.tier}`,
-                    )}`}
-                  </CardSubtitle>
-                ) : null}
               </CardSubtitle>
+              {completion.completion_language ? (
+                <CardSubtitle>
+                  {`${t("completionLanguage")} ${
+                    mapLangToLanguage[completion?.completion_language ?? ""] ||
+                    completion.completion_language
+                  }`}
+                </CardSubtitle>
+              ) : null}
+              {notEmpty(completion.tier) && (
+                <CardSubtitle>
+                  {`${t("completionTier")} ${t(
+                    // @ts-ignore: tier
+                    `completionTier-${completion.tier}`,
+                  )}`}
+                </CardSubtitle>
+              )}
+              {notEmpty(completion?.grade) && (
+                <CardSubtitle>
+                  {t("grade")} <strong>{completion.grade}</strong>
+                </CardSubtitle>
+              )}
             </Column>
           </Row>
           <Row>
@@ -182,7 +188,7 @@ export const CompletionListItem = ({
             </Link>
           ) : null}
           {hasCertificate && course ? (
-            <CertificateButton course={course} />
+            <CertificateButton course={course} completion={completion} />
           ) : null}
         </ButtonColumn>
       </Row>

--- a/frontend/graphql/fragments/completion.fragments.graphql
+++ b/frontend/graphql/fragments/completion.fragments.graphql
@@ -26,6 +26,9 @@ fragment CompletionDetailedFields on Completion {
   completions_registered {
     ...CompletionRegisteredCoreFields
   }
+  certificate_availability {
+    ...CertificateAvailabilityFields
+  }
 }
 
 fragment CompletionDetailedFieldsWithCourse on Completion {
@@ -66,4 +69,10 @@ fragment CompletionsQueryConnectionFields on QueryCompletionsPaginated_type_Conn
       ...CompletionsQueryNodeFields
     }
   }
+}
+
+fragment CertificateAvailabilityFields on CertificateAvailability {
+  completed_course
+  existing_certificate
+  honors
 }

--- a/frontend/graphql/generated/index.ts
+++ b/frontend/graphql/generated/index.ts
@@ -16,7 +16,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>
 }
-// Generated on 2022-08-17T16:32:35+03:00
+// Generated on 2022-09-27T12:44:49+03:00
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -88,8 +88,16 @@ export type AbStudyUpsertInput = {
   name: Scalars["String"]
 }
 
+export type CertificateAvailability = {
+  __typename?: "CertificateAvailability"
+  completed_course: Maybe<Scalars["Boolean"]>
+  existing_certificate: Maybe<Scalars["String"]>
+  honors: Maybe<Scalars["Boolean"]>
+}
+
 export type Completion = {
   __typename?: "Completion"
+  certificate_availability: Maybe<CertificateAvailability>
   certificate_id: Maybe<Scalars["String"]>
   completion_date: Maybe<Scalars["DateTime"]>
   completion_language: Maybe<Scalars["String"]>
@@ -1187,15 +1195,12 @@ export type OrganizationOrderByInput = {
   email?: InputMaybe<SortOrder>
   hidden?: InputMaybe<SortOrder>
   id?: InputMaybe<SortOrder>
-  join_organization_email_template_id?: InputMaybe<SortOrder>
   logo_content_type?: InputMaybe<SortOrder>
   logo_file_name?: InputMaybe<SortOrder>
   logo_file_size?: InputMaybe<SortOrder>
   logo_updated_at?: InputMaybe<SortOrder>
   phone?: InputMaybe<SortOrder>
   pinned?: InputMaybe<SortOrder>
-  required_confirmation?: InputMaybe<SortOrder>
-  required_organization_email?: InputMaybe<SortOrder>
   secret_key?: InputMaybe<SortOrder>
   slug?: InputMaybe<SortOrder>
   tmc_created_at?: InputMaybe<SortOrder>
@@ -2112,6 +2117,12 @@ export type CompletionDetailedFieldsFragment = {
       slug: string
     } | null
   }>
+  certificate_availability: {
+    __typename?: "CertificateAvailability"
+    completed_course: boolean | null
+    existing_certificate: string | null
+    honors: boolean | null
+  } | null
 }
 
 export type CompletionDetailedFieldsWithCourseFragment = {
@@ -2167,6 +2178,12 @@ export type CompletionDetailedFieldsWithCourseFragment = {
       slug: string
     } | null
   }>
+  certificate_availability: {
+    __typename?: "CertificateAvailability"
+    completed_course: boolean | null
+    existing_certificate: string | null
+    honors: boolean | null
+  } | null
 }
 
 export type CompletionsQueryNodeFieldsFragment = {
@@ -2280,6 +2297,13 @@ export type CompletionsQueryConnectionFieldsFragment = {
       }>
     } | null
   } | null> | null
+}
+
+export type CertificateAvailabilityFieldsFragment = {
+  __typename?: "CertificateAvailability"
+  completed_course: boolean | null
+  existing_certificate: string | null
+  honors: boolean | null
 }
 
 export type CompletionRegisteredCoreFieldsFragment = {
@@ -3002,6 +3026,12 @@ export type UserOverviewFieldsFragment = {
         slug: string
       } | null
     }>
+    certificate_availability: {
+      __typename?: "CertificateAvailability"
+      completed_course: boolean | null
+      existing_certificate: string | null
+      honors: boolean | null
+    } | null
   }> | null
 }
 
@@ -3292,6 +3322,12 @@ export type UserCourseSummaryCoreFieldsFragment = {
         slug: string
       } | null
     }>
+    certificate_availability: {
+      __typename?: "CertificateAvailability"
+      completed_course: boolean | null
+      existing_certificate: string | null
+      honors: boolean | null
+    } | null
   } | null
 }
 
@@ -4761,6 +4797,12 @@ export type UserSummaryQuery = {
             slug: string
           } | null
         }>
+        certificate_availability: {
+          __typename?: "CertificateAvailability"
+          completed_course: boolean | null
+          existing_certificate: string | null
+          honors: boolean | null
+        } | null
       } | null
     } | null> | null
   } | null
@@ -4837,6 +4879,12 @@ export type CurrentUserOverviewQuery = {
           slug: string
         } | null
       }>
+      certificate_availability: {
+        __typename?: "CertificateAvailability"
+        completed_course: boolean | null
+        existing_certificate: string | null
+        honors: boolean | null
+      } | null
     }> | null
   } | null
 }
@@ -4914,6 +4962,12 @@ export type UserOverviewQuery = {
           slug: string
         } | null
       }>
+      certificate_availability: {
+        __typename?: "CertificateAvailability"
+        completed_course: boolean | null
+        existing_certificate: string | null
+        honors: boolean | null
+      } | null
     }> | null
   } | null
 }
@@ -5384,6 +5438,30 @@ export const CompletionRegisteredCoreFieldsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<CompletionRegisteredCoreFieldsFragment, unknown>
+export const CertificateAvailabilityFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CertificateAvailabilityFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "CertificateAvailability" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "completed_course" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "existing_certificate" },
+          },
+          { kind: "Field", name: { kind: "Name", value: "honors" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CertificateAvailabilityFieldsFragment, unknown>
 export const CompletionDetailedFieldsFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -5412,6 +5490,22 @@ export const CompletionDetailedFieldsFragmentDoc = {
                   name: {
                     kind: "Name",
                     value: "CompletionRegisteredCoreFields",
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "certificate_availability" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "FragmentSpread",
+                  name: {
+                    kind: "Name",
+                    value: "CertificateAvailabilityFields",
                   },
                 },
               ],
@@ -9805,6 +9899,7 @@ export const UserSummaryDocument = {
     ...CompletionDetailedFieldsFragmentDoc.definitions,
     ...CompletionCoreFieldsFragmentDoc.definitions,
     ...CompletionRegisteredCoreFieldsFragmentDoc.definitions,
+    ...CertificateAvailabilityFieldsFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<UserSummaryQuery, UserSummaryQueryVariables>
 export const CurrentUserOverviewDocument = {
@@ -9839,6 +9934,7 @@ export const CurrentUserOverviewDocument = {
     ...CompletionDetailedFieldsFragmentDoc.definitions,
     ...CompletionCoreFieldsFragmentDoc.definitions,
     ...CompletionRegisteredCoreFieldsFragmentDoc.definitions,
+    ...CertificateAvailabilityFieldsFragmentDoc.definitions,
     ...CourseWithPhotoCoreFieldsFragmentDoc.definitions,
     ...CourseCoreFieldsFragmentDoc.definitions,
     ...ImageCoreFieldsFragmentDoc.definitions,
@@ -9899,6 +9995,7 @@ export const UserOverviewDocument = {
     ...CompletionDetailedFieldsFragmentDoc.definitions,
     ...CompletionCoreFieldsFragmentDoc.definitions,
     ...CompletionRegisteredCoreFieldsFragmentDoc.definitions,
+    ...CertificateAvailabilityFieldsFragmentDoc.definitions,
     ...CourseWithPhotoCoreFieldsFragmentDoc.definitions,
     ...CourseCoreFieldsFragmentDoc.definitions,
     ...ImageCoreFieldsFragmentDoc.definitions,

--- a/frontend/lib/with-apollo-client/get-apollo.ts
+++ b/frontend/lib/with-apollo-client/get-apollo.ts
@@ -17,6 +17,7 @@ import notEmpty from "/util/notEmpty"
 let apolloClient: ApolloClient<NormalizedCacheObject> | null = null
 
 const production = process.env.NODE_ENV === "production"
+const isBrowser = typeof window !== "undefined"
 
 function create(initialState: any, originalAccessToken?: string) {
   const authLink = setContext((_, { headers }) => {
@@ -97,11 +98,11 @@ function create(initialState: any, originalAccessToken?: string) {
   })
 
   return new ApolloClient<NormalizedCacheObject>({
-    link: process.browser
+    link: isBrowser
       ? ApolloLink.from([errorLink, authLink.concat(uploadLink)])
       : authLink.concat(uploadLink),
     cache: cache.restore(initialState || {}),
-    ssrMode: !process.browser, // isBrowser,
+    ssrMode: !isBrowser,
     ssrForceFetchDelay: 100,
     defaultOptions: {
       watchQuery: {

--- a/frontend/translations/completions/en.json
+++ b/frontend/translations/completions/en.json
@@ -9,5 +9,8 @@
     "nameFormCancel":"Cancel",
     "nameFormErrorTitle": "Error",
     "nameFormErrorCheckCertificate": "There was an error checking the certificate. Please try again later.",
-    "nameFormErrorSubmit": "There was an error submitting. Please try again later."
+    "nameFormErrorSubmit": "There was an error submitting. Please try again later.",
+    "eligibleForCertificateButNotGenerated": "User is eligible for certificate but hasn't generated it yet",
+    "certificateGeneratedTitle": "Certificate generated",
+    "certificateGeneratedMessage": "Your certificate was generated successfully! Press 'Show your certificate' to view it."
 }

--- a/frontend/translations/completions/fi.json
+++ b/frontend/translations/completions/fi.json
@@ -9,5 +9,8 @@
     "nameFormCancel":"Peruuta",
     "nameFormErrorTitle": "Virhe",
     "nameFormErrorCheckCertificate": "Virhe sertifikaatin tarkistuksessa. Yritä myöhemmin uudelleen.",
-    "nameFormErrorSubmit": "Virhe tietojen lähetyksessä. Yritä myöhemmin uudelleen."
+    "nameFormErrorSubmit": "Virhe tietojen lähetyksessä. Yritä myöhemmin uudelleen.",
+    "eligibleForCertificateButNotGenerated": "Oikeutettu sertifikaattiin, mutta sitä ei ole generoitu.",
+    "certificateGeneratedTitle": "Sertifikaatti generoitu",
+    "certificateGeneratedMessage": "Sertifikaattisi on nyt generoitu! Paina 'Näytä sertifikaatti' nähdäksesi sen."
 }

--- a/frontend/translations/profile/en.json
+++ b/frontend/translations/profile/en.json
@@ -36,5 +36,6 @@
     "no": "no",
     "progress": "Progress",
     "totalProgress": "Total progress",
-    "exercisesCompleted": "Exercises completed"
+    "exercisesCompleted": "Exercises completed",
+    "grade": "grade:"
 }

--- a/frontend/translations/profile/fi.json
+++ b/frontend/translations/profile/fi.json
@@ -36,5 +36,6 @@
     "no": "ei",
     "progress": "Edistyminen",
     "totalProgress": "Kokonaisedistyminen",
-    "exercisesCompleted": "Tehtyjä tehtäviä"
+    "exercisesCompleted": "Tehtyjä tehtäviä",
+    "grade": "arvosana:"
 }


### PR DESCRIPTION
Instead of calling the Certificates API to check for certificate availability in the frontend, have it in the backend as a field in Completion model. The field is very lightly cached to not spam the other API (which, in turn, calls MOOC.fi API) but also not to get stale too easily.

* admins can now see the user certificate availability in the completion box. Currently they cannot generate the certificate for the user from there, but there's a note visible if the user is eligible for the certificate but one hasn't been generated.
* added an endpoint to which Certificates can send the generated certificate ID so the user completion can be updated with it. The information as such isn't used anywhere yet.
* grade, if present, is now visible in the completion box