### PR TITLE
Fix course stats not getting correct values by adding course instance language

### DIFF
--- a/backend/config/languageConfig.ts
+++ b/backend/config/languageConfig.ts
@@ -6,6 +6,12 @@ export const languageInfo = [
     langName: "Swedish",
   },
   {
+    language: "sv",
+    completion_language: "sv_SE",
+    country: "Sweden",
+    langName: "Swedish",
+  },
+  {
     language: "fi",
     completion_language: "fi_FI",
     country: "Finland",

--- a/backend/graphql/EmailTemplate.ts
+++ b/backend/graphql/EmailTemplate.ts
@@ -26,6 +26,7 @@ export const EmailTemplate = objectType({
     t.model.triggered_automatically_by_course_id()
     t.model.exercise_completions_threshold()
     t.model.points_threshold()
+    t.model.course_instance_language()
     t.model.course_stats_subscriptions()
   },
 })
@@ -69,6 +70,7 @@ export const EmailTemplateMutations = extendType({
         triggered_automatically_by_course_id: stringArg(),
         exercise_completions_threshold: intArg(),
         points_threshold: intArg(),
+        course_instance_language: stringArg(),
       },
       authorize: isAdmin,
       resolve: (_, args, ctx) => {
@@ -81,6 +83,7 @@ export const EmailTemplateMutations = extendType({
           triggered_automatically_by_course_id,
           exercise_completions_threshold,
           points_threshold,
+          course_instance_language,
         } = args
 
         if (name == "") throw new UserInputError("Name is empty!")
@@ -95,6 +98,7 @@ export const EmailTemplateMutations = extendType({
             triggered_automatically_by_course_id,
             exercise_completions_threshold,
             points_threshold,
+            course_instance_language,
           },
         })
       },
@@ -112,6 +116,7 @@ export const EmailTemplateMutations = extendType({
         triggered_automatically_by_course_id: stringArg(),
         exercise_completions_threshold: intArg(),
         points_threshold: intArg(),
+        course_instance_language: stringArg(),
       },
       authorize: isAdmin,
       resolve: async (_, args, ctx) => {
@@ -125,6 +130,7 @@ export const EmailTemplateMutations = extendType({
           triggered_automatically_by_course_id,
           exercise_completions_threshold,
           points_threshold,
+          course_instance_language,
         } = args
 
         return ctx.prisma.emailTemplate.update({
@@ -140,6 +146,7 @@ export const EmailTemplateMutations = extendType({
             triggered_automatically_by_course_id,
             exercise_completions_threshold,
             points_threshold,
+            course_instance_language,
           },
         })
       },

--- a/backend/migrations/20230113122527_alter_table_email_template_add_course_instance_language.ts
+++ b/backend/migrations/20230113122527_alter_table_email_template_add_course_instance_language.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE email_template
+    ADD COLUMN course_instance_language text;
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE email_template
+    DROP COLUMN course_instance_language;
+  `)
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -212,6 +212,7 @@ model EmailTemplate {
   exercise_completions_threshold           Int?         
   points_threshold                         Int?         
   updated_at                               DateTime?                  @updatedAt
+  course_instance_language                 String?
   triggered_automatically_by_course_id     String?              
   triggered_automatically_by_course        Course?                    @relation("emailTemplateToCourse_triggered", fields: [triggered_automatically_by_course_id], references: [id])
   courses                                  Course[]                   @relation("courseTocourse_completion_email")

--- a/frontend/graphql/fragments/emailTemplate.fragments.graphql
+++ b/frontend/graphql/fragments/emailTemplate.fragments.graphql
@@ -5,6 +5,7 @@ fragment EmailTemplateCoreFields on EmailTemplate {
   txt_body
   html_body
   template_type
+  course_instance_language
   created_at
   updated_at
 }

--- a/frontend/graphql/generated/index.ts
+++ b/frontend/graphql/generated/index.ts
@@ -16,7 +16,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>
 }
-// Generated on 2022-11-25T17:50:48+02:00
+// Generated on 2023-01-13T15:36:40+02:00
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -586,6 +586,7 @@ export type EmailDeliveryWhereUniqueInput = {
 
 export type EmailTemplate = {
   __typename?: "EmailTemplate"
+  course_instance_language: Maybe<Scalars["String"]>
   course_stats_subscriptions: Array<CourseStatsSubscription>
   courses: Array<Course>
   created_at: Maybe<Scalars["DateTime"]>
@@ -833,6 +834,7 @@ export type MutationaddCourseVariantArgs = {
 }
 
 export type MutationaddEmailTemplateArgs = {
+  course_instance_language?: InputMaybe<Scalars["String"]>
   exercise_completions_threshold?: InputMaybe<Scalars["Int"]>
   html_body?: InputMaybe<Scalars["String"]>
   name: Scalars["String"]
@@ -1016,6 +1018,7 @@ export type MutationupdateCourseVariantArgs = {
 }
 
 export type MutationupdateEmailTemplateArgs = {
+  course_instance_language?: InputMaybe<Scalars["String"]>
   exercise_completions_threshold?: InputMaybe<Scalars["Int"]>
   html_body?: InputMaybe<Scalars["String"]>
   id: Scalars["ID"]
@@ -2643,6 +2646,7 @@ export type EmailTemplateCoreFieldsFragment = {
   txt_body: string | null
   html_body: string | null
   template_type: string | null
+  course_instance_language: string | null
   created_at: any | null
   updated_at: any | null
 }
@@ -2658,6 +2662,7 @@ export type EmailTemplateFieldsFragment = {
   txt_body: string | null
   html_body: string | null
   template_type: string | null
+  course_instance_language: string | null
   created_at: any | null
   updated_at: any | null
 }
@@ -3622,6 +3627,7 @@ export type UpdateCourseMutation = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -3633,6 +3639,7 @@ export type UpdateCourseMutation = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -3745,6 +3752,7 @@ export type UpdateEmailTemplateMutation = {
     txt_body: string | null
     html_body: string | null
     template_type: string | null
+    course_instance_language: string | null
     created_at: any | null
     updated_at: any | null
   } | null
@@ -3774,6 +3782,7 @@ export type AddEmailTemplateMutation = {
     txt_body: string | null
     html_body: string | null
     template_type: string | null
+    course_instance_language: string | null
     created_at: any | null
     updated_at: any | null
   } | null
@@ -3793,6 +3802,7 @@ export type DeleteEmailTemplateMutation = {
     txt_body: string | null
     html_body: string | null
     template_type: string | null
+    course_instance_language: string | null
     created_at: any | null
     updated_at: any | null
   } | null
@@ -4451,6 +4461,7 @@ export type EmailTemplateEditorCoursesQuery = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -4462,6 +4473,7 @@ export type EmailTemplateEditorCoursesQuery = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -4493,6 +4505,7 @@ export type CourseDashboardQuery = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -4504,6 +4517,7 @@ export type CourseDashboardQuery = {
       txt_body: string | null
       html_body: string | null
       template_type: string | null
+      course_instance_language: string | null
       created_at: any | null
       updated_at: any | null
     } | null
@@ -4525,6 +4539,7 @@ export type EmailTemplatesQuery = {
     txt_body: string | null
     html_body: string | null
     template_type: string | null
+    course_instance_language: string | null
     created_at: any | null
     updated_at: any | null
   }> | null
@@ -4547,6 +4562,7 @@ export type EmailTemplateQuery = {
     txt_body: string | null
     html_body: string | null
     template_type: string | null
+    course_instance_language: string | null
     created_at: any | null
     updated_at: any | null
   } | null
@@ -6383,6 +6399,10 @@ export const EmailTemplateCoreFieldsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "txt_body" } },
           { kind: "Field", name: { kind: "Name", value: "html_body" } },
           { kind: "Field", name: { kind: "Name", value: "template_type" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "course_instance_language" },
+          },
           { kind: "Field", name: { kind: "Name", value: "created_at" } },
           { kind: "Field", name: { kind: "Name", value: "updated_at" } },
         ],

--- a/frontend/pages/email-templates/[id].tsx
+++ b/frontend/pages/email-templates/[id].tsx
@@ -89,7 +89,7 @@ const TemplateList = styled("div")`
 `
 
 interface SnackbarData {
-  type: "error" | "success" | "warning" | "error"
+  type: "error" | "success" | "warning"
   message: string
 }
 
@@ -112,6 +112,9 @@ const EmailTemplateView = () => {
     useState<
       EmailTemplateFieldsFragment["triggered_automatically_by_course_id"]
     >()
+  const [courseInstanceLanguage, setCourseInstanceLanguage] =
+    useState<EmailTemplateFieldsFragment["course_instance_language"]>()
+
   const [didInit, setDidInit] = useState(false)
   const [isHelpOpen, setIsHelpOpen] = useState(false)
   const id = useQueryParameter("id")
@@ -159,6 +162,7 @@ const EmailTemplateView = () => {
     setTriggeredByCourseId(
       data.email_template?.triggered_automatically_by_course_id,
     )
+    setCourseInstanceLanguage(data.email_template?.course_instance_language)
     setDidInit(true)
     setEmailTemplate(data.email_template)
   }
@@ -265,6 +269,21 @@ const EmailTemplateView = () => {
                   />
                 </>
               ) : null}
+              {templateType === "course-stats" ? (
+                <>
+                  <TextField
+                    label="Course instance language (used if course is handled by a parent course; short code like fi, sv, fr-be)"
+                    fullWidth
+                    autoComplete="off"
+                    variant="outlined"
+                    value={courseInstanceLanguage ?? ""}
+                    onChange={(e) => {
+                      e.preventDefault()
+                      setCourseInstanceLanguage(e.target.value)
+                    }}
+                  />
+                </>
+              ) : null}
               <CollapseButton
                 open={isHelpOpen}
                 label="Help"
@@ -292,16 +311,17 @@ const EmailTemplateView = () => {
                               {` }}`}
                             </code>
                           </CardTitle>
-                          {(value.description || value.types?.length) && (
+                          {(value.description ||
+                            (value.types?.length ?? 0) > 0) && (
                             <CardContent>
                               <Typography variant="body1">
                                 {value.description}
                               </Typography>
-                              {value.types?.length && (
+                              {(value.types?.length ?? 0) > 0 && (
                                 <p>
                                   Limited to template type
-                                  {value.types.length > 1 ? "s" : ""}{" "}
-                                  {value.types.map((type, index) => (
+                                  {value.types!.length > 1 ? "s" : ""}{" "}
+                                  {value.types!.map((type, index) => (
                                     <>
                                       {index > 0 ? ", " : ""}
                                       <strong>
@@ -339,6 +359,7 @@ const EmailTemplateView = () => {
                         exercise_completions_threshold: exerciseThreshold,
                         points_threshold: pointsThreshold,
                         template_type: templateType,
+                        course_instance_language: courseInstanceLanguage,
                       },
                     })
                     console.log(data)


### PR DESCRIPTION
For courses that have handlers (settings and/or completion), the course stats have not been working correctly as they have been either a) getting the child course counts or b) getting the parent course counts without limiting the language of the child. 

Added field `course_instance_language` to `EmailTemplate` -- this corresponds to the short code used in `UserCourseSetting`, ie. `fi`, `sv`, `en-ie` and so on. If this is present, then this is used as a filter. Also, now the parent course will always be queried if it is present in the course settings.