### PR TITLE
fix MUI component augmentation for next/link

### DIFF
--- a/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
+++ b/frontend/components/Buttons/ButtonWithPaddingAndMargin.tsx
@@ -1,3 +1,4 @@
+import { EnhancedButton } from "@mui/material"
 import Button from "@mui/material/Button"
 import { styled } from "@mui/material/styles"
 
@@ -11,4 +12,4 @@ export const ButtonWithPaddingAndMargin = styled(Button)`
       : color ?? "#000000"};
   font-size: 18px;
   padding: 0.5em;
-` as typeof Button
+` as EnhancedButton

--- a/frontend/components/Buttons/FormSubmitButton.tsx
+++ b/frontend/components/Buttons/FormSubmitButton.tsx
@@ -4,4 +4,4 @@ import { styled } from "@mui/material/styles"
 export const FormSubmitButton = styled(Button)`
   margin-bottom: 0.5rem;
   font-size: 1.1rem;
-` as typeof Button
+`

--- a/frontend/components/Buttons/HeaderMenuButton.tsx
+++ b/frontend/components/Buttons/HeaderMenuButton.tsx
@@ -1,3 +1,4 @@
+import { EnhancedButton } from "@mui/material"
 import Button from "@mui/material/Button"
 import { styled } from "@mui/material/styles"
 
@@ -13,4 +14,4 @@ export const HeaderMenuButton = styled(Button)`
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-` as typeof Button
+` as EnhancedButton

--- a/frontend/components/Dashboard/CourseCard.tsx
+++ b/frontend/components/Dashboard/CourseCard.tsx
@@ -63,7 +63,8 @@ const ImageContainer = styled("div")`
 const StyledLink = styled(Link)`
   text-decoration: none;
   margin-left: 0px;
-`
+` as typeof Link
+
 const CourseCardItem = styled("li")`
   display: flex;
   padding: 1rem;

--- a/frontend/components/HeaderBar/LanguageSwitch.tsx
+++ b/frontend/components/HeaderBar/LanguageSwitch.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router"
 
 import Language from "@mui/icons-material/Language"
-import { Link } from "@mui/material"
+import { EnhancedLink, Link } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 const SwitchLink = styled(Link)`
@@ -21,7 +21,7 @@ const SwitchLink = styled(Link)`
   @media (max-width: 400px) {
     font-size: 10px;
   }
-` as typeof Link
+` as EnhancedLink
 
 const LanguageIcon = styled(Language)`
   margin-right: 0.4rem;

--- a/frontend/components/HeaderBar/LoggedInUserMenu.tsx
+++ b/frontend/components/HeaderBar/LoggedInUserMenu.tsx
@@ -2,6 +2,7 @@ import ChalkboardTeacherIcon from "@fortawesome/fontawesome-free/svgs/solid/chal
 import EnvelopeIcon from "@fortawesome/fontawesome-free/svgs/solid/envelope.svg?icon"
 import ListIcon from "@fortawesome/fontawesome-free/svgs/solid/list.svg?icon"
 import SearchIcon from "@fortawesome/fontawesome-free/svgs/solid/magnifying-glass.svg?icon"
+import { EnhancedButton } from "@mui/material"
 import Button from "@mui/material/Button"
 import { styled } from "@mui/material/styles"
 import Typography from "@mui/material/Typography"
@@ -11,9 +12,13 @@ import { useLoginStateContext } from "/contexts/LoginStateContext"
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
 
+interface StyledButtonProps {
+  active?: boolean
+}
+
 const StyledButton = styled(Button, {
   shouldForwardProp: (prop) => prop !== "active",
-})<{ active?: boolean }>`
+})<StyledButtonProps>`
   margin: 1rem;
   font-size: 22px;
   border-radius: 0px;
@@ -36,7 +41,7 @@ const StyledButton = styled(Button, {
   }
   color: ${(props) => (props.active ? "#378170" : "black")};
   border-bottom: ${(props) => (props.active ? "1px solid #378170" : "")};
-`
+` as EnhancedButton<"button", StyledButtonProps>
 
 const ButtonLabel = styled(Typography)`
   font-family: var(--header-font) !important;
@@ -63,7 +68,7 @@ const UserMenu = () => {
             href="/courses"
             color="inherit"
             variant="text"
-            active={active == "courses" ? 1 : null}
+            active={active === "courses"}
             style={{ marginLeft: "1em" }}
           >
             <ChalkboardTeacherIcon />
@@ -74,7 +79,7 @@ const UserMenu = () => {
             href="/study-modules"
             color="inherit"
             variant="text"
-            active={active == "study-modules" ? 1 : null}
+            active={active === "study-modules"}
           >
             <ListIcon />
             <ButtonLabel>{t("modules")}</ButtonLabel>
@@ -83,7 +88,7 @@ const UserMenu = () => {
             href="/users/search"
             color="inherit"
             variant="text"
-            active={active == "users" ? 1 : null}
+            active={active === "users"}
           >
             <SearchIcon />
             <ButtonLabel>{t("userSearch")}</ButtonLabel>
@@ -92,7 +97,7 @@ const UserMenu = () => {
             href="/email-templates"
             color="inherit"
             variant="text"
-            active={active == "email-templates" ? 1 : null}
+            active={active === "email-templates"}
           >
             <EnvelopeIcon />
             <ButtonLabel>{t("emailTemplates")}</ButtonLabel>

--- a/frontend/components/Home/FAQ/Common.tsx
+++ b/frontend/components/Home/FAQ/Common.tsx
@@ -5,7 +5,12 @@ import { MDXComponents } from "mdx/types"
 import dynamic from "next/dynamic"
 
 import { MDXProvider } from "@mdx-js/react"
-import { Link as MUILink, Skeleton, Typography } from "@mui/material"
+import {
+  EnhancedLink,
+  Link as MUILink,
+  Skeleton,
+  Typography,
+} from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import ErrorMessage from "/components/ErrorMessage"
@@ -88,7 +93,7 @@ export const Note = styled("section")`
 
 export const Link = styled(MUILink)`
   color: default;
-`
+` as EnhancedLink
 
 const List = styled("ul")``
 const OrderedList = styled("ol")``
@@ -157,7 +162,7 @@ interface FAQPageProps {
 }
 
 const mdxComponents: MDXComponents = {
-  a: Link,
+  a: Link as React.ElementType,
   ul: List,
   ol: OrderedList,
   li: ListItem,

--- a/frontend/components/Home/ModuleSmallCourseCard.tsx
+++ b/frontend/components/Home/ModuleSmallCourseCard.tsx
@@ -1,5 +1,5 @@
-import { Grid, Skeleton, Typography } from "@mui/material"
-import { styled } from "@mui/material/styles"
+import { EnhancedButtonBase, Grid, Skeleton, Typography } from "@mui/material"
+import { css, styled } from "@mui/material/styles"
 
 import {
   ModuleCardText,
@@ -21,7 +21,6 @@ const SkeletonText = styled(Skeleton)`
 
 interface BackgroundProps {
   upcoming?: boolean
-  component: string
 }
 
 const Background = styled(ClickableButtonBase)<BackgroundProps>`
@@ -34,29 +33,29 @@ const Background = styled(ClickableButtonBase)<BackgroundProps>`
   width: 100%;
   ${({ upcoming }) =>
     upcoming
-      ? `
-    &:after {
-      border-left: 80px solid transparent;
-      border-right: 80px solid green;
-      border-top: 80px solid transparent;
-      height: 0;
-      width: 0;
-      position: absolute;
-      right: 0px;
-      bottom: 0px;
-      content: "";
-      z-index: 2;
-    }
-    &:after.span {
-      color: #ffffff;
-      font-family: sans-serif;
-      font-size: 1.005em;
-      right: 0px;
-      bottom: 83px;
-      position: absolute;
-      width: 60px;
-    }
-  `
+      ? css`
+          &:after {
+            border-left: 80px solid transparent;
+            border-right: 80px solid green;
+            border-top: 80px solid transparent;
+            height: 0;
+            width: 0;
+            position: absolute;
+            right: 0px;
+            bottom: 0px;
+            content: "";
+            z-index: 2;
+          }
+          &:after.span {
+            color: #ffffff;
+            font-family: sans-serif;
+            font-size: 1.005em;
+            right: 0px;
+            bottom: 83px;
+            position: absolute;
+            width: 60px;
+          }
+        `
       : undefined}
   @media (min-width: 960px) {
     min-height: 150px;
@@ -64,7 +63,7 @@ const Background = styled(ClickableButtonBase)<BackgroundProps>`
   @media (min-width: 600px) and (max-width: 960px) {
     min-height: 250px;
   }
-`
+` as EnhancedButtonBase<"button", BackgroundProps>
 
 const ContentArea = styled("div")`
   padding: 1rem 1rem 2rem 1rem;

--- a/frontend/components/Home/NaviCard.tsx
+++ b/frontend/components/Home/NaviCard.tsx
@@ -2,7 +2,7 @@ import { ClickableDiv } from "components/Surfaces/ClickableCard"
 import { CardTitle } from "components/Text/headers"
 import Image from "next/image"
 
-import { Button, Grid, Link } from "@mui/material"
+import { Button, EnhancedLink, Grid, Link } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import {
@@ -23,7 +23,7 @@ const NaviItemBase = styled(ClickableDiv)`
 const StyledLink = styled(Link)`
   color: black;
   text-decoration: none;
-`
+` as EnhancedLink
 
 type NaviItem = {
   title: string

--- a/frontend/components/Home/WideNaviCard.tsx
+++ b/frontend/components/Home/WideNaviCard.tsx
@@ -2,7 +2,7 @@ import { ClickableDiv } from "components/Surfaces/ClickableCard"
 import { CardTitle } from "components/Text/headers"
 import Image from "next/image"
 
-import { Button, Grid, Link } from "@mui/material"
+import { Button, EnhancedLink, Grid, Link } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import {
@@ -23,7 +23,7 @@ const NaviItemBase = styled(ClickableDiv)`
 const StyledLink = styled(Link)`
   color: black;
   text-decoration: none;
-`
+` as EnhancedLink
 
 type NaviItem = {
   title?: string

--- a/frontend/components/Link.tsx
+++ b/frontend/components/Link.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+
+import NextLink, { LinkProps as NextLinkProps } from "next/link"
+
+export const LinkBehavior = React.forwardRef<HTMLAnchorElement, NextLinkProps>(
+  (props, ref) => {
+    const { href, ...other } = props
+    return <NextLink ref={ref} href={href} {...other} />
+  },
+)

--- a/frontend/components/NewLayout/Header/LanguageSwitch.tsx
+++ b/frontend/components/NewLayout/Header/LanguageSwitch.tsx
@@ -8,14 +8,15 @@ import {
   ButtonGroup,
   ButtonGroupProps,
   ButtonProps,
+  EnhancedButton,
 } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
 
-const LanguageSwitchButton = (buttonProps: ButtonProps) => (
-  <Button component="div" {...buttonProps} tabIndex={-1} />
+const LanguageSwitchButton = (buttonProps: ButtonProps<"div">) => (
+  <Button {...buttonProps} component="div" tabIndex={-1} />
 )
 
 const LanguageSwitchContainer = styled(
@@ -26,7 +27,7 @@ const LanguageSwitchContainer = styled(
       disableFocusRipple
       disableTouchRipple
       {...props}
-      tabIndex="-1"
+      tabIndex={-1}
     />
   ),
   {
@@ -38,9 +39,12 @@ const LanguageSwitchContainer = styled(
   max-height: 8vh;
 `
 
+interface LanguageButtonProps {
+  active: boolean
+}
 const Language = styled(Button, {
   shouldForwardProp: (prop) => prop !== "active",
-})<ButtonProps & { active: boolean }>`
+})<LanguageButtonProps>`
   border: 0;
   text-decoration: none;
   color: inherit;
@@ -49,7 +53,7 @@ const Language = styled(Button, {
   &:hover {
     border: 0;
   }
-`
+` as EnhancedButton<"button", LanguageButtonProps>
 
 const LanguageSwitch = () => {
   const t = useTranslator(CommonTranslations)

--- a/frontend/components/NewLayout/Navigation/DesktopNavigationMenu.tsx
+++ b/frontend/components/NewLayout/Navigation/DesktopNavigationMenu.tsx
@@ -5,7 +5,13 @@ import { useRouter } from "next/router"
 import { useApolloClient } from "@apollo/client"
 import SignOut from "@fortawesome/fontawesome-free/svgs/solid/right-from-bracket.svg?icon"
 import User from "@fortawesome/fontawesome-free/svgs/solid/user.svg?icon"
-import { Button, ButtonProps, SvgIconProps, useMediaQuery } from "@mui/material"
+import {
+  Button,
+  ButtonProps,
+  EnhancedButton,
+  SvgIconProps,
+  useMediaQuery,
+} from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import { NavigationLinks } from "./NavigationLinks"
@@ -59,7 +65,7 @@ const MenuButtonBase = styled(Button)`
   overflow: hidden;
   word-wrap: break-word;
   overflow-wrap: normal;
-`
+` as EnhancedButton<"button", MenuButtonProps>
 
 interface MenuButtonProps {
   Icon?: React.FunctionComponent<SvgIconProps>

--- a/frontend/components/NewLayout/Navigation/MobileNavigationMenu.tsx
+++ b/frontend/components/NewLayout/Navigation/MobileNavigationMenu.tsx
@@ -19,11 +19,12 @@ import User from "@fortawesome/fontawesome-free/svgs/solid/user.svg?icon"
 import MenuIcon from "@mui/icons-material/Menu"
 import {
   Divider,
+  EnhancedMenuItem,
   IconButton,
   ListItemIcon,
   ListItemText,
   Menu,
-  MenuItem,
+  MenuItem as MUIMenuItem,
   SvgIcon,
 } from "@mui/material"
 import { styled } from "@mui/material/styles"
@@ -51,6 +52,8 @@ interface MobileMenuItemProps {
   onClick?: React.MouseEventHandler<HTMLLIElement>
   [key: string]: any
 }
+
+const MenuItem = MUIMenuItem as EnhancedMenuItem
 
 // TODO: check if necessary and remove if it isn't
 const MobileMenuItemLink = forwardRef<HTMLLIElement, MobileMenuItemProps>(

--- a/frontend/components/NewLayout/Navigation/NavigationLinks.tsx
+++ b/frontend/components/NewLayout/Navigation/NavigationLinks.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@mui/material"
+import { EnhancedLink, Link } from "@mui/material"
 import { css, styled } from "@mui/material/styles"
 
 import { useActiveTab } from "/components/NewLayout/Navigation"
@@ -6,9 +6,13 @@ import { useLoginStateContext } from "/contexts/LoginStateContext"
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
 
+interface NavigationLinkProps {
+  active: boolean
+}
+
 const NavigationLink = styled(Link, {
   shouldForwardProp: (prop) => prop !== "active",
-})<React.ComponentProps<"a"> & { active: boolean }>`
+})<NavigationLinkProps>`
   text-decoration: none;
   color: inherit;
   font-size: 1rem;
@@ -26,7 +30,7 @@ const NavigationLink = styled(Link, {
         `}
 
   transition: 0.1s;
-`
+` as EnhancedLink<"a", NavigationLinkProps>
 
 const NavigationLinkContainer = styled("div")`
   display: flex;

--- a/frontend/components/NewLayout/Navigation/NavigationMenu.tsx
+++ b/frontend/components/NewLayout/Navigation/NavigationMenu.tsx
@@ -19,12 +19,13 @@ import MenuIcon from "@mui/icons-material/Menu"
 import {
   Button,
   Divider,
+  EnhancedMenuItem,
   IconButton,
   ListItemIcon,
   ListItemText,
   Menu,
-  MenuItem,
   MenuItemProps,
+  MenuItem as MUIMenuItem,
 } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
@@ -34,6 +35,8 @@ import { useLoginStateContext } from "/contexts/LoginStateContext"
 import { signOut } from "/lib/authentication"
 import CommonTranslations from "/translations/common"
 import { useTranslator } from "/util/useTranslator"
+
+const MenuItem = MUIMenuItem as EnhancedMenuItem
 
 const NavigationMenuContainer = styled("nav")(
   ({ theme }) => `
@@ -150,7 +153,7 @@ const MobileMenuItem = forwardRef<HTMLLIElement, MobileMenuItemProps>(
       </MenuItem>
     )
   },
-)
+) as EnhancedMenuItem<"li", MobileMenuItemProps>
 
 const MobileNavigationMenu = forwardRef<HTMLDivElement>(({}, ref) => {
   const [isOpen, setIsOpen] = useState(false)

--- a/frontend/components/OutboundLink.tsx
+++ b/frontend/components/OutboundLink.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from "react"
 
 import upRightFromSquareSvg from "@fortawesome/fontawesome-free/svgs/solid/up-right-from-square.svg"
-import { Link, LinkProps } from "@mui/material"
+import { EnhancedLink, Link, LinkProps } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 const StyledOutboundLink = styled(Link)`
@@ -15,7 +15,7 @@ const StyledOutboundLink = styled(Link)`
     height: 0.75rem;
     margin-left: 0.5rem;
   }
-` as Link
+` as EnhancedLink
 
 function OutboundLink({
   label,

--- a/frontend/components/Profile/ConsentNotification.tsx
+++ b/frontend/components/Profile/ConsentNotification.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { useRouter } from "next/router"
 
 import Warning from "@mui/icons-material/Warning"
-import { Link, Typography } from "@mui/material"
+import { EnhancedLink, Link as MUILink, Typography } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import ProfileTranslations from "/translations/profile"
@@ -17,6 +17,8 @@ const ConsentNotificationWrapper = styled("div")`
   letter-spacing: 0.01071em;
   background-color: rgb(255, 244, 229);
 `
+
+const Link = MUILink as EnhancedLink
 
 function ConsentNotification() {
   const t = useTranslator(ProfileTranslations)

--- a/frontend/components/Surfaces/ClickableCard.tsx
+++ b/frontend/components/Surfaces/ClickableCard.tsx
@@ -1,4 +1,4 @@
-import ButtonBase from "@mui/material/ButtonBase"
+import { ButtonBase, EnhancedButtonBase } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 export const ClickableButtonBase = styled(ButtonBase)`
@@ -11,7 +11,7 @@ export const ClickableButtonBase = styled(ButtonBase)`
     transition-duration: 0.4s;
     cursor: pointer;
   }
-` as typeof ButtonBase
+` as EnhancedButtonBase
 
 export const ShadowedDiv = styled("div")`
   position: relative;

--- a/frontend/pages/courses/[slug]/index.tsx
+++ b/frontend/pages/courses/[slug]/index.tsx
@@ -4,7 +4,14 @@ import { useConfirm } from "material-ui-confirm"
 import { NextSeo } from "next-seo"
 
 import { useApolloClient, useMutation, useQuery } from "@apollo/client"
-import { Button, Card, Link, Paper, Typography } from "@mui/material"
+import {
+  Button,
+  Card,
+  EnhancedLink,
+  Link as MUILink,
+  Paper,
+  Typography,
+} from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import { WideContainer } from "/components/Container"
@@ -30,6 +37,8 @@ import {
   UserCourseStatsSubscribeDocument,
   UserCourseStatsUnsubscribeDocument,
 } from "/graphql/generated"
+
+const Link = MUILink as EnhancedLink
 
 const Title = styled(Typography)`
   margin-bottom: 0.7em;

--- a/frontend/pages/installation/[id].tsx
+++ b/frontend/pages/installation/[id].tsx
@@ -160,7 +160,7 @@ export const ContainedImage = ({ src, alt, ...props }: any) => {
 
 const mdxComponents: MDXComponents = {
   // Image: ContainedImage,
-  a: Link,
+  a: Link as React.ElementType,
 }
 
 interface InstallationInstructionProps {

--- a/frontend/src/newTheme/components.tsx
+++ b/frontend/src/newTheme/components.tsx
@@ -1,18 +1,7 @@
-import React from "react"
-
-import Link, { LinkProps as NextLinkProps } from "next/link"
-
-import { LinkProps } from "@mui/material"
 import { createTheme, Theme } from "@mui/material/styles"
 
 import { bodyFont } from "./typography"
-
-const LinkBehavior = React.forwardRef<HTMLAnchorElement, NextLinkProps>(
-  (props, ref) => {
-    const { href, ...other } = props
-    return <Link ref={ref} href={href} {...other} />
-  },
-)
+import { LinkBehavior } from "/components/Link"
 
 export const withComponents = (theme: Theme) =>
   createTheme(theme, {
@@ -20,7 +9,7 @@ export const withComponents = (theme: Theme) =>
       MuiLink: {
         defaultProps: {
           component: LinkBehavior,
-        } as LinkProps,
+        },
       },
       MuiTextField: {
         defaultProps: {

--- a/frontend/src/theme/components.tsx
+++ b/frontend/src/theme/components.tsx
@@ -1,19 +1,8 @@
-import React from "react"
-
-import Link, { LinkProps as NextLinkProps } from "next/link"
-
-import { LinkProps } from "@mui/material"
+import { ButtonBaseProps, MenuItemProps } from "@mui/material"
 import { createTheme, Theme } from "@mui/material/styles"
 
+import { LinkBehavior } from "/components/Link"
 import { openSansCondensedDeclaration } from "/src/fonts"
-
-const LinkBehavior = React.forwardRef<HTMLAnchorElement, NextLinkProps>(
-  (props, ref) => {
-    const { href, ...other } = props
-
-    return <Link ref={ref} href={href} {...other} />
-  },
-)
 
 export const withComponents = (theme: Theme) =>
   createTheme(theme, {
@@ -21,7 +10,7 @@ export const withComponents = (theme: Theme) =>
       MuiLink: {
         defaultProps: {
           component: LinkBehavior,
-        } as LinkProps,
+        },
       },
       MuiTextField: {
         defaultProps: {
@@ -44,12 +33,12 @@ export const withComponents = (theme: Theme) =>
         defaultProps: {
           LinkComponent: LinkBehavior,
         },
-      },
+      } as ButtonBaseProps,
       MuiMenuItem: {
         defaultProps: {
           LinkComponent: LinkBehavior,
         },
-      },
+      } as MenuItemProps,
       MuiButton: {
         defaultProps: {
           variant: "contained",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -59,6 +59,7 @@
   ],
   "include": [
     "next-env.d.ts",
+    "types/mui.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "**/*.js"

--- a/frontend/types/mui.d.ts
+++ b/frontend/types/mui.d.ts
@@ -1,21 +1,84 @@
 import { LinkProps as NextLinkProps } from "next/link"
 
+import { Button as MUIButton } from "@mui/material"
+import {
+  ButtonProps,
+  ButtonTypeMap as MUIButtonTypeMap,
+} from "@mui/material/Button"
+import {
+  ButtonBaseProps,
+  ExtendButtonBase,
+  ExtendButtonBaseTypeMap,
+  ButtonBaseTypeMap as MUIButtonBaseTypeMap,
+} from "@mui/material/ButtonBase"
+import { LinkTypeMap as MUILinkTypeMap } from "@mui/material/Link"
+import { MenuItemTypeMap as MUIMenuItemTypeMap } from "@mui/material/MenuItem"
+import {
+  OverridableComponent,
+  OverridableTypeMap,
+  OverrideProps,
+} from "@mui/material/OverridableComponent"
+
+type LinkProps = Omit<
+  NextLinkProps,
+  {
+    [K in keyof NextLinkProps]: K extends `on${string}` ? K : never
+  }[keyof NextLinkProps]
+>
+
 declare module "@mui/material/Link" {
-  import * as base from "@mui/material/Link"
   export type LinkProps<
-    D extends React.ElementType = LinkTypeMap["defaultComponent"],
-    P = object,
-  > = OverrideProps<LinkTypeMap<P, D>, D> & NextLinkProps
-  export = base
+    D extends React.ElementType = MUILinkTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = OverrideProps<MUILinkTypeMap<P, D>, D> & LinkProps
+  declare const Link: OverridableComponent<MUILinkTypeMap<LinkProps, "a">>
+  export default Link
+}
+declare module "@mui/material/ButtonBase" {
+  export type ButtonBaseProps<
+    D extends React.ElementType = MUIButtonBaseTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = OverrideProps<MUIButtonBaseTypeMap<P, D>, D> & Partial<LinkProps>
+  declare const ButtonBase: ExtendButtonBase<
+    MUIButtonBaseTypeMap<Partial<LinkProps>, "button">
+  >
+  export default ButtonBase
 }
 
-declare module "@mui/material/ButtonBase" {
-  import * as base from "@mui/material/ButtonBase"
-  export type ButtonBaseProps<
-    D extends React.ElementType = ButtonBaseTypeMap["defaultComponent"],
-    P = object,
-  > = OverrideProps<ButtonBaseTypeMap<P, D>, D> & NextLinkProps
-  export = base
+declare module "@mui/material/Button" {
+  export type ButtonProps<
+    D extends React.ElementType = MUIButtonTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = OverrideProps<MUIButtonTypeMap<P, D>, D> & Partial<LinkProps>
+  declare const Button: ExtendButtonBase<
+    MUIButtonTypeMap<Partial<LinkProps>, "button">
+  >
+  export default Button
+}
+declare module "@mui/material" {
+  export type EnhancedLink<
+    D extends React.ElementType = MUILinkTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = OverridableComponent<MUILinkTypeMap<P & LinkProps, D>>
+  export type EnhancedButtonBase<
+    D extends React.ElementType = MUIButtonBaseTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = ExtendButtonBase<MUIButtonBaseTypeMap<P & Partial<LinkProps>, D>>
+  export type EnhancedButton<
+    D extends React.ElementType = MUIButtonTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = ExtendButtonBase<MUIButtonTypeMap<P & Partial<LinkProps>, D>>
+  export type EnhancedMenuItem<
+    D extends React.ElementType = MUIMenuItemTypeMap["defaultComponent"],
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    P = {},
+  > = ExtendButtonBase<MUIMenuItemTypeMap<P & Partial<LinkProps>, D>>
 }
 
 declare module "@mui/material/Typography" {


### PR DESCRIPTION
We've been using the `next/link` behavior in the MUI elements such as `Link`, `Button`, `MenuItem` and indeed everything that extends `ButtonBase`.  To make Typescript happy with merging of the two prop types, I had augmented the existing types -- but apparently this hadn't worked as I thought it would because there were default exports and augmentation didn't work with those and promptly made the prop type for any of those elements `any`. That's why the front page course card links broke when I removed Google Analytics -- TS didn't tell me I had forgotten to change one `to` to `href` in the card element props.

This change is not very optimal as it depends on some manual typing, but if some `Link`,  `Button` etc. is being difficult with non-compatible props that come from `next/link` (such as `shallow`, `prefetch` etc.), you can type the element with `EnhancedLink`, `EnhancedButton` and so on. The generic types follow MUI element types - `EnhancedButton<"div", MyOwnButtonProps>` would tell TS to expect props usually passed to a div (instead of a button), as well as the custom props specified. 