### PR TITLE
Add user search box to user summary; batch frontend graphql

### DIFF
--- a/backend/middlewares/cache.ts
+++ b/backend/middlewares/cache.ts
@@ -23,17 +23,17 @@ export const cachePlugin = () =>
         rawToken = context.req?.connection.context["Authorization"]
       }*/
         if (root || info.parentType.toString() !== "Query" || rawToken) {
-          return await next(root, args, context, info)
+          return next(root, args, context, info)
         }
 
         const key = `${info.fieldName}-${JSON.stringify(
           info.fieldNodes,
         )}-${JSON.stringify(args)}`
 
-        let hash = createHash("sha512").update(key).digest("hex")
+        const hash = createHash("sha512").update(key).digest("hex")
 
         const res = await redisify<any>(
-          async () => await next(root, args, context, info),
+          async () => next(root, args, context, info),
           {
             prefix: "graphql-response",
             expireTime: 300,

--- a/backend/services/tmc.ts
+++ b/backend/services/tmc.ts
@@ -121,7 +121,7 @@ export default class TmcClient {
   async getUserAppDatum(after: string | null): Promise<any[]> {
     let res
     if (after != null) {
-      after = await encodeURI(after)
+      after = encodeURI(after)
       res = await axios.get(
         `${TMC_HOST}/api/v8/user_app_datum?after=${after}`,
         {
@@ -139,7 +139,7 @@ export default class TmcClient {
   async getUserFieldValues(after: string | null): Promise<UserFieldValue[]> {
     let res
     if (after != null) {
-      after = await encodeURI(after)
+      after = encodeURI(after)
       res = await axios.get(
         `${TMC_HOST}/api/v8/user_field_value?after=${after}`,
         {

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -78,7 +78,7 @@ function SayHello(id: string) {
 }
 
 // or, if you're outside React components, assuming client is an ApolloClient instance
-async function getStaffMemberDetails(client: ApolloClient<any>, id: string) {
+async function getStaffMemberDetails(client: ApolloClient<object>, id: string) {
   const { data } = await client.query({
     query: StaffMemberDetailsDocument,
     variables: { id },

--- a/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/Course/CourseEditForm.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 
 import {
   Form,
@@ -8,6 +8,7 @@ import {
   yupToFormErrors,
 } from "formik"
 import * as Yup from "yup"
+import { ObjectShape } from "yup/lib/object"
 
 import styled from "@emotion/styled"
 import AdapterLuxon from "@mui/lab/AdapterLuxon"
@@ -67,7 +68,7 @@ const ModuleList = styled(List)`
   overflow: auto;
 `
 
-const ModuleListItem = styled(ListItem)<any>`
+const ModuleListItem = styled(ListItem)`
   padding: 0px;
 `
 
@@ -511,11 +512,11 @@ const renderForm =
     )
   }
 
-interface CourseEditFormProps {
+interface CourseEditFormProps<SchemaType extends ObjectShape> {
   course: CourseFormValues
   studyModules?: StudyModuleDetailedFieldsFragment[]
   courses?: EditorCourseOtherCoursesFieldsFragment[]
-  validationSchema: Yup.ObjectSchema<any>
+  validationSchema: Yup.ObjectSchema<SchemaType>
   onSubmit: (
     values: CourseFormValues,
     FormikHelpers: FormikHelpers<CourseFormValues>,
@@ -524,50 +525,48 @@ interface CourseEditFormProps {
   onDelete: (values: CourseFormValues) => void
 }
 
-const CourseEditForm = memo(
-  ({
-    course,
-    studyModules,
-    courses,
-    validationSchema,
-    onSubmit,
-    onCancel,
-    onDelete,
-  }: CourseEditFormProps) => {
-    const validate = useCallback(async (values: CourseFormValues) => {
-      try {
-        await validationSchema.validate(values, {
-          abortEarly: false,
-          context: { values },
-        })
-      } catch (e) {
-        return yupToFormErrors(e)
-      }
-    }, [])
+function CourseEditForm<SchemaType extends ObjectShape>({
+  course,
+  studyModules,
+  courses,
+  validationSchema,
+  onSubmit,
+  onCancel,
+  onDelete,
+}: CourseEditFormProps<SchemaType>) {
+  const validate = useCallback(async (values: CourseFormValues) => {
+    try {
+      await validationSchema.validate(values, {
+        abortEarly: false,
+        context: { values },
+      })
+    } catch (e) {
+      return yupToFormErrors(e)
+    }
+  }, [])
 
-    const [tab, setTab] = useState(0)
+  const [tab, setTab] = useState(0)
 
-    return (
-      <Formik
-        initialValues={course}
-        validate={validate}
-        onSubmit={onSubmit}
-        validateOnChange={false}
-      >
-        <FormWrapper<CourseFormValues>
-          renderForm={renderForm({
-            initialValues: course,
-            courses,
-            studyModules,
-          })}
-          onCancel={onCancel}
-          onDelete={onDelete}
-          tab={tab}
-          setTab={setTab}
-        />
-      </Formik>
-    )
-  },
-)
+  return (
+    <Formik
+      initialValues={course}
+      validate={validate}
+      onSubmit={onSubmit}
+      validateOnChange={false}
+    >
+      <FormWrapper<CourseFormValues>
+        renderForm={renderForm({
+          initialValues: course,
+          courses,
+          studyModules,
+        })}
+        onCancel={onCancel}
+        onDelete={onDelete}
+        tab={tab}
+        setTab={setTab}
+      />
+    </Formik>
+  )
+}
 
-export default CourseEditForm
+export default React.memo(CourseEditForm)

--- a/frontend/components/Dashboard/Editor/FormWrapper.tsx
+++ b/frontend/components/Dashboard/Editor/FormWrapper.tsx
@@ -7,7 +7,12 @@ import {
   useState,
 } from "react"
 
-import { FormikErrors, FormikTouched, useFormikContext } from "formik"
+import {
+  FormikContextType,
+  FormikErrors,
+  FormikTouched,
+  useFormikContext,
+} from "formik"
 import { useConfirm } from "material-ui-confirm"
 
 import styled from "@emotion/styled"
@@ -36,11 +41,11 @@ const FormBackground = styled(Paper)`
   padding: 2em;
 `
 
-const Status = styled.p<any>`
+const Status = styled.p<FormikContextType<unknown>["status"]>`
   color: ${(props: any) => (props.error ? "#FF0000" : "default")};
 `
 
-interface FormWrapperProps<T> {
+interface FormWrapperProps<T extends FormValues> {
   onCancel: () => void
   onDelete: (values: T) => void
   renderForm: (props: any) => ReactNode

--- a/frontend/components/Dashboard/Editor/StudyModule/StudyModuleEditForm.tsx
+++ b/frontend/components/Dashboard/Editor/StudyModule/StudyModuleEditForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "formik"
 import { useConfirm } from "material-ui-confirm"
 import * as Yup from "yup"
+import { ObjectShape } from "yup/lib/object"
 
 import styled from "@emotion/styled"
 import HelpIcon from "@mui/icons-material/Help"
@@ -285,9 +286,9 @@ const RenderForm = () => {
   )
 }
 
-interface StudyModuleEditFormProps {
+interface StudyModuleEditFormProps<SchemaType extends ObjectShape> {
   module: StudyModuleFormValues
-  validationSchema: Yup.ObjectSchema<any>
+  validationSchema: Yup.ObjectSchema<SchemaType>
   onSubmit: (
     values: StudyModuleFormValues,
     FormikHelpers: FormikHelpers<StudyModuleFormValues>,
@@ -296,13 +297,13 @@ interface StudyModuleEditFormProps {
   onDelete: (values: StudyModuleFormValues) => void
 }
 
-const StudyModuleEditForm = ({
+function StudyModuleEditForm<SchemaType extends ObjectShape>({
   module,
   validationSchema,
   onSubmit,
   onCancel,
   onDelete,
-}: StudyModuleEditFormProps) => {
+}: StudyModuleEditFormProps<SchemaType>) {
   const validate = useCallback(async (values: StudyModuleFormValues) => {
     try {
       await validationSchema.validate(values, {

--- a/frontend/components/Dashboard/Editor/common.tsx
+++ b/frontend/components/Dashboard/Editor/common.tsx
@@ -85,7 +85,7 @@ interface CheckboxFieldProps {
 }
 
 export const CheckboxField = ({ id, label, checked }: CheckboxFieldProps) => {
-  const { setFieldValue } = useFormikContext<any>()
+  const { setFieldValue } = useFormikContext()
 
   return (
     <Field

--- a/frontend/components/Dashboard/Editor2/Common/Fields/ControlledModuleList.tsx
+++ b/frontend/components/Dashboard/Editor2/Common/Fields/ControlledModuleList.tsx
@@ -31,7 +31,7 @@ const ModuleList = styled(List)`
   max-height: 400px;
   overflow: auto;
 `
-const ModuleListItem = styled(ListItem)<any>`
+const ModuleListItem = styled(ListItem)`
   padding: 0px;
 `
 

--- a/frontend/components/Dashboard/Editor2/Common/index.tsx
+++ b/frontend/components/Dashboard/Editor2/Common/index.tsx
@@ -52,9 +52,7 @@ interface EnumeratingAnchorProps {
   id: string
 }
 
-export const EnumeratingAnchor: React.FC<any> = ({
-  id,
-}: EnumeratingAnchorProps) => {
+export const EnumeratingAnchor: React.FC<EnumeratingAnchorProps> = ({ id }) => {
   const { addAnchor } = useAnchorContext()
   const { tab } = useTabContext()
 

--- a/frontend/components/Dashboard/Editor2/EditorContainer.tsx
+++ b/frontend/components/Dashboard/Editor2/EditorContainer.tsx
@@ -25,8 +25,8 @@ const FormBackground = styled(Paper)`
   padding: 2em;
 `
 
-const Status = styled.p<any>`
-  color: ${(props: FormStatus) => (props.error ? "#FF0000" : "default")};
+const Status = styled.p<{ error: FormStatus["error"] }>`
+  color: ${(props) => (props.error ? "#FF0000" : "default")};
 `
 
 function EditorContainer<T extends FormValues>({

--- a/frontend/components/Dashboard/Editor2/EditorContext.tsx
+++ b/frontend/components/Dashboard/Editor2/EditorContext.tsx
@@ -18,9 +18,9 @@ export interface EditorContext<T extends FormValues> {
 
 export const EditorContext = createContext<EditorContext<any>>({
   status: { message: null },
-  setStatus: (_: any) => {},
+  setStatus: (_) => {},
   tab: 0,
-  setTab: (_: any) => {},
+  setTab: (_) => {},
   onSubmit: () => {},
   onError: () => {},
   onCancel: () => {},
@@ -28,6 +28,6 @@ export const EditorContext = createContext<EditorContext<any>>({
   initialValues: {},
 })
 
-export function useEditorContext<T>() {
+export function useEditorContext<T extends FormValues>() {
   return useContext<EditorContext<T>>(EditorContext)
 }

--- a/frontend/components/Dashboard/ImageDropzoneInput.tsx
+++ b/frontend/components/Dashboard/ImageDropzoneInput.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useEffect, useState } from "react"
 
-import { FileRejection, useDropzone } from "react-dropzone"
+import { DropzoneState, FileRejection, useDropzone } from "react-dropzone"
 
 import styled from "@emotion/styled"
 import { Typography } from "@mui/material"
@@ -14,7 +14,9 @@ const isChrome = process.browser
     (!!(window as any).chrome.webstore || !!(window as any).chrome.runtime)
   : false
 
-const DropzoneContainer = styled.div<any>`
+const DropzoneContainer = styled.div<
+  DropzoneState & { error: MessageProps["error"] }
+>`
   display: flex;
   width: 100%;
   min-height: 250px;
@@ -104,10 +106,10 @@ const ImageDropzoneInput = ({
 
   return (
     <DropzoneContainer
+      {...getRootProps()}
       isDragActive={isDragActive}
       isDragAccept={isChrome || isDragAccept}
       error={status.error}
-      {...getRootProps()}
     >
       {children}
       <input {...getInputProps()} />

--- a/frontend/components/Dashboard/PointsExportButton.tsx
+++ b/frontend/components/Dashboard/PointsExportButton.tsx
@@ -19,6 +19,7 @@ const PointsExportButtonContainer = styled.div`
 export interface PointsExportButtonProps {
   slug: string
 }
+
 function PointsExportButton(props: PointsExportButtonProps) {
   const { slug } = props
   const client = useApolloClient()

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useContext } from "react"
+import React, { useCallback, useContext } from "react"
 
 import range from "lodash/range"
 import Link from "next/link"
@@ -32,7 +32,7 @@ const UserCard = styled(Card)`
   margin-bottom: 0.5rem;
 `
 
-const MobileGrid: FC<any> = () => {
+const MobileGrid: React.FC = () => {
   const { data, page, rowsPerPage, loading } = useContext(UserSearchContext)
   const t = useTranslator(UsersTranslations)
 
@@ -70,7 +70,7 @@ const MobileGrid: FC<any> = () => {
   )
 }
 
-const RenderCards: FC<any> = () => {
+const RenderCards: React.FC = () => {
   const { data, loading } = useContext(UserSearchContext)
 
   if (loading) {

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -32,7 +32,7 @@ const StyledTablePagination = styled(TablePagination)`
   }
 `
 
-const TablePaginationActions: React.FC<any> = () => {
+const TablePaginationActions: React.FC = () => {
   const theme = useTheme()
   const {
     data,
@@ -140,7 +140,7 @@ const TablePaginationActions: React.FC<any> = () => {
   )
 }
 
-const Pagination: React.FC<any> = () => {
+const Pagination: React.FC = () => {
   const t = useTranslator(UsersTranslations)
   const {
     data,

--- a/frontend/components/Dashboard/Users/SearchForm.tsx
+++ b/frontend/components/Dashboard/Users/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from "react"
+import { useCallback, useContext } from "react"
 
 import styled from "@emotion/styled"
 import { TextField, useMediaQuery } from "@mui/material"
@@ -21,25 +21,23 @@ const StyledButton = styled(ButtonWithPaddingAndMargin)`
 `
 
 const SearchForm = () => {
-  const { page, rowsPerPage, searchVariables, setPage, setSearchVariables } =
+  const { page, search, setSearch, rowsPerPage, setPage, setSearchVariables } =
     useContext(UserSearchContext)
   const t = useTranslator(UsersTranslations)
 
-  const [searchFormText, setSearchFormText] = useState(searchVariables.search)
-
   const handleSubmit = useCallback(() => {
-    if (searchFormText !== "") {
+    if (search !== "") {
       setSearchVariables({
-        search: searchFormText,
+        search,
         first: rowsPerPage,
         skip: 0,
       })
       setPage(0)
     }
-  }, [searchFormText, page, rowsPerPage])
+  }, [search, page, rowsPerPage])
 
   const onTextBoxChange = (event: any) => {
-    setSearchFormText(event.target.value as string)
+    setSearch(event.target.value as string)
   }
 
   const isMobile = useMediaQuery("(max-width:900px)", { noSsr: true })
@@ -63,13 +61,13 @@ const SearchForm = () => {
             type="search"
             margin="normal"
             autoComplete="off"
-            value={searchFormText}
+            value={search}
             onChange={onTextBoxChange}
           />
 
           <StyledButton
             variant="contained"
-            disabled={searchFormText === ""}
+            disabled={search === ""}
             onClick={async (event: any) => {
               event.preventDefault()
               handleSubmit()

--- a/frontend/components/Dashboard/Users/Summary/UserPointsSummary.tsx
+++ b/frontend/components/Dashboard/Users/Summary/UserPointsSummary.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 
 import { sortBy } from "lodash"
 
+import styled from "@emotion/styled"
 import BuildIcon from "@mui/icons-material/Build"
 import { Button, Dialog, Paper } from "@mui/material"
 
@@ -16,11 +17,19 @@ import RawView from "/components/Dashboard/Users/Summary/RawView"
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
 
-import { UserCourseSummaryCoreFieldsFragment } from "/graphql/generated"
+import {
+  EditorCoursesQueryVariables,
+  UserCourseSummaryCoreFieldsFragment,
+} from "/graphql/generated"
+
+const DataPlaceholder = styled.div`
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+`
 
 interface UserPointsSummaryProps {
   data?: UserCourseSummaryCoreFieldsFragment[]
-  search?: string
+  search?: EditorCoursesQueryVariables["search"]
 }
 
 export default function UserPointsSummary({
@@ -83,7 +92,9 @@ export default function UserPointsSummary({
           label={coursesClosed ? t("showAll") : t("hideAll")}
         />
       </Paper>
-      {filteredData.length === 0 ? <div>No data</div> : null}
+      {filteredData.length === 0 ? (
+        <DataPlaceholder>{t("noResults")}</DataPlaceholder>
+      ) : null}
       {sortBy(filteredData, (stats) => stats?.course?.name).map(
         (entry, index) => (
           <CourseEntry key={entry.course?.id ?? index} data={entry} />

--- a/frontend/components/FilterMenu.tsx
+++ b/frontend/components/FilterMenu.tsx
@@ -16,10 +16,15 @@ import {
   TextField,
 } from "@mui/material"
 
+import { useSearch } from "/hooks/useSearch"
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
 
-import { CourseCoreFieldsFragment, CourseStatus } from "/graphql/generated"
+import {
+  CourseCoreFieldsFragment,
+  CourseStatus,
+  EditorCoursesQueryVariables,
+} from "/graphql/generated"
 
 const Container = styled.div`
   background-color: white;
@@ -52,26 +57,20 @@ const Row = styled.section`
   }
 `
 
-interface SearchVariables {
-  search?: string
-  hidden?: boolean | null
-  handledBy?: string | null
-  status?: CourseStatus[] | null
-}
-
 interface FilterFields {
   hidden: boolean
   status: boolean
   handler: boolean
 }
 interface FilterProps {
-  searchVariables: SearchVariables
-  setSearchVariables: React.Dispatch<SearchVariables>
+  searchVariables: EditorCoursesQueryVariables
+  setSearchVariables: React.Dispatch<EditorCoursesQueryVariables>
   handlerCourses?: CourseCoreFieldsFragment[]
   status?: string[]
   setStatus?: React.Dispatch<React.SetStateAction<CourseStatus[]>>
   loading: boolean
   fields?: FilterFields
+  label?: string
 }
 
 export default function FilterMenu({
@@ -82,6 +81,7 @@ export default function FilterMenu({
   status = [],
   setStatus = () => {},
   fields,
+  label,
 }: FilterProps) {
   const t = useTranslator(CommonTranslations)
   const {
@@ -95,7 +95,7 @@ export default function FilterMenu({
     handledBy: initialHandledBy,
   } = searchVariables
 
-  const [searchString, setSearchString] = useState<string>(initialSearch ?? "")
+  const { search, setSearch } = useSearch({ search: initialSearch ?? "" })
   const [hidden, setHidden] = useState(
     initialHidden === null ? true : initialHidden,
   )
@@ -109,7 +109,7 @@ export default function FilterMenu({
   const onSubmit = () => {
     setSearchVariables({
       ...searchVariables,
-      search: searchString,
+      search,
       hidden,
       handledBy,
     })
@@ -120,7 +120,9 @@ export default function FilterMenu({
       const newStatus = (
         e.target.checked
           ? [...(searchVariables?.status || []), value]
-          : searchVariables?.status?.filter((v) => v !== value) || []
+          : (searchVariables?.status as CourseStatus[])?.filter(
+              (v) => v !== value,
+            ) || []
       ) as CourseStatus[]
 
       setStatus(newStatus)
@@ -151,12 +153,12 @@ export default function FilterMenu({
       <Row>
         <TextField
           id="searchString"
-          label={t("search")}
-          value={searchString}
+          label={label ?? t("search")}
+          value={search}
           autoComplete="off"
           variant="outlined"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setSearchString(e.target.value)
+            setSearch(e.target.value)
           }
           onKeyDown={(e) => e.key === "Enter" && onSubmit()}
           InputProps={{
@@ -164,9 +166,9 @@ export default function FilterMenu({
               <InputAdornment position="end">
                 <IconButton
                   onClick={() => {
-                    setSearchString("")
+                    setSearch("")
                   }}
-                  disabled={searchString === ""}
+                  disabled={search === ""}
                   edge="end"
                   aria-label="clear search"
                   size="large"

--- a/frontend/components/HeaderBar/Header.tsx
+++ b/frontend/components/HeaderBar/Header.tsx
@@ -30,7 +30,7 @@ function HideOnScroll(props: Props) {
   )
 }
 
-const StyledToolbar = styled<any>(Toolbar)`
+const StyledToolbar = styled(Toolbar)`
   display: flex;
   flex-direction: row;
 `

--- a/frontend/components/Home/FAQ/Common.tsx
+++ b/frontend/components/Home/FAQ/Common.tsx
@@ -1,3 +1,5 @@
+import React from "react"
+
 import { range } from "lodash"
 import dynamic from "next/dynamic"
 
@@ -103,14 +105,16 @@ export const Loader = () => (
   </Background>
 )
 
+type DynamicImportType = <T>() => Promise<React.ComponentType<T>>
+
 interface FAQComponentProps {
-  mdxImport?: () => Promise<any>
-  onSuccess: (mdx: any) => any
+  mdxImport?: DynamicImportType
+  onSuccess: <T>(mdx: React.ComponentType<T>) => React.ComponentType<T>
   onError: () => void
 }
 
 export function FAQComponent({
-  mdxImport = () => Promise.resolve(),
+  mdxImport = () => Promise.resolve(() => <React.Fragment />),
   onSuccess,
   onError,
 }: FAQComponentProps) {
@@ -118,9 +122,10 @@ export function FAQComponent({
     async () => {
       return mdxImport()
         .then(onSuccess)
-        .catch((error: any) => {
+        .catch((error: unknown) => {
           console.log("error", error)
           onError()
+          return () => <React.Fragment />
         })
     },
     { loading: () => <Loader /> },

--- a/frontend/components/Home/UkraineInfo.tsx
+++ b/frontend/components/Home/UkraineInfo.tsx
@@ -72,10 +72,10 @@ const InfoContainer = styled.div`
   padding: 0rem;
 
   a {
-    font-size: clamp(12px, 1.5vw, 22px);
+    font-size: clamp(12px, 1.5vw, 18px);
   }
   h3 {
-    font-size: clamp(14px, 2vw, 22px);
+    font-size: clamp(14px, 2vw, 24px);
   }
 `
 

--- a/frontend/components/NewLayout/Frontpage/Hero.tsx
+++ b/frontend/components/NewLayout/Frontpage/Hero.tsx
@@ -32,17 +32,17 @@ const HeroContentContainer = styled.div`
   background-color: rgba(255, 255, 255, 0.6);
 `
 
-const Title = styled(Typography)<any>`
+const Title = styled(Typography)`
   padding: 2rem;
   max-width: 80vw;
   text-align: center;
 `
-const Paragraph = styled(Typography)<any>`
+const Paragraph = styled(Typography)`
   max-width: 60vw;
   text-align: center;
 `
 
-const CourseButton = styled(Button)<any>`
+const CourseButton = styled(Button)`
   border-radius: 20px;
   background-color: #fff;
   margin-top: 2rem;

--- a/frontend/contexts/UserSearchContext.ts
+++ b/frontend/contexts/UserSearchContext.ts
@@ -1,26 +1,23 @@
 import { createContext } from "react"
 
-import { UserDetailsContainsQuery } from "/graphql/generated"
-
-export interface SearchVariables {
-  search: string
-  cursor?: string
-  first?: number
-  last?: number
-  skip?: number
-  after?: string | null
-  before?: string | null
-}
+import {
+  UserDetailsContainsQuery,
+  UserDetailsContainsQueryVariables,
+} from "/graphql/generated"
 
 interface UserSearchContext {
   data?: UserDetailsContainsQuery
   loading: boolean
   page: number
   rowsPerPage: number
-  searchVariables: SearchVariables
+  search: string
+  searchVariables: UserDetailsContainsQueryVariables
   setPage: React.Dispatch<React.SetStateAction<number>>
-  setSearchVariables: React.Dispatch<React.SetStateAction<any>>
-  setRowsPerPage: React.Dispatch<React.SetStateAction<any>>
+  setSearchVariables: React.Dispatch<
+    React.SetStateAction<UserDetailsContainsQueryVariables>
+  >
+  setRowsPerPage: React.Dispatch<React.SetStateAction<number>>
+  setSearch: React.Dispatch<React.SetStateAction<string>>
 }
 
 export default createContext<UserSearchContext>({
@@ -31,7 +28,9 @@ export default createContext<UserSearchContext>({
   searchVariables: {
     search: "",
   },
+  search: "",
   setPage: () => {},
   setSearchVariables: () => {},
   setRowsPerPage: () => {},
+  setSearch: () => {},
 })

--- a/frontend/hooks/useFAQPage.tsx
+++ b/frontend/hooks/useFAQPage.tsx
@@ -4,6 +4,14 @@ import { useRouter } from "next/router"
 
 import { FAQComponent } from "/components/Home/FAQ/Common"
 
+type MDXComponent<T> = {
+  meta?: {
+    title?: string
+    ingress?: string
+    breadcrumb?: string
+  }
+} & React.ComponentType<T>
+
 export function useFAQPage(topic: string) {
   const { locale } = useRouter()
 
@@ -20,7 +28,7 @@ export function useFAQPage(topic: string) {
   const Component = FAQComponent({
     mdxImport: () =>
       import(`../static/md_pages/${sanitizedTopic}_${locale}.mdx`),
-    onSuccess: (mdx: any) => {
+    onSuccess: (mdx: MDXComponent<any>) => {
       setTitle(mdx?.meta?.title ?? "")
       setIngress(mdx?.meta?.ingress ?? "")
       setBreadcrumb(mdx?.meta?.breadcrumb ?? mdx?.meta?.title ?? "")

--- a/frontend/hooks/useSearch.tsx
+++ b/frontend/hooks/useSearch.tsx
@@ -1,0 +1,32 @@
+import { useMemo, useState } from "react"
+
+interface UserSearchOptions {
+  page?: number
+  rowsPerPage?: number
+  search?: string
+}
+
+export function useSearch(opts: UserSearchOptions = {}) {
+  const {
+    search: _search = "",
+    page: _page = 0,
+    rowsPerPage: _rowsPerPage = 10,
+  } = opts
+  const [search, setSearch] = useState(_search)
+  const [page, setPage] = useState(_page)
+  const [rowsPerPage, setRowsPerPage] = useState(_rowsPerPage)
+
+  const value = useMemo(
+    () => ({
+      page,
+      rowsPerPage,
+      search,
+      setPage,
+      setRowsPerPage,
+      setSearch,
+    }),
+    [page, search, rowsPerPage],
+  )
+
+  return value
+}

--- a/frontend/lib/authentication.ts
+++ b/frontend/lib/authentication.ts
@@ -69,7 +69,7 @@ export const signIn = async ({
   return details
 }
 
-export const signOut = async (apollo: ApolloClient<any>, cb: Function) => {
+export const signOut = async (apollo: ApolloClient<object>, cb: Function) => {
   document.cookie =
     "access_token" + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/"
   document.cookie = "admin" + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/"

--- a/frontend/lib/with-apollo-client/fetch-user-details.ts
+++ b/frontend/lib/with-apollo-client/fetch-user-details.ts
@@ -1,10 +1,8 @@
-import { ApolloClient, NormalizedCacheObject } from "@apollo/client"
+import { ApolloClient } from "@apollo/client"
 
 import { CurrentUserDocument } from "/graphql/generated"
 
-export default async function fetchUserDetails(
-  apollo: ApolloClient<NormalizedCacheObject>,
-) {
+export default async function fetchUserDetails(apollo: ApolloClient<object>) {
   const { data } = await apollo.query({
     query: CurrentUserDocument,
     fetchPolicy: "cache-first",

--- a/frontend/lib/with-apollo-client/index.tsx
+++ b/frontend/lib/with-apollo-client/index.tsx
@@ -2,18 +2,14 @@ import { NextPageContext } from "next"
 import { AppContext } from "next/app"
 import { renderToString } from "react-dom/server"
 
-import {
-  type ApolloClient,
-  ApolloProvider,
-  type NormalizedCacheObject,
-} from "@apollo/client"
+import { type ApolloClient, ApolloProvider } from "@apollo/client"
 
 import fetchUserDetails from "./fetch-user-details"
 import getApollo, { initNewApollo } from "./get-apollo"
 import { getAccessToken } from "/lib/authentication"
 
 interface Props {
-  apollo: ApolloClient<NormalizedCacheObject>
+  apollo: ApolloClient<object>
   // Server side rendered state. Prevents queries from running again in the frontend.
   apolloState: any
   accessToken?: string

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "axios": "^0.27.2",
         "compression": "^1.7.4",
         "express": "^4.17.3",
+        "extract-files": "^13.0.0",
         "formik": "^2.2.9",
         "formik-mui": "^4.0.0-alpha.3",
         "formik-mui-lab": "^1.0.0-alpha.3",
@@ -3194,6 +3195,18 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
     },
     "node_modules/@graphql-tools/url-loader/node_modules/meros": {
       "version": "1.2.0",
@@ -6822,6 +6835,17 @@
       "peerDependencies": {
         "@apollo/client": "^3.0.0",
         "graphql": "14 - 16"
+      }
+    },
+    "node_modules/apollo-upload-client/node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
       }
     },
     "node_modules/apollo-utilities": {
@@ -11250,14 +11274,28 @@
       }
     },
     "node_modules/extract-files": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
-      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-13.0.0.tgz",
+      "integrity": "sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==",
+      "dependencies": {
+        "is-plain-obj": "^4.1.0"
+      },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
+    "node_modules/extract-files/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/extract-stack": {
@@ -23539,21 +23577,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   },
   "dependencies": {
@@ -25962,6 +25985,12 @@
           "dev": true,
           "optional": true,
           "peer": true
+        },
+        "extract-files": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+          "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+          "dev": true
         },
         "meros": {
           "version": "1.2.0",
@@ -28788,6 +28817,13 @@
       "integrity": "sha512-pue33bWVbdlXAGFPkgz53TTmxVMrKeQr0mdRcftNY+PoHIdbGZD0hoaXHvO6OePJAkFz7OiCFUf98p1G/9+Ykw==",
       "requires": {
         "extract-files": "^11.0.0"
+      },
+      "dependencies": {
+        "extract-files": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+          "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ=="
+        }
       }
     },
     "apollo-utilities": {
@@ -32212,9 +32248,19 @@
       }
     },
     "extract-files": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
-      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ=="
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-13.0.0.tgz",
+      "integrity": "sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==",
+      "requires": {
+        "is-plain-obj": "^4.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        }
+      }
     },
     "extract-stack": {
       "version": "2.0.0",
@@ -41536,12 +41582,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
       "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-      "integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
-      "optional": true
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "axios": "^0.27.2",
     "compression": "^1.7.4",
     "express": "^4.17.3",
+    "extract-files": "^13.0.0",
     "formik": "^2.2.9",
     "formik-mui": "^4.0.0-alpha.3",
     "formik-mui-lab": "^1.0.0-alpha.3",

--- a/frontend/pages/courses.tsx
+++ b/frontend/pages/courses.tsx
@@ -20,19 +20,13 @@ import { useTranslator } from "/util/useTranslator"
 import {
   CourseStatus,
   EditorCoursesDocument,
+  EditorCoursesQueryVariables,
   HandlerCoursesDocument,
 } from "/graphql/generated"
 
 const Background = styled.section`
   background-color: #61baad;
 `
-
-interface SearchVariables {
-  search?: string
-  hidden?: boolean | null
-  handledBy?: string | null
-  status?: CourseStatus[] | null
-}
 
 const notEmptyOrEmptyString = (value: any): value is string | true | number =>
   notEmpty(value) && value !== "" && value !== false
@@ -51,7 +45,7 @@ function useCourseSearch() {
     ?.split(",")
     .filter(notEmptyOrEmptyString) ?? []) as CourseStatus[]
 
-  const initialSearchVariables: SearchVariables = {
+  const initialSearchVariables: EditorCoursesQueryVariables = {
     search: useQueryParameter("search", false) ?? "",
     hidden:
       (useQueryParameter("hidden", false) ?? "").toLowerCase() !== "false" ??
@@ -62,11 +56,10 @@ function useCourseSearch() {
       : [CourseStatus.Active, CourseStatus.Upcoming],
   }
 
-  const [searchVariables, setSearchVariables] = useState<SearchVariables>(
-    initialSearchVariables,
-  )
+  const [searchVariables, setSearchVariables] =
+    useState<EditorCoursesQueryVariables>(initialSearchVariables)
   const [status, setStatus] = useState<CourseStatus[]>(
-    initialSearchVariables.status ?? [],
+    (initialSearchVariables.status ?? []) as CourseStatus[],
   )
 
   const {
@@ -110,7 +103,10 @@ function useCourseSearch() {
         searchVariables.status.includes(CourseStatus.Upcoming)
       )
     ) {
-      searchParams.set("status", searchVariables.status.join(","))
+      searchParams.set(
+        "status",
+        (searchVariables.status as CourseStatus[]).join(","),
+      )
     }
 
     const query = searchParams.toString().length

--- a/frontend/pages/email-templates/[id].tsx
+++ b/frontend/pages/email-templates/[id].tsx
@@ -28,6 +28,7 @@ import { useQueryParameter } from "/util/useQueryParameter"
 import {
   DeleteEmailTemplateDocument,
   EmailTemplateDocument,
+  EmailTemplateFieldsFragment,
   UpdateEmailTemplateDocument,
 } from "/graphql/generated"
 
@@ -87,30 +88,36 @@ const TemplateList = styled.div`
   }
 `
 
+interface SnackbarData {
+  type: "error" | "success" | "warning" | "error"
+  message: string
+}
+
 const EmailTemplateView = () => {
-  // TODO: Get rid of any
-  const [emailTemplate, setEmailTemplate] = useState<any>()
-  const [name, setName] = useState<any>()
-  const [txtBody, setTxtBody] = useState<any>()
-  const [htmlBody, setHtmlBody] = useState<any>()
-  const [title, setTitle] = useState<any>()
-  const [exerciseThreshold, setExerciseThreshold] = useState<
-    number | null | undefined
-  >()
-  const [pointsThreshold, setPointsThreshold] = useState<
-    number | null | undefined
-  >()
-  const [templateType, setTemplateType] = useState<string | null | undefined>()
-  const [triggeredByCourseId, setTriggeredByCourseId] = useState<any>()
+  const [emailTemplate, setEmailTemplate] =
+    useState<EmailTemplateFieldsFragment | null>()
+  const [name, setName] = useState<EmailTemplateFieldsFragment["name"]>()
+  const [txtBody, setTxtBody] =
+    useState<EmailTemplateFieldsFragment["txt_body"]>()
+  const [htmlBody, setHtmlBody] =
+    useState<EmailTemplateFieldsFragment["html_body"]>()
+  const [title, setTitle] = useState<EmailTemplateFieldsFragment["title"]>()
+  const [exerciseThreshold, setExerciseThreshold] =
+    useState<EmailTemplateFieldsFragment["exercise_completions_threshold"]>()
+  const [pointsThreshold, setPointsThreshold] =
+    useState<EmailTemplateFieldsFragment["points_threshold"]>()
+  const [templateType, setTemplateType] =
+    useState<EmailTemplateFieldsFragment["template_type"]>()
+  const [triggeredByCourseId, setTriggeredByCourseId] =
+    useState<
+      EmailTemplateFieldsFragment["triggered_automatically_by_course_id"]
+    >()
   const [didInit, setDidInit] = useState(false)
   const [isHelpOpen, setIsHelpOpen] = useState(false)
   const id = useQueryParameter("id")
   const client = useApolloClient()
-  interface SnackbarData {
-    type: "error" | "success" | "warning" | "error"
-    message: string
-  }
-  const [snackbarData, setSnackbarData]: [SnackbarData, any] = useState({
+
+  const [snackbarData, setSnackbarData] = useState<SnackbarData>({
     type: "error",
     message: "Error: Could not save",
   })

--- a/frontend/pages/users/[id]/summary.tsx
+++ b/frontend/pages/users/[id]/summary.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useMemo, useReducer, useState } from "react"
 
+import { useRouter } from "next/router"
+
 import { useQuery } from "@apollo/client"
-import { Paper } from "@mui/material"
+import styled from "@emotion/styled"
+import { Paper, TextField } from "@mui/material"
 
 import Container from "/components/Container"
 import CollapseContext, {
@@ -13,20 +16,26 @@ import UserPointsSummary from "/components/Dashboard/Users/Summary/UserPointsSum
 import ErrorMessage from "/components/ErrorMessage"
 import FilterMenu from "/components/FilterMenu"
 import { useBreadcrumbs } from "/hooks/useBreadcrumbs"
+import { useSearch } from "/hooks/useSearch"
 import withAdmin from "/lib/with-admin"
+import UsersTranslations from "/translations/users"
 import notEmpty from "/util/notEmpty"
 import { useQueryParameter } from "/util/useQueryParameter"
+import { useTranslator } from "/util/useTranslator"
 
-import { CourseStatus, UserSummaryDocument } from "/graphql/generated"
+import {
+  EditorCoursesQueryVariables,
+  UserSummaryDocument,
+} from "/graphql/generated"
 
-interface SearchVariables {
-  search?: string
-  hidden?: boolean | null
-  handledBy?: string | null
-  status?: CourseStatus[] | null
-}
+const StyledForm = styled.form`
+  display: flex;
+  padding: 1rem;
+`
 
 function UserSummaryView() {
+  const t = useTranslator(UsersTranslations)
+  const router = useRouter()
   const id = useQueryParameter("id")
   const { loading, error, data } = useQuery(UserSummaryDocument, {
     variables: { upstream_id: Number(id) },
@@ -47,9 +56,12 @@ function UserSummaryView() {
   ])
 
   const [state, dispatch] = useReducer(collapseReducer, {})
-  const [searchVariables, setSearchVariables] = useState<SearchVariables>({
-    search: "",
-  })
+  const [searchVariables, setSearchVariables] =
+    useState<EditorCoursesQueryVariables>({
+      search: "",
+    })
+  const { search: userSearch, setSearch: setUserSearch } = useSearch()
+
   useEffect(() => {
     dispatch({
       type: ActionType.INIT_STATE,
@@ -58,6 +70,16 @@ function UserSummaryView() {
       ),
     })
   }, [data])
+
+  const handleUserSearchSubmit = () => {
+    if (userSearch !== "") {
+      router.push(`/users/search/${encodeURIComponent(userSearch)}`)
+    }
+  }
+
+  const onUserSearchChange = (event: any) => {
+    setUserSearch(event.target.value as string)
+  }
 
   const contextValue = useMemo(() => ({ state, dispatch }), [state])
 
@@ -73,10 +95,27 @@ function UserSummaryView() {
     <Container>
       <CollapseContext.Provider value={contextValue}>
         <Paper style={{ marginBottom: "0.5rem" }}>
+          <StyledForm
+            onSubmit={async (event: any) => {
+              event.preventDefault()
+              handleUserSearchSubmit()
+            }}
+          >
+            <TextField
+              id="standard-search"
+              label={t("searchUser")}
+              type="search"
+              margin="normal"
+              autoComplete="off"
+              value={userSearch}
+              onChange={onUserSearchChange}
+            />
+          </StyledForm>
           <FilterMenu
             searchVariables={searchVariables}
             setSearchVariables={setSearchVariables}
             loading={loading}
+            label={t("searchInCourses")}
             fields={{
               hidden: false,
               status: false,

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -62,5 +62,6 @@
     "myProfile": "My profile",
     "ukraineHyLink": "https://www.helsinki.fi/en/cooperation/support-us/ukraine-appeal",
     "ukraineHyText": "Support students and researchers affected by the invasion of Ukraine",
-    "ukraineHyLinkText": "University of Helsinki Ukraine appeal"
+    "ukraineHyLinkText": "University of Helsinki Ukraine appeal",
+    "noResults": "No results"
 }

--- a/frontend/translations/common/fi.json
+++ b/frontend/translations/common/fi.json
@@ -62,6 +62,7 @@
     "myProfile": "Oma profiili",
     "ukraineHyText": "Helsingin yliopiston Ukraina-keräys",
     "ukraineHyLink": "https://www.helsinki.fi/fi/yhteistyo/lahjoittajille/ukraina-kerays",
-    "ukraineHyLinkText": "Lahjoita Ukraina-keräykseen opiskelijoiden ja tutkijoiden tueksi"
+    "ukraineHyLinkText": "Lahjoita Ukraina-keräykseen opiskelijoiden ja tutkijoiden tueksi",
+    "noResults": "Ei tuloksia"
 }
 

--- a/frontend/translations/common/se.json
+++ b/frontend/translations/common/se.json
@@ -62,5 +62,6 @@
     "myProfile": "My profile",
     "ukraineHyLink": "https://www.helsinki.fi/en/cooperation/support-us/ukraine-appeal",
     "ukraineHyText": "Support students and researchers affected by the invasion of Ukraine",
-    "ukraineHyLinkText": "University of Helsinki Ukraine appeal"
+    "ukraineHyLinkText": "University of Helsinki Ukraine appeal",
+    "noResults": "No results"
 }

--- a/frontend/translations/users/en.json
+++ b/frontend/translations/users/en.json
@@ -12,5 +12,7 @@
   "displayedRowsOf": " of ",
   "nextPage": "Next page",
   "previousPage": "Previous page",
-  "searchByString": "Search by string"
+  "searchByString": "Search by string",
+  "searchInCourses": "Search in courses",
+  "searchUser": "Search for another user..."
 }

--- a/frontend/translations/users/fi.json
+++ b/frontend/translations/users/fi.json
@@ -12,5 +12,7 @@
   "displayedRowsOf": "/",
   "nextPage": "Seuraava sivu",
   "previousPage": "Edellinen sivu",
-  "searchByString": "Etsi merkkijonolla"
+  "searchByString": "Etsi merkkijonolla",
+  "searchInCourses": "Etsi kursseista",
+  "searchUser": "Etsi toista käyttäjää..."
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -44,7 +44,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true
+    "incremental": true,
+    "maxNodeModuleJsDepth": 10
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
I keep on trying to search for another user right away when I'm in the user summary page, so I added a field to launch quick searches.

Replace upload link in Apollo client with custom one that uses the upload link only if there are files, otherwise link that can batch queries.