### PR TITLE
Update to node 16.16.0; update gc-sdk-node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ orbs:
   helm: circleci/helm@2.0.1
   docker: circleci/docker@1.7.0
   jq: circleci/jq@2.2.0
-  node: circleci/node@5.0.3
+  node: circleci/node@5.1.0
 #  codecov: codecov/codecov@3.2.4
 executors:
   backend_test:
     docker:
-      - image: cimg/node:14.18.3
-      - image: cimg/postgres:11.13
+      - image: cimg/node:16.16.0
+      - image: cimg/postgres:14.6
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
@@ -21,7 +21,7 @@ executors:
 jobs:
   code_style:
     docker:
-      - image: cimg/node:14.18.3
+      - image: cimg/node:16.16.0
     steps:
       - checkout
       - node/install-packages
@@ -84,7 +84,7 @@ jobs:
   test_backend:
     executor: backend_test
     environment:
-      DATABASE_URL: postgres://root@localhost:5432/circle_test
+      DATABASE_URL: postgres://root@localhost/circle_test
       DB_HOST: localhost
       DB_PORT: 5432
       DB_USER: root
@@ -97,9 +97,18 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      # - run:
+      #     name: "Install psql client"
+      #     command: |
+      #       sudo apt-get update
+      #       sudo apt-get install postgresql-client
       - run:
-          name: "Prepare database"
-          command: "bin/prepare-db-for-tests.sh"
+          name: "Wait for database"
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: "Create extensions"
+          command: |
+            psql -d circle_test -U root -p 5432 -h localhost -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE EXTENSION IF NOT EXISTS \"pg_trgm\"; CREATE EXTENSION IF NOT EXISTS \"btree_gin\";"
       - run:
           name: "Run tests"
           command: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:14-buster
+FROM node:16.16.0-buster
 
 RUN apt-get update \
   && apt-get install -yy build-essential libpng-dev postgresql-client libpq-dev redis-tools git jq \
   && rm -rf /var/lib/apt/lists/*
-
 RUN wget https://github.com/edenhill/librdkafka/archive/v1.8.2.tar.gz  -O - | tar -xz \
   && cd librdkafka-1.8.2 \
   && ./configure --prefix=/usr \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:14-buster
+FROM node:16.16.0-buster
 
 RUN apt-get update \
   && apt-get install -y build-essential libgl1-mesa-glx \
   && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /app && chown -R node /app
 
 USER node

--- a/util/GoogleCloudSdkWithNode.dockerfile
+++ b/util/GoogleCloudSdkWithNode.dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk
 
 RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -yy nodejs && rm -rf /var/lib/apt/lists/*
+RUN curl -o nodejs.deb https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.16.0-deb-1nodesource1_amd64.deb
+RUN apt-get -yy install ./nodejs.deb && rm -rf /var/lib/apt/lists/*
 RUN npm i -g npm
 RUN npm install -g @sentry/cli --unsafe-perm


### PR DESCRIPTION
Apparently we can't go higher than 16.16.0 on the backend, as 16.17 changes something that breaks with Prisma 2. We _could_ update Prisma by using a `nexus-plugin-prisma` fork, which would be okay, I guess.

Also updated the version in the Google Cloud SDK custom image; had to lock the version there.