### PR TITLE
Fix: if exercise.deleted was null, then it wouldn't appear

### DIFF
--- a/backend/graphql/Course/model.ts
+++ b/backend/graphql/Course/model.ts
@@ -108,7 +108,10 @@ export const Course = objectType({
             where: { id: parent.id },
           })
           .exercises({
-            ...(!includeDeleted && { where: { deleted: { not: true } } }),
+            ...(!includeDeleted && {
+              // same here: { deleted: { not: true } } will skip null
+              where: { OR: [{ deleted: false }, { deleted: null }] },
+            }),
           })
       },
     })

--- a/backend/graphql/User/model.ts
+++ b/backend/graphql/User/model.ts
@@ -268,9 +268,10 @@ export const User = objectType({
           })
           .exercise_completions({
             where: {
-              ...(!includeDeleted
-                ? { exercise: { deleted: { not: true } } }
-                : {}),
+              ...(!includeDeleted && {
+                // same here: { deleted: { not: true } } will skip null
+                exercise: { OR: [{ deleted: false }, { deleted: null }] },
+              }),
             },
             distinct: "exercise_id",
             orderBy: [{ timestamp: "desc" }, { updated_at: "desc" }],

--- a/backend/graphql/UserCourseSummary.ts
+++ b/backend/graphql/UserCourseSummary.ts
@@ -115,7 +115,10 @@ export const UserCourseSummary = objectType({
             where: {
               exercise: {
                 course_id,
-                ...(!includeDeleted ? { deleted: { not: true } } : {}),
+                ...(!includeDeleted && {
+                  // same here: { deleted: { not: true } } will skip null
+                  OR: [{ deleted: false }, { deleted: null }],
+                }),
               },
             },
             orderBy: [{ timestamp: "desc" }, { updated_at: "desc" }],


### PR DESCRIPTION
`elements-of-ai-ee` had `deleted` as null for all exercises. Prisma query `{ not: true }` would skip them, have to check if they're null as well. (I set all null deleted as false in the database, but just to be sure.)