### PR TITLE
Feat: add user course points consumer

### DIFF
--- a/backend/bin/kafkaConsumer/common/userFunctions.ts
+++ b/backend/bin/kafkaConsumer/common/userFunctions.ts
@@ -86,7 +86,10 @@ export const checkRequiredExerciseCompletions = async ({
       .andWhereNot("exercise.deleted", true)
       .andWhereNot("exercise.max_points", 0)
 
-    return exercise_completions[0].count >= course.exercise_completions_needed
+    return (
+      Number(exercise_completions[0].count) >=
+      course.exercise_completions_needed
+    )
   }
   return true
 }

--- a/backend/bin/kafkaConsumer/common/userPoints/__test__/saveToDB.test.ts
+++ b/backend/bin/kafkaConsumer/common/userPoints/__test__/saveToDB.test.ts
@@ -176,18 +176,18 @@ describe("userPoints/saveToDatabase", () => {
         ...message,
         timestamp: "1900-01-01T10:00:00.00+02:00",
       })
-      if (!ret.isOk()) {
+      if (!ret.isWarning()) {
         fail()
       }
-      expect(ret.value).toContain("Timestamp older")
+      expect(ret.value.message).toContain("Timestamp older")
     })
 
     it("aborts on equal timestamp", async () => {
       const ret = await saveToDatabase(kafkaContext, message)
-      if (!ret.isOk()) {
+      if (!ret.isWarning()) {
         fail()
       }
-      expect(ret.value).toContain("Timestamp older")
+      expect(ret.value.message).toContain("Timestamp older")
     })
 
     it("updates actions when not completed", async () => {

--- a/backend/bin/kafkaConsumer/common/userPoints/exerciseCompletionFunctions.ts
+++ b/backend/bin/kafkaConsumer/common/userPoints/exerciseCompletionFunctions.ts
@@ -83,7 +83,7 @@ export const getExerciseAndCompletions = async <
 }
 
 export const getCreatedAndUpdatedExerciseCompletions = async <
-  M extends { user_id: number; exercises: Array<Message> },
+  M extends { course_id: string; user_id: number; exercises: Array<Message> },
 >(
   { logger, prisma }: KafkaContext,
   message: M,
@@ -122,6 +122,19 @@ export const getCreatedAndUpdatedExerciseCompletions = async <
       new DatabaseInputError(
         `Given exercises do not exist`,
         missingExerciseIds,
+      ),
+    )
+  }
+
+  const wrongCourseIds = existingExercises
+    .filter((e) => e.course_id !== message.course_id)
+    .map((e) => e.custom_id)
+
+  if (wrongCourseIds.length > 0) {
+    return err(
+      new DatabaseInputError(
+        `Given exercises do not belong to the given course`,
+        wrongCourseIds,
       ),
     )
   }

--- a/backend/bin/kafkaConsumer/common/userPoints/exerciseCompletionFunctions.ts
+++ b/backend/bin/kafkaConsumer/common/userPoints/exerciseCompletionFunctions.ts
@@ -1,0 +1,226 @@
+import { DateTime } from "luxon"
+
+import {
+  Exercise,
+  ExerciseCompletion,
+  ExerciseCompletionRequiredAction,
+  Prisma,
+} from "@prisma/client"
+
+import { DatabaseInputError, TimestampWarning } from "../../../../lib/errors"
+import { err, ok } from "../../../../util/result"
+import { parseTimestamp } from "../../util"
+import { KafkaContext } from "../kafkaContext"
+import { Message } from "./interfaces"
+
+interface ExerciseCompletionData {
+  timestamp: DateTime
+  exercise: Exercise
+  exerciseCompletions: Array<
+    ExerciseCompletion & {
+      exercise_completion_required_actions: Array<ExerciseCompletionRequiredAction>
+    }
+  >
+}
+
+export const createExerciseCompletion = async (
+  context: KafkaContext,
+  message: Message,
+  data: {
+    timestamp: DateTime
+    exercise: Exercise
+  },
+) => {
+  const { logger, prisma } = context
+  const { timestamp, exercise } = data
+  const required_actions = message.completed ? [] : message.required_actions
+
+  logger.info("No previous exercise completion, creating a new one")
+  let originalSubmissionDate: DateTime | null = null
+
+  if (message.original_submission_date) {
+    try {
+      originalSubmissionDate = parseTimestamp(message.original_submission_date)
+    } catch (e) {
+      return err(
+        new DatabaseInputError(
+          "Invalid original submission date",
+          message,
+          e instanceof Error ? e : new Error(e as string),
+        ),
+      )
+    }
+  }
+
+  let savedExerciseCompletion: ExerciseCompletion
+
+  const exerciseCompletionCreateInputData: Prisma.ExerciseCompletionCreateInput =
+    {
+      exercise: {
+        connect: { id: exercise.id },
+      },
+      user: {
+        connect: { upstream_id: Number(message.user_id) },
+      },
+      n_points: Number(message.n_points),
+      completed: message.completed,
+      attempted: message.attempted !== null ? message.attempted : undefined,
+      exercise_completion_required_actions: {
+        create: required_actions.map((value) => ({ value })),
+      },
+      timestamp: timestamp.toJSDate(),
+      original_submission_date: originalSubmissionDate?.toJSDate(),
+    }
+  logger.info(`Inserting ${JSON.stringify(exerciseCompletionCreateInputData)}`)
+  try {
+    savedExerciseCompletion = await prisma.exerciseCompletion.create({
+      data: exerciseCompletionCreateInputData,
+    })
+    return ok(savedExerciseCompletion)
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.warn(
+        `Inserting exercise completion failed ${e.name}: ${e.message}`,
+      )
+      return err(e)
+    } else {
+      logger.warn(`Inserting exercise completion failed: ${String(e)}`)
+      return err(new DatabaseInputError(String(e)))
+    }
+  }
+}
+
+export const updateExerciseCompletion = async (
+  context: KafkaContext,
+  message: Message,
+  data: {
+    timestamp: DateTime
+    exerciseCompletions: Array<
+      ExerciseCompletion & {
+        exercise_completion_required_actions: Array<ExerciseCompletionRequiredAction>
+      }
+    >
+  },
+) => {
+  const { logger, prisma } = context
+  const { timestamp, exerciseCompletions } = data
+  const required_actions = message.completed ? [] : message.required_actions
+
+  const exerciseCompleted = exerciseCompletions[0]
+  const existingActionsOnNewestExerciseCompletion =
+    exerciseCompleted.exercise_completion_required_actions
+
+  logger.info("Updating previous exercise completion")
+  const oldTimestamp = DateTime.fromISO(
+    exerciseCompleted?.timestamp?.toISOString() ?? "",
+  )
+
+  // TODO: should we remove the actions if the timestamp is older?
+  if (timestamp <= oldTimestamp) {
+    return ok(new TimestampWarning("Timestamp older than in DB, aborting"))
+  }
+
+  const existingActionValues =
+    existingActionsOnNewestExerciseCompletion?.map((ea) => ea.value) ?? []
+  const createActions = required_actions
+    .filter((ra) => !existingActionValues.includes(ra))
+    .map((value) => ({ value }))
+  const deletedActions = existingActionsOnNewestExerciseCompletion.filter(
+    (ea) => !required_actions.includes(ea.value),
+  )
+
+  let savedExerciseCompletion: ExerciseCompletion
+
+  try {
+    savedExerciseCompletion = await prisma.exerciseCompletion.update({
+      where: { id: exerciseCompleted.id },
+      data: {
+        n_points: Number(message.n_points),
+        completed: { set: message.completed },
+        attempted: {
+          set: message.attempted !== null ? message.attempted : undefined,
+        },
+        exercise_completion_required_actions: {
+          create: createActions,
+          deleteMany: deletedActions.map((da) => ({ id: da.id })),
+        },
+        timestamp: { set: timestamp.toJSDate() },
+        original_submission_date: {
+          set: message.original_submission_date
+            ? DateTime.fromISO(message.original_submission_date).toJSDate()
+            : null,
+        },
+      },
+    })
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.warn(`Updating exercise completion failed ${e.name}: ${e.message}`)
+      return err(e)
+    } else {
+      logger.warn(`Updating exercise completion failed: ${String(e)}`)
+      return err(new DatabaseInputError(String(e)))
+    }
+  }
+
+  return ok(savedExerciseCompletion)
+}
+
+export const pruneExerciseCompletions = async (
+  context: KafkaContext,
+  exerciseCompletions: ExerciseCompletionData["exerciseCompletions"],
+) => {
+  const { logger, prisma } = context
+  const exerciseCompleted = exerciseCompletions[0]
+  // TODO/FIXME: we could prune all the duplicate actions for this user/exercise combination?
+  const exerciseCompletionsWithSameTimestamp = exerciseCompletions
+    .filter((ec) => ec.id !== exerciseCompleted.id)
+    .filter(
+      (ec) =>
+        ec.timestamp.toISOString() ===
+        exerciseCompleted.timestamp.toISOString(),
+    )
+    .filter(
+      (ec) =>
+        (ec?.updated_at ?? new Date(0)) <=
+        (exerciseCompleted?.updated_at ?? new Date(0)),
+    )
+
+  if (exerciseCompletionsWithSameTimestamp.length > 0) {
+    logger.info(
+      "Pruning duplicate exercise completions with same timestamp as the newest one",
+    )
+    try {
+      const prunedActions =
+        await prisma.exerciseCompletionRequiredAction.deleteMany({
+          where: {
+            exercise_completion_id: {
+              in: exerciseCompletionsWithSameTimestamp.map((ec) => ec.id),
+            },
+          },
+        })
+
+      const pruned = await prisma.exerciseCompletion.deleteMany({
+        where: {
+          id: { in: exerciseCompletionsWithSameTimestamp.map((ec) => ec.id) },
+        },
+      })
+      logger.info(
+        `Pruned ${pruned.count} exercise completions and ${prunedActions.count} related required actions`,
+      )
+      return ok({ pruned, prunedActions })
+    } catch (e) {
+      if (e instanceof Error) {
+        logger.warn(
+          `Pruning duplicate exercise completions failed ${e.name}: ${e.message}`,
+        )
+        return err(e)
+      } else {
+        logger.warn(
+          `Pruning duplicate exercise completions failed: ${String(e)}`,
+        )
+        return err(new DatabaseInputError(String(e)))
+      }
+    }
+  }
+  return ok({})
+}

--- a/backend/bin/kafkaConsumer/common/userPoints/saveToDB.ts
+++ b/backend/bin/kafkaConsumer/common/userPoints/saveToDB.ts
@@ -5,7 +5,6 @@ import {
   Exercise,
   ExerciseCompletion,
   ExerciseCompletionRequiredAction,
-  Prisma,
   User,
 } from "@prisma/client"
 
@@ -19,6 +18,11 @@ import { parseTimestamp } from "../../util"
 import { getUserWithRaceCondition } from "../getUserWithRaceCondition"
 import { KafkaContext } from "../kafkaContext"
 import { checkCompletion } from "../userFunctions"
+import {
+  createExerciseCompletion,
+  pruneExerciseCompletions,
+  updateExerciseCompletion,
+} from "./exerciseCompletionFunctions"
 import { Message } from "./interfaces"
 
 const getTimestamp = (
@@ -147,7 +151,7 @@ export const saveToDatabase = async (
   context: KafkaContext,
   message: Message,
 ) => {
-  const { logger, prisma } = context
+  const { logger } = context
 
   logger.info("Handling message: " + JSON.stringify(message))
   const maybeTimestamp = getTimestamp(context, message)
@@ -175,141 +179,41 @@ export const saveToDatabase = async (
   const course = maybeCourse.value
   const [exercise, exerciseCompletions] = maybeExerciseAndCompletions.value
 
-  // @ts-ignore: value not used
-  let savedExerciseCompletion: ExerciseCompletion
-
-  const required_actions = message.completed ? [] : message.required_actions
-
   if (exerciseCompletions.length === 0) {
-    logger.info("No previous exercise completion, creating a new one")
-    let originalSubmissionDate: DateTime | null = null
-
-    if (message.original_submission_date) {
-      try {
-        originalSubmissionDate = parseTimestamp(
-          message.original_submission_date,
-        )
-      } catch (e) {
-        return err(
-          new DatabaseInputError(
-            "Invalid original submission date",
-            message,
-            e instanceof Error ? e : new Error(e as string),
-          ),
-        )
-      }
-    }
-
-    const data: Prisma.ExerciseCompletionCreateInput = {
-      exercise: {
-        connect: { id: exercise.id },
+    const exerciseCompletionCreateResult = await createExerciseCompletion(
+      context,
+      message,
+      {
+        timestamp,
+        exercise,
       },
-      user: {
-        connect: { upstream_id: Number(message.user_id) },
-      },
-      n_points: Number(message.n_points),
-      completed: message.completed,
-      attempted: message.attempted !== null ? message.attempted : undefined,
-      exercise_completion_required_actions: {
-        create: required_actions.map((value) => ({ value })),
-      },
-      timestamp: timestamp.toJSDate(),
-      original_submission_date: originalSubmissionDate?.toJSDate(),
-    }
-    logger.info(`Inserting ${JSON.stringify(data)}`)
-    try {
-      savedExerciseCompletion = await prisma.exerciseCompletion.create({
-        data,
-      })
-    } catch (e) {
-      if (e instanceof Error) {
-        logger.warn(
-          `Inserting exercise completion failed ${e.name}: ${e.message}`,
-        )
-      } else {
-        logger.warn(`Inserting exercise completion failed: ${String(e)}`)
-      }
+    )
+    if (exerciseCompletionCreateResult.isErr()) {
+      return exerciseCompletionCreateResult
     }
   } else {
-    const exerciseCompleted = exerciseCompletions[0]
-    const existingActionsOnNewestExerciseCompletion =
-      exerciseCompleted.exercise_completion_required_actions
-
-    logger.info("Updating previous exercise completion")
-    const oldTimestamp = DateTime.fromISO(
-      exerciseCompleted?.timestamp?.toISOString() ?? "",
-    )
-
-    // TODO: should we remove the actions if the timestamp is older?
-    if (timestamp <= oldTimestamp) {
-      return ok("Timestamp older than in DB, aborting")
-    }
-
-    const existingActionValues =
-      existingActionsOnNewestExerciseCompletion?.map((ea) => ea.value) ?? []
-    const createActions = required_actions
-      .filter((ra) => !existingActionValues.includes(ra))
-      .map((value) => ({ value }))
-    const deletedActions = existingActionsOnNewestExerciseCompletion.filter(
-      (ea) => !required_actions.includes(ea.value),
-    )
-
-    savedExerciseCompletion = await prisma.exerciseCompletion.update({
-      where: { id: exerciseCompleted.id },
-      data: {
-        n_points: Number(message.n_points),
-        completed: { set: message.completed },
-        attempted: {
-          set: message.attempted !== null ? message.attempted : undefined,
-        },
-        exercise_completion_required_actions: {
-          create: createActions,
-          deleteMany: deletedActions.map((da) => ({ id: da.id })),
-        },
-        timestamp: { set: timestamp.toJSDate() },
-        original_submission_date: {
-          set: message.original_submission_date
-            ? DateTime.fromISO(message.original_submission_date).toJSDate()
-            : null,
-        },
+    const exerciseCompletionUpdateResult = await updateExerciseCompletion(
+      context,
+      message,
+      {
+        timestamp,
+        exerciseCompletions,
       },
-    })
+    )
 
-    // TODO/FIXME: we could prune all the duplicate actions for this user/exercise combination?
-    const exerciseCompletionsWithSameTimestamp = exerciseCompletions
-      .filter((ec) => ec.id !== exerciseCompleted.id)
-      .filter(
-        (ec) =>
-          ec.timestamp.toISOString() ===
-          exerciseCompleted.timestamp.toISOString(),
-      )
-      .filter(
-        (ec) =>
-          (ec?.updated_at ?? new Date(0)) <=
-          (exerciseCompleted?.updated_at ?? new Date(0)),
-      )
+    if (
+      exerciseCompletionUpdateResult.isErr() ||
+      exerciseCompletionUpdateResult.isWarning()
+    ) {
+      return exerciseCompletionUpdateResult
+    }
+    const pruneExerciseCompletionsResult = await pruneExerciseCompletions(
+      context,
+      exerciseCompletions,
+    )
 
-    if (exerciseCompletionsWithSameTimestamp.length > 0) {
-      logger.info(
-        "Pruning duplicate exercise completions with same timestamp as the newest one",
-      )
-      const prunedActions =
-        await prisma.exerciseCompletionRequiredAction.deleteMany({
-          where: {
-            exercise_completion_id: {
-              in: exerciseCompletionsWithSameTimestamp.map((ec) => ec.id),
-            },
-          },
-        })
-
-      const pruned = await prisma.exerciseCompletion.deleteMany({
-        where: {
-          id: { in: exerciseCompletionsWithSameTimestamp.map((ec) => ec.id) },
-        },
-      })
-      logger.info(
-        `Pruned ${pruned.count} exercise completions and ${prunedActions.count} related required actions`,
-      )
+    if (pruneExerciseCompletionsResult.isErr()) {
+      // we do nothing as it isn't critical
     }
   }
 

--- a/backend/bin/kafkaConsumer/common/userPoints/util.ts
+++ b/backend/bin/kafkaConsumer/common/userPoints/util.ts
@@ -1,0 +1,79 @@
+import { DateTime } from "luxon"
+
+import { Course, User } from "@prisma/client"
+
+import { DatabaseInputError, TMCError } from "../../../../lib/errors"
+import { err, ok, Result } from "../../../../util/result"
+import { parseTimestamp } from "../../util"
+import { getUserWithRaceCondition } from "../getUserWithRaceCondition"
+import { KafkaContext } from "../kafkaContext"
+
+export const getTimestamp = <M extends { timestamp: string }>(
+  { logger }: KafkaContext,
+  message: M,
+): Result<DateTime, Error> => {
+  logger.info("Parsing timestamp")
+
+  let timestamp: DateTime
+
+  try {
+    timestamp = parseTimestamp(message.timestamp)
+  } catch (e) {
+    return err(
+      new DatabaseInputError(
+        "Invalid date",
+        message,
+        e instanceof Error ? e : new Error(e as string),
+      ),
+    )
+  }
+
+  return ok(timestamp)
+}
+
+export const getUser = async <M extends { user_id: number }>(
+  context: KafkaContext,
+  message: M,
+): Promise<Result<User, Error>> => {
+  const { logger } = context
+  logger.info(`Checking if user ${message.user_id} exists`)
+
+  let user: User | undefined | null
+
+  try {
+    user = await getUserWithRaceCondition(context, message.user_id)
+  } catch (e) {
+    return err(
+      new DatabaseInputError(
+        "User not found",
+        message,
+        e instanceof Error ? e : new TMCError(e as string),
+      ),
+    )
+  }
+
+  if (!user) {
+    return err(new DatabaseInputError(`Invalid user`, message))
+  }
+
+  return ok(user)
+}
+
+export const getCourse = async <M extends { course_id: string }>(
+  { prisma }: KafkaContext,
+  message: M,
+): Promise<
+  Result<Course & { completions_handled_by: Course | null }, Error>
+> => {
+  const course = await prisma.course.findUnique({
+    where: { id: message.course_id },
+    include: {
+      completions_handled_by: true,
+    },
+  })
+
+  if (!course) {
+    return err(new DatabaseInputError(`Invalid course`, message))
+  }
+  return ok(course)
+}

--- a/backend/bin/kafkaConsumer/kafkaConfig.ts
+++ b/backend/bin/kafkaConsumer/kafkaConfig.ts
@@ -14,5 +14,8 @@ export default {
   user_course_progress_realtime_consumer: {
     topic_name: "user-course-progress-realtime",
   },
+  user_course_points_consumer: {
+    topic_name: "user-course-points-batch",
+  },
   commit_interval: 50,
 }

--- a/backend/bin/kafkaConsumer/userCoursePointsConsumer/interfaces.ts
+++ b/backend/bin/kafkaConsumer/userCoursePointsConsumer/interfaces.ts
@@ -1,0 +1,9 @@
+import { Message as UserPointsMessage } from "../common/userPoints/interfaces"
+
+export interface Message {
+  timestamp: string
+  user_id: number
+  course_id: string
+  exercises: UserPointsMessage[]
+  message_format_version: number
+}

--- a/backend/bin/kafkaConsumer/userCoursePointsConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userCoursePointsConsumer/kafkaConsumer.ts
@@ -1,0 +1,72 @@
+import { Message as KafkaMessage, LibrdKafkaError } from "node-rdkafka"
+
+import { Mutex } from "../../../lib/await-semaphore"
+import { KafkaError } from "../../../lib/errors"
+import sentryLogger from "../../../lib/logger"
+import prisma from "../../../prisma"
+import knex from "../../../services/knex"
+import { createKafkaConsumer } from "../common/createKafkaConsumer"
+import { handleMessage } from "../common/handleMessage"
+import { KafkaContext } from "../common/kafkaContext"
+import { handledRecently, setHandledRecently } from "../common/messageHashCache"
+import config from "../kafkaConfig"
+import { saveToDatabase } from "./saveToDB"
+import { MessageYupSchema } from "./validate"
+
+const TOPIC_NAME = [config.user_course_points_consumer.topic_name]
+
+const mutex = new Mutex()
+
+const logger = sentryLogger({ service: "kafka-consumer-user-course-points" })
+const consumer = createKafkaConsumer({ logger, prisma })
+
+consumer.connect()
+
+const context: KafkaContext = {
+  prisma,
+  logger,
+  mutex,
+  consumer,
+  knex,
+  topic_name: TOPIC_NAME[0],
+}
+
+consumer.on("ready", () => {
+  logger.info("Ready to consume")
+  consumer.subscribe(TOPIC_NAME)
+
+  const consumerImpl = async (
+    error: LibrdKafkaError,
+    messages: KafkaMessage[],
+  ) => {
+    if (error) {
+      logger.error(new KafkaError("Error while consuming", error))
+      process.exit(-1)
+    }
+
+    if (messages.length > 0) {
+      const messageString = messages[0]?.value?.toString("utf8") ?? ""
+      if (!handledRecently(messageString)) {
+        await handleMessage({
+          context,
+          kafkaMessage: messages[0],
+          MessageYupSchema,
+          saveToDatabase,
+        })
+        setHandledRecently(messageString)
+      } else {
+        logger.info("Skipping message because it was already handled recently.")
+      }
+
+      setImmediate(() => {
+        consumer.consume(1, consumerImpl)
+      })
+    } else {
+      setTimeout(() => {
+        consumer.consume(1, consumerImpl)
+      }, 10)
+    }
+  }
+
+  consumer.consume(1, consumerImpl)
+})

--- a/backend/bin/kafkaConsumer/userCoursePointsConsumer/validate.ts
+++ b/backend/bin/kafkaConsumer/userCoursePointsConsumer/validate.ts
@@ -1,0 +1,17 @@
+import * as yup from "yup"
+
+import { MessageYupSchema as UserPointsMessageYupSchema } from "../common/userPoints/validate"
+
+const CURRENT_MESSAGE_FORMAT_VERSION = 1
+
+export const MessageYupSchema = yup.object().shape({
+  timestamp: yup.date().required(),
+  user_id: yup.number().required(),
+  course_id: yup.string().length(36).required(),
+  exercises: yup.array(UserPointsMessageYupSchema).required(),
+  message_format_version: yup
+    .number()
+    .min(CURRENT_MESSAGE_FORMAT_VERSION)
+    .max(CURRENT_MESSAGE_FORMAT_VERSION)
+    .required(),
+})

--- a/backend/bin/kafkaConsumer/userPointsConsumer/kafkaConsumer.ts
+++ b/backend/bin/kafkaConsumer/userPointsConsumer/kafkaConsumer.ts
@@ -9,7 +9,6 @@ import { createKafkaConsumer } from "../common/createKafkaConsumer"
 import { handleMessage } from "../common/handleMessage"
 import { KafkaContext } from "../common/kafkaContext"
 import { handledRecently, setHandledRecently } from "../common/messageHashCache"
-import { Message } from "../common/userPoints/interfaces"
 import { saveToDatabase } from "../common/userPoints/saveToDB"
 import { MessageYupSchema } from "../common/userPoints/validate"
 import config from "../kafkaConfig"
@@ -44,10 +43,11 @@ consumer.on("ready", () => {
       logger.error(new KafkaError("Error while consuming", error))
       process.exit(-1)
     }
+
     if (messages.length > 0) {
       const messageString = messages[0]?.value?.toString("utf8") ?? ""
       if (!handledRecently(messageString)) {
-        await handleMessage<Message>({
+        await handleMessage({
           context,
           kafkaMessage: messages[0],
           MessageYupSchema,

--- a/backend/graphql/Completion/__test__/Completion.test.ts
+++ b/backend/graphql/Completion/__test__/Completion.test.ts
@@ -91,7 +91,7 @@ describe("Completion", () => {
             "create",
           )
 
-          const res = await ctx.client.request(recheckMutation, {
+          const res = await ctx.client.request<any>(recheckMutation, {
             course_id: "00000000000000000000000000000002",
           })
 
@@ -150,7 +150,7 @@ describe("Completion", () => {
             },
           })
 
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             createRegistrationAttemptDateMutation,
             {
               id: "30000000-0000-0000-0000-000000000102",
@@ -187,7 +187,7 @@ describe("Completion", () => {
             },
           })
 
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             createRegistrationAttemptDateMutation,
             {
               id: "30000000-0000-0000-0000-000000000103",
@@ -223,7 +223,7 @@ describe("Completion", () => {
             },
           })
 
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             createRegistrationAttemptDateMutation,
             {
               id: "30000000-0000-0000-0000-000000000102",

--- a/backend/graphql/Course/__test__/Course.mutations.test.ts
+++ b/backend/graphql/Course/__test__/Course.mutations.test.ts
@@ -195,7 +195,7 @@ describe("Course", () => {
       test.each(cases)(
         "creates a course %s",
         async (_, { data, expected, omitIdFields = [] }) => {
-          const res = await ctx.client.request(createCourseMutation, {
+          const res = await ctx.client.request<any>(createCourseMutation, {
             course: data,
           })
 
@@ -270,7 +270,7 @@ describe("Course", () => {
       })
 
       it("updates course", async () => {
-        const res = await ctx.client.request(updateCourseMutation, {
+        const res = await ctx.client.request<any>(updateCourseMutation, {
           course: {
             ...getUpdateCourse(),
             new_photo: undefined,
@@ -314,7 +314,7 @@ describe("Course", () => {
       })
 
       it("updates language tag", async () => {
-        const res = await ctx.client.request(updateCourseMutation, {
+        const res = await ctx.client.request<any>(updateCourseMutation, {
           course: {
             ...getUpdateCourse(),
             new_photo: undefined,
@@ -353,7 +353,7 @@ describe("Course", () => {
       })
 
       it("removes language tag", async () => {
-        const res = await ctx.client.request(updateCourseMutation, {
+        const res = await ctx.client.request<any>(updateCourseMutation, {
           course: {
             ...getUpdateCourse(),
             new_photo: undefined,
@@ -392,7 +392,7 @@ describe("Course", () => {
       })
 
       it("updates photo", async () => {
-        const res = await ctx.client.request(updateCourseMutation, {
+        const res = await ctx.client.request<any>(updateCourseMutation, {
           course: getUpdateCourse(),
         })
 
@@ -435,7 +435,7 @@ describe("Course", () => {
       })
 
       it("deletes photo", async () => {
-        const res = await ctx.client.request(updateCourseMutation, {
+        const res = await ctx.client.request<any>(updateCourseMutation, {
           course: {
             ...getUpdateCourse(),
             new_photo: undefined,

--- a/backend/graphql/Course/__test__/Course.queries.test.ts
+++ b/backend/graphql/Course/__test__/Course.queries.test.ts
@@ -40,10 +40,10 @@ describe("Course", () => {
         })
 
         it("returns course on id and slug", async () => {
-          const resId = await ctx.client.request(courseQuery, {
+          const resId = await ctx.client.request<any>(courseQuery, {
             id: createdCourses?.[0].id,
           })
-          const resSlug = await ctx.client.request(courseQuery, {
+          const resSlug = await ctx.client.request<any>(courseQuery, {
             slug: "course1",
           })
 
@@ -56,7 +56,7 @@ describe("Course", () => {
         })
 
         it("returns correct language", async () => {
-          const res = await ctx.client.request(courseQuery, {
+          const res = await ctx.client.request<any>(courseQuery, {
             slug: "course1",
             language: "en_US",
           })
@@ -68,7 +68,7 @@ describe("Course", () => {
         })
 
         it("should return null on non-existent language", async () => {
-          const res = await ctx.client.request(courseQuery, {
+          const res = await ctx.client.request<any>(courseQuery, {
             slug: "course1",
             language: "sv_SE",
           })
@@ -96,10 +96,10 @@ describe("Course", () => {
         beforeEach(() => ctx.client.setHeader("Authorization", "Bearer admin"))
 
         it("returns full course on id and slug", async () => {
-          const resId = await ctx.client.request(fullCourseQuery, {
+          const resId = await ctx.client.request<any>(fullCourseQuery, {
             id: createdCourses?.[0].id,
           })
-          const resSlug = await ctx.client.request(fullCourseQuery, {
+          const resSlug = await ctx.client.request<any>(fullCourseQuery, {
             slug: "course1",
           })
 
@@ -115,7 +115,7 @@ describe("Course", () => {
         })
 
         it("should include deleted exercises if specified", async () => {
-          const res = await ctx.client.request(fullCourseQuery, {
+          const res = await ctx.client.request<any>(fullCourseQuery, {
             slug: "course1",
             includeDeletedExercises: true,
           })
@@ -135,7 +135,7 @@ describe("Course", () => {
       })
 
       it("returns courses", async () => {
-        const res = await ctx.client.request(coursesQuery)
+        const res = await ctx.client.request<any>(coursesQuery)
 
         expect(
           orderBy(res.courses.map(sortStudyModules), ["id"]),
@@ -144,7 +144,7 @@ describe("Course", () => {
 
       it("returns courses ordered", async () => {
         for (const order of ["asc", "desc"]) {
-          const res = await ctx.client.request(coursesQuery, {
+          const res = await ctx.client.request<any>(coursesQuery, {
             orderBy: { name: order },
           })
 
@@ -156,7 +156,7 @@ describe("Course", () => {
 
       it("returns courses filtered by language", async () => {
         for (const language of ["fi_FI", "en_US", "bogus"]) {
-          const res = await ctx.client.request(coursesQuery, {
+          const res = await ctx.client.request<any>(coursesQuery, {
             language,
           })
 
@@ -179,7 +179,7 @@ describe("Course", () => {
 
       it("returns search results", async () => {
         for (const [search, expected] of searchTest) {
-          const res = await ctx.client.request(coursesQuery, {
+          const res = await ctx.client.request<any>(coursesQuery, {
             search,
           })
 
@@ -192,7 +192,7 @@ describe("Course", () => {
 
       it("filters hidden", async () => {
         for (const hidden of [true, false, null]) {
-          const res = await ctx.client.request(coursesQuery, {
+          const res = await ctx.client.request<any>(coursesQuery, {
             hidden,
           })
 
@@ -204,7 +204,7 @@ describe("Course", () => {
 
       it("filters handledBy", async () => {
         for (const handledBy of ["handler", "foo"]) {
-          const res = await ctx.client.request(coursesQuery, {
+          const res = await ctx.client.request<any>(coursesQuery, {
             handledBy,
           })
 
@@ -244,7 +244,7 @@ describe("Course", () => {
       })
 
       it("returns correctly", async () => {
-        const res = await ctx.client.request(
+        const res = await ctx.client.request<any>(
           handlerCoursesQuery,
           {},
           {

--- a/backend/graphql/Course/__test__/Course.test.ts
+++ b/backend/graphql/Course/__test__/Course.test.ts
@@ -120,7 +120,7 @@ describe("Course", () => {
       })
 
       it("works with user_id", async () => {
-        const res = await ctx.client.request(
+        const res = await ctx.client.request<any>(
           courseCompletionsQuery,
           {
             slug: "course1",
@@ -138,7 +138,7 @@ describe("Course", () => {
       })
 
       it("works with user_upstream_id", async () => {
-        const res = await ctx.client.request(
+        const res = await ctx.client.request<any>(
           courseCompletionsQuery,
           {
             slug: "course1",
@@ -156,7 +156,7 @@ describe("Course", () => {
       })
 
       it("shouldn't return anything with non-existent user", async () => {
-        const res = await ctx.client.request(
+        const res = await ctx.client.request<any>(
           courseCompletionsQuery,
           {
             slug: "course1",
@@ -199,7 +199,7 @@ describe("Course", () => {
         })
 
         it("should return name and description in root when language provided", async () => {
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             courseTagsQuery,
             {
               slug: "course1",
@@ -225,7 +225,7 @@ describe("Course", () => {
         })
 
         it("should not return hidden tags", async () => {
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             courseTagsQuery,
             {
               slug: "course2",
@@ -240,7 +240,7 @@ describe("Course", () => {
         })
 
         it("should only return search matches", async () => {
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             courseTagsQuery,
             {
               slug: "course1",
@@ -257,7 +257,7 @@ describe("Course", () => {
         })
 
         it("should only return chosen types", async () => {
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             courseTagsQuery,
             {
               slug: "course1",
@@ -276,7 +276,7 @@ describe("Course", () => {
 
       describe("admin", () => {
         it("should return hidden tags", async () => {
-          const res = await ctx.client.request(
+          const res = await ctx.client.request<any>(
             courseTagsQuery,
             {
               slug: "course2",

--- a/backend/graphql/User/__test__/User.test.ts
+++ b/backend/graphql/User/__test__/User.test.ts
@@ -106,7 +106,7 @@ describe("User", () => {
       it("shows null when not logged in", async () => {
         ctx.client.setHeader("Authorization", "")
 
-        const res = await ctx.client.request(`
+        const res = await ctx.client.request<any>(`
       query {
         currentUser {
           id
@@ -132,7 +132,7 @@ describe("User", () => {
       it("returns courses with completions", async () => {
         ctx.client.setHeader("Authorization", "Bearer normal")
 
-        const res = await ctx.client.request(`
+        const res = await ctx.client.request<any>(`
           query {
             currentUser {
               id
@@ -263,9 +263,12 @@ describe("User", () => {
       it("updates correctly", async () => {
         ctx.client.setHeader("Authorization", "Bearer normal")
 
-        const res = await ctx.client.request(updateReseachConsentMutation, {
-          value: true,
-        })
+        const res = await ctx.client.request<any>(
+          updateReseachConsentMutation,
+          {
+            value: true,
+          },
+        )
 
         expect(res.updateResearchConsent).toMatchSnapshot({
           id: expect.stringMatching(ID_REGEX),
@@ -300,7 +303,7 @@ describe("User", () => {
       it("updates correctly", async () => {
         ctx.client.setHeader("Authorization", "Bearer normal")
 
-        const res = await ctx.client.request(updateUserNameMutation, {
+        const res = await ctx.client.request<any>(updateUserNameMutation, {
           first_name: "updated first",
           last_name: "updated last",
         })

--- a/backend/lib/errors.ts
+++ b/backend/lib/errors.ts
@@ -10,6 +10,14 @@ class CustomError extends Error {
   }
 }
 
+export abstract class Warning extends Error {
+  constructor(message: string) {
+    super(message)
+
+    this.name = this.constructor.name
+  }
+}
+
 class CustomGraphQLError extends GraphQLError {
   constructor(message: string, options?: GraphQLErrorOptions) {
     super(message, options)
@@ -182,6 +190,14 @@ export class CourseStatsEmailerError extends CustomError {
   override name = "CourseStatsEmailerError"
 
   constructor(message: string, readonly Erorr?: Error) {
+    super(message)
+  }
+}
+
+export class TimestampWarning extends Warning {
+  override name = "TimestampWarning"
+
+  constructor(message: string) {
     super(message)
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "kafka-consumer-user-course-progress-realtime": "node ./dist/bin/kafkaConsumer/userCourseProgressRealtimeConsumer/kafkaConsumer.js",
     "kafka-consumer-user-points-batch": "node ./dist/bin/kafkaConsumer/userPointsConsumer/kafkaConsumer.js",
     "kafka-consumer-user-points-realtime": "node ./dist/bin/kafkaConsumer/userPointsRealtimeConsumer/kafkaConsumer.js",
+    "kafka-consumer-user-course-points-batch": "node ./dist/bin/kafkaConsumer/userCoursePointsConsumer/kafkaConsumer.js",
     "kafka-consumer-exercises": "node ./dist/bin/kafkaConsumer/exerciseConsumer/kafkaConsumer.js",
     "generate": "npm run generate:prisma && npm run generate:nexus",
     "generate:prisma": "prisma generate",

--- a/backend/util/result.ts
+++ b/backend/util/result.ts
@@ -1,3 +1,5 @@
+import { Warning } from "../lib/errors"
+
 export type Result<T, E> = Ok<T, never> | Err<never, E>
 export const ok = <T>(value: T): Ok<T, never> => new Ok(value)
 export const err = <E>(err: E): Err<never, E> => new Err(err)
@@ -5,13 +7,15 @@ export const err = <E>(err: E): Err<never, E> => new Err(err)
 export class Ok<T, E> {
   constructor(readonly value: T) {}
 
-  isOk(): this is Ok<T, E> {
-    return true
+  isOk(): this is Ok<T extends Warning ? never : T, never> {
+    return !(this.value instanceof Warning)
   }
   isErr(): this is Err<never, E> {
-    return !this.isOk()
+    return !this.isOk() && !this.isWarning()
   }
-
+  isWarning(): this is Ok<T extends Warning ? T : never, never> {
+    return this.value instanceof Warning
+  }
   hasValue() {
     return !!this.value
   }
@@ -24,14 +28,16 @@ export class Ok<T, E> {
 export class Err<T, E> {
   constructor(readonly error: E) {}
 
-  isOk(): this is Ok<T, never> {
+  isOk(): this is Ok<T extends Warning ? never : T, never> {
     return false
   }
   isErr(): this is Err<never, E> {
     return !this.isOk()
   }
-
-  hasError() {
+  isWarning(): this is Ok<T extends Warning ? T : never, never> {
+    return false
+  }
+  hasError(): this is Err<never, E> {
     return !!this.error
   }
 

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -41,7 +41,7 @@ Some libraries allow to use autocommit feature. Autocommit with commit every mes
 >From a certain point onward there is no longer any turning back. That is the point that must be reached.  
 > ~ Franz Kafka
 ---
-## In Points.mooc.fi
+## In mooc.fi
 
 At the moment we have six topics in mooc.fi kafka:
 
@@ -59,7 +59,8 @@ First sive are meant to be consumed by us and the last is produced by us. The to
 `Current message format version is: 1`  
 
 This is for submitting users progress in a specific course from a specific service. In typescript the message format looks like this: 
-```Typescript
+
+```ts
 export interface Message {
   timestamp: string
   user_id: number
@@ -80,7 +81,7 @@ export interface PointsByGroup {
 Description of message format version `1`:  
 
 Message  :
-| varibale | description | more info |
+| variable | description | more info |
 | ----------|----------------------------|----|
 | timestamp | when the message was sent | |
 | user_id   | user id from tmc | can be queryed from tmc api with email |
@@ -103,8 +104,9 @@ PointsByGroup:
 
 This is for submitting services exercise data to points. (What exerices are in a course). You provide us a list
 of exercises and we add them to our db. We will delete existing exercies if they are not included in newest exercise update.
+
 In typescript the message format is: 
-```Typescript
+```ts
 export interface Message {
   timestamp: string
   course_id: string
@@ -151,7 +153,8 @@ ExerciseData:
 This is for submitting users points in single exercise.
 
 In typescript the message format is:
-```Typescript
+
+```ts
 export interface Message {
   timestamp: string
   exercise_id: string
@@ -162,6 +165,7 @@ export interface Message {
   course_id: string
   service_id: string
   required_actions: string[]
+  original_submission_date: string
   message_format_version: Number
 }
 ```
@@ -180,13 +184,50 @@ Message:
 | course_id | course id from points db | this is broadcasted in kafka topic courses when a course is created
 | service_id | service_id from points db | each service has one id and this should be stored in services own db
 | required_actions | Array of strings, which describe what user needs to do to complete the exercise | this field is optional
+| original_submission_date | when the user originally submitted the exercise to the service (ie. created at from that database) | this field is optional
 | message_format_version | which version of message format is used | messages with wrong number are not processed
 
+---
 
+### user-course-points-batch
+`Current message format version is: 1`
 
+This is for submitting multiple exercises for one user for one course at a time.
 
+In typescript the message format is:
 
+```ts
+export interface Message {
+  timestamp: string
+  user_id: number
+  course_id: string
+  exercises: Array<{
+    timestamp: string
+    exercise_id: string
+    n_points: Number
+    completed: boolean
+    attempted: boolean
+    user_id: Number
+    course_id: string
+    service_id: string
+    required_actions: string[]
+    original_submission_date: string
+    message_format_version: Number
+  }>
+  message_format_version: number
+}
+```
 
+The `exercises` field is imported from the `user-points-*` message format automatically, so if it changes, this one does as well.
 
+Description of message format version `1`:
 
+Message: 
 
+| variable | description | more info |
+| -------- | ----------- | --------- |
+| timestamp | when the message was sent |
+| user_id | user id from tmc | can be queryed from tmc api with email
+| course_id | course id from points db | this is broadcasted in kafka topic courses when a course is created
+| exercises | array of exercises | see user-points-realtime / user-points-batch 
+| message_format_version | which version of message format is used | messages with wrong number are not processed

--- a/helm/templates/kafka/kafka-consumer-user-course-points-batch.yml
+++ b/helm/templates/kafka/kafka-consumer-user-course-points-batch.yml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-consumer-user-course-points-batch
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: kafka-consumer-user-course-points-batch
+      {{- include "helm.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.kafkaConsumer.userCoursePoints.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: kafka-consumer-user-course-points-batch
+        {{- include "helm.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: kafka-consumer-user-course-points-batch
+          image: "{{ .Values.image.repository }}/moocfi-backend:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["sh", "-c", "npm run kafka-consumer-user-course-points-batch"]
+          imagePullPolicy: Always
+          ports:
+            - name: backend-http
+              containerPort: 4000
+          resources:
+            limits:
+              memory: 1000Mi
+              cpu: 200m
+            requests:
+              memory: 100Mi
+              cpu: 50m
+          envFrom:
+          - secretRef:
+              name: backend-secret
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: redis-password
+          volumeMounts:
+            - name: google-cloud-storage-serviceaccount
+              mountPath: "/etc/gcs"
+              readOnly: true
+      volumes:
+        - name: google-cloud-storage-serviceaccount
+          secret:
+            secretName: google-cloud-storage-serviceaccount
+            items:
+              - key: account.json
+                path: account.json

--- a/helm/templates/kafka/user-course-points-batch-topic.yml
+++ b/helm/templates/kafka/user-course-points-batch-topic.yml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: user-course-points-batch
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka-cluster
+spec:
+  partitions: 10
+  replicas: 2
+  config:
+    retention.ms: 604800000
+    segment.bytes: 107374182

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,6 +22,8 @@ kafkaConsumer:
     replicaCount: 10
   userPointsRealtime:
     replicaCount: 1
+  userCoursePoints:
+    replicaCount: 2
 
 email:
   # controls whether the background email service should be running


### PR DESCRIPTION
Consume multiple `user-points` (ie. exercise completions) for one user for one course. 

Consumer listens to `user-course-points-batch` topic; the message format is updated in the Kafka documentation.