### PR TITLE
Feat: user search returns partial results

### DIFF
--- a/backend/graphql/Completion/queries.ts
+++ b/backend/graphql/Completion/queries.ts
@@ -90,7 +90,9 @@ export const CompletionQueries = extendType({
             completion_language,
             ...(search
               ? {
-                  user: buildUserSearch(search),
+                  user: {
+                    OR: buildUserSearch(search),
+                  },
                 }
               : {}),
           },

--- a/backend/graphql/UserCourseSetting.ts
+++ b/backend/graphql/UserCourseSetting.ts
@@ -380,7 +380,8 @@ const getUserCourseSettingSearch = ({
   user_id,
   user_upstream_id,
 }: GetUserCourseSettingSearchArgs) => {
-  const userSearch = search && search !== "" ? buildUserSearch(search) : null
+  const userSearch =
+    search && search !== "" ? { OR: buildUserSearch(search) } : null
 
   const userConditions = [
     user_id || user_upstream_id

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@devoxa/prisma-relay-cursor-connection": "^2.2.2",
         "@google-cloud/storage": "^6.9.3",
+        "@graphql-tools/schema": "^9.0.17",
         "@prisma/client": "2.23.0",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.7",
@@ -28,6 +29,7 @@
         "graphql": "16.6.0",
         "graphql-scalars": "^1.20.1",
         "graphql-upload": "^13.0.0",
+        "graphql-ws": "^5.12.1",
         "helmet": "^6.0.1",
         "JSONStream": "^1.3.5",
         "knex": "^2.4.2",
@@ -52,6 +54,7 @@
         "websocket": "^1.0.34",
         "winston": "^3.8.2",
         "winston-sentry-log": "^1.0.26",
+        "ws": "^8.13.0",
         "yup": "^1.0.0"
       },
       "devDependencies": {
@@ -75,6 +78,7 @@
         "@types/shortid": "^0.0.29",
         "@types/uuid": "^8.3.4",
         "@types/websocket": "^1.0.5",
+        "@types/ws": "^8.5.4",
         "esm": "^3.2.25",
         "faker": "^5.5.3",
         "get-port": "^5.0.0",
@@ -2305,11 +2309,11 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.3.15",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
-      "integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.0.tgz",
+      "integrity": "sha512-3XYCWe0d3I4F1azNj1CdShlbHfTIfiDgj00R9uvFH8tHKh7i1IWN3F7QQYovcHKhayaR6zPok3YYMESYQcBoaA==",
       "dependencies": {
-        "@graphql-tools/utils": "9.1.4",
+        "@graphql-tools/utils": "9.2.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -2317,12 +2321,12 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
-      "integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.17.tgz",
+      "integrity": "sha512-HVLq0ecbkuXhJlpZ50IHP5nlISqH2GbNgjBJhhRzHeXhfwlUOT4ISXGquWTmuq61K0xSaO0aCjMpxe4QYbKTng==",
       "dependencies": {
-        "@graphql-tools/merge": "8.3.15",
-        "@graphql-tools/utils": "9.1.4",
+        "@graphql-tools/merge": "8.4.0",
+        "@graphql-tools/utils": "9.2.1",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.12"
       },
@@ -2339,10 +2343,11 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
-      "integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -2353,7 +2358,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
       "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "dev": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
@@ -3491,6 +3495,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
       "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5728,6 +5741,17 @@
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
+      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/gtoken": {
@@ -9758,6 +9782,26 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -11466,21 +11510,21 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.3.15",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
-      "integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.0.tgz",
+      "integrity": "sha512-3XYCWe0d3I4F1azNj1CdShlbHfTIfiDgj00R9uvFH8tHKh7i1IWN3F7QQYovcHKhayaR6zPok3YYMESYQcBoaA==",
       "requires": {
-        "@graphql-tools/utils": "9.1.4",
+        "@graphql-tools/utils": "9.2.1",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
-      "integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.17.tgz",
+      "integrity": "sha512-HVLq0ecbkuXhJlpZ50IHP5nlISqH2GbNgjBJhhRzHeXhfwlUOT4ISXGquWTmuq61K0xSaO0aCjMpxe4QYbKTng==",
       "requires": {
-        "@graphql-tools/merge": "8.3.15",
-        "@graphql-tools/utils": "9.1.4",
+        "@graphql-tools/merge": "8.4.0",
+        "@graphql-tools/utils": "9.2.1",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.12"
       },
@@ -11493,10 +11537,11 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
-      "integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
       "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
       }
     },
@@ -11504,7 +11549,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
       "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "dev": true,
       "requires": {}
     },
     "@grpc/grpc-js": {
@@ -12501,6 +12545,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
       "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -14212,6 +14265,12 @@
           "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
         }
       }
+    },
+    "graphql-ws": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
+      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
+      "requires": {}
     },
     "gtoken": {
       "version": "6.1.2",
@@ -17202,6 +17261,12 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "requires": {}
     },
     "xml": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,7 @@
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
     "@devoxa/prisma-relay-cursor-connection": "^2.2.2",
     "@google-cloud/storage": "^6.9.3",
+    "@graphql-tools/schema": "^9.0.17",
     "@prisma/client": "2.23.0",
     "@sentry/integrations": "^6.19.7",
     "@sentry/node": "^6.19.7",
@@ -77,6 +78,7 @@
     "graphql": "16.6.0",
     "graphql-scalars": "^1.20.1",
     "graphql-upload": "^13.0.0",
+    "graphql-ws": "^5.12.1",
     "helmet": "^6.0.1",
     "JSONStream": "^1.3.5",
     "knex": "^2.4.2",
@@ -101,6 +103,7 @@
     "websocket": "^1.0.34",
     "winston": "^3.8.2",
     "winston-sentry-log": "^1.0.26",
+    "ws": "^8.13.0",
     "yup": "^1.0.0"
   },
   "devDependencies": {
@@ -124,6 +127,7 @@
     "@types/shortid": "^0.0.29",
     "@types/uuid": "^8.3.4",
     "@types/websocket": "^1.0.5",
+    "@types/ws": "^8.5.4",
     "esm": "^3.2.25",
     "faker": "^5.5.3",
     "get-port": "^5.0.0",

--- a/backend/util/db-functions.ts
+++ b/backend/util/db-functions.ts
@@ -33,41 +33,14 @@ const getNameCombinations = (search: string) => {
 
 export const buildUserSearch = (
   search?: string | null,
-): Prisma.UserWhereInput => {
+): Array<Prisma.UserWhereInput> => {
   if (isNullOrUndefined(search)) {
-    return {}
+    return []
   }
 
   const possibleNameCombinations = getNameCombinations(search)
 
-  const userSearchQuery: Prisma.UserWhereInput["OR"] = [
-    {
-      email: { contains: search, mode: "insensitive" },
-    },
-    {
-      last_name: { contains: search, mode: "insensitive" },
-    },
-    {
-      first_name: { contains: search, mode: "insensitive" },
-    },
-    {
-      username: { contains: search, mode: "insensitive" },
-    },
-    {
-      student_number: { contains: search },
-    },
-    {
-      real_student_number: { contains: search },
-    },
-  ]
-
-  const searchAsNumber = parseInt(search)
-
-  if (!isNaN(searchAsNumber)) {
-    userSearchQuery.push({
-      upstream_id: searchAsNumber,
-    })
-  }
+  const userSearchQuery: Array<Prisma.UserWhereInput> = []
 
   if (possibleNameCombinations.length) {
     possibleNameCombinations.forEach(({ first_name, last_name }) => {
@@ -78,9 +51,38 @@ export const buildUserSearch = (
     })
   }
 
-  return {
-    OR: userSearchQuery,
+  userSearchQuery.push(
+    ...([
+      {
+        email: { contains: search, mode: "insensitive" },
+      },
+      {
+        last_name: { contains: search, mode: "insensitive" },
+      },
+      {
+        first_name: { contains: search, mode: "insensitive" },
+      },
+      {
+        username: { contains: search, mode: "insensitive" },
+      },
+      {
+        student_number: { contains: search },
+      },
+      {
+        real_student_number: { contains: search },
+      },
+    ] as Array<Prisma.UserWhereInput>),
+  )
+
+  const searchAsNumber = parseInt(search)
+
+  if (!isNaN(searchAsNumber)) {
+    userSearchQuery.push({
+      upstream_id: searchAsNumber,
+    })
   }
+
+  return userSearchQuery
 }
 
 export const buildSearch = (fields: string[], search?: string) =>

--- a/backend/util/db-functions.ts
+++ b/backend/util/db-functions.ts
@@ -42,16 +42,16 @@ export const buildUserSearch = (
 
   const userSearchQuery: Prisma.UserWhereInput["OR"] = [
     {
-      first_name: { contains: search, mode: "insensitive" },
+      email: { contains: search, mode: "insensitive" },
     },
     {
       last_name: { contains: search, mode: "insensitive" },
     },
     {
-      username: { contains: search, mode: "insensitive" },
+      first_name: { contains: search, mode: "insensitive" },
     },
     {
-      email: { contains: search, mode: "insensitive" },
+      username: { contains: search, mode: "insensitive" },
     },
     {
       student_number: { contains: search },

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -58,7 +58,7 @@ const MobileGrid: React.FC = () => {
 
   return (
     <>
-      {loading || data?.userDetailsContains?.edges?.length ? (
+      {loading || data?.count ? (
         <PaginationComponent />
       ) : (
         <Typography>{t("noResults")}</Typography>
@@ -70,7 +70,7 @@ const MobileGrid: React.FC = () => {
 }
 
 const RenderCards: React.FC = () => {
-  const { data, loading } = useContext(UserSearchContext)
+  const { data, loading, page, rowsPerPage } = useContext(UserSearchContext)
 
   if (loading) {
     return (
@@ -84,12 +84,11 @@ const RenderCards: React.FC = () => {
 
   return (
     <>
-      {data?.userDetailsContains?.edges?.map((row, index) => (
-        <DataCard
-          key={row?.node?.upstream_id ?? index}
-          row={row?.node ?? undefined}
-        />
-      ))}
+      {data?.matches
+        .slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+        .map((row, index) => (
+          <DataCard key={row?.upstream_id ?? index} row={row} />
+        ))}
     </>
   )
 }

--- a/frontend/components/Dashboard/Users/MobileGrid.tsx
+++ b/frontend/components/Dashboard/Users/MobileGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from "react"
+import React, { useCallback, useContext, useMemo } from "react"
 
 import range from "lodash/range"
 
@@ -32,7 +32,8 @@ const UserCard = styled(Card)`
 `
 
 const MobileGrid: React.FC = () => {
-  const { data, page, rowsPerPage, loading } = useContext(UserSearchContext)
+  const { data, meta, page, rowsPerPage, loading } =
+    useContext(UserSearchContext)
   const t = useTranslator(UsersTranslations)
 
   const PaginationComponent = useCallback(
@@ -58,11 +59,10 @@ const MobileGrid: React.FC = () => {
 
   return (
     <>
-      {loading || data?.count ? (
-        <PaginationComponent />
-      ) : (
+      {loading || meta.count ? <PaginationComponent /> : null}
+      {!loading && meta.finished && meta.count === 0 ? (
         <Typography>{t("noResults")}</Typography>
-      )}
+      ) : null}
       <RenderCards />
       <PaginationComponent />
     </>
@@ -70,7 +70,7 @@ const MobileGrid: React.FC = () => {
 }
 
 const RenderCards: React.FC = () => {
-  const { data, loading, page, rowsPerPage } = useContext(UserSearchContext)
+  const { data, loading } = useContext(UserSearchContext)
 
   if (loading) {
     return (
@@ -84,11 +84,9 @@ const RenderCards: React.FC = () => {
 
   return (
     <>
-      {data?.matches
-        .slice(page * rowsPerPage, (page + 1) * rowsPerPage)
-        .map((row, index) => (
-          <DataCard key={row?.upstream_id ?? index} row={row} />
-        ))}
+      {data.map((row, index) => (
+        <DataCard key={row?.upstream_id ?? index} row={row} />
+      ))}
     </>
   )
 }
@@ -100,28 +98,35 @@ interface DataCardProps {
 const DataCard = ({ row }: DataCardProps) => {
   const t = useTranslator(UsersTranslations)
 
-  const { email, upstream_id, first_name, last_name, student_number } =
-    row ?? {}
+  const { upstream_id } = row ?? {}
 
-  const fields = [
-    {
-      text: t("userEmail"),
-      value: email,
-      title: true,
-    },
-    {
-      text: t("userFirstName"),
-      value: first_name,
-    },
-    {
-      text: t("userLastName"),
-      value: last_name,
-    },
-    {
-      text: t("userStudentNumber"),
-      value: student_number,
-    },
-  ]
+  const fields = useMemo(() => {
+    const { email, first_name, last_name, student_number } = row ?? {}
+
+    return [
+      {
+        text: t("userEmail"),
+        value: email,
+        title: true,
+      },
+      {
+        text: t("userFirstName"),
+        value: first_name,
+      },
+      {
+        text: t("userLastName"),
+        value: last_name,
+      },
+      {
+        text: t("userStudentNumber"),
+        value: student_number,
+      },
+      {
+        text: t("userTMCid"),
+        value: upstream_id,
+      },
+    ]
+  }, [t, row])
 
   return (
     <UserCard>

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -37,8 +37,9 @@ const StyledTablePagination = styled(TablePagination)`
 
 const TablePaginationActions: React.FC = () => {
   const theme = useTheme()
+
   const {
-    data,
+    meta,
     page,
     rowsPerPage,
     setPage,
@@ -48,7 +49,7 @@ const TablePaginationActions: React.FC = () => {
 
   // const startCursor = data?.userDetailsContains?.pageInfo?.startCursor
   //  const endCursor = data?.userDetailsContains?.pageInfo?.endCursor
-  const count = data?.count ?? 0
+  const { count } = meta
 
   const handleFirstPageButtonClick = useCallback(
     async (_: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -146,7 +147,7 @@ const TablePaginationActions: React.FC = () => {
 const Pagination: React.FC = () => {
   const t = useTranslator(UsersTranslations)
   const {
-    data,
+    meta,
     rowsPerPage,
     page,
     setPage,
@@ -170,10 +171,14 @@ const Pagination: React.FC = () => {
   )
 
   const labelDisplayedRows = useCallback(
-    ({ from, to, count }: LabelDisplayedRowsArgs) =>
-      count > 0
-        ? `${from}-${to === -1 ? count : to}${t("displayedRowsOf")}${count}`
-        : "",
+    ({ from, to, count }: LabelDisplayedRowsArgs) => {
+      if (count === 0) {
+        return ""
+      }
+      const toOrCount = to === -1 ? count : to
+
+      return `${from}-${toOrCount}${t("displayedRowsOf")}${count}`
+    },
     [],
   )
 
@@ -183,7 +188,7 @@ const Pagination: React.FC = () => {
     <StyledTablePagination
       rowsPerPageOptions={[10, 20, 50]}
       colSpan={5}
-      count={data?.count ?? 0}
+      count={meta.count ?? 0}
       rowsPerPage={rowsPerPage}
       page={page}
       SelectProps={{

--- a/frontend/components/Dashboard/Users/Pagination.tsx
+++ b/frontend/components/Dashboard/Users/Pagination.tsx
@@ -46,9 +46,9 @@ const TablePaginationActions: React.FC = () => {
     setSearchVariables,
   } = useContext(UserSearchContext)
 
-  const startCursor = data?.userDetailsContains?.pageInfo?.startCursor
-  const endCursor = data?.userDetailsContains?.pageInfo?.endCursor
-  const count = data?.userDetailsContains?.count ?? 0
+  // const startCursor = data?.userDetailsContains?.pageInfo?.startCursor
+  //  const endCursor = data?.userDetailsContains?.pageInfo?.endCursor
+  const count = data?.count ?? 0
 
   const handleFirstPageButtonClick = useCallback(
     async (_: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -65,8 +65,8 @@ const TablePaginationActions: React.FC = () => {
     async (_: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
         search: searchVariables.search,
-        last: rowsPerPage,
-        before: startCursor,
+        //last: rowsPerPage,
+        //before: startCursor,
       })
       setPage(page - 1)
     },
@@ -77,9 +77,9 @@ const TablePaginationActions: React.FC = () => {
     async (_: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
         search: searchVariables.search,
-        first: rowsPerPage,
-        after: endCursor,
-        skip: 1,
+        //first: rowsPerPage,
+        //after: endCursor,
+        //skip: 1,
       })
       setPage(page + 1)
     },
@@ -90,7 +90,7 @@ const TablePaginationActions: React.FC = () => {
     async (_: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
       setSearchVariables({
         search: searchVariables.search,
-        last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
+        //last: rowsPerPage - (rowsPerPage - (count % rowsPerPage)),
       })
       setPage(Math.max(0, Math.ceil(count / rowsPerPage) - 1))
     },
@@ -183,7 +183,7 @@ const Pagination: React.FC = () => {
     <StyledTablePagination
       rowsPerPageOptions={[10, 20, 50]}
       colSpan={5}
-      count={data?.userDetailsContains?.count ?? 0}
+      count={data?.count ?? 0}
       rowsPerPage={rowsPerPage}
       page={page}
       SelectProps={{

--- a/frontend/components/Dashboard/Users/SearchForm.tsx
+++ b/frontend/components/Dashboard/Users/SearchForm.tsx
@@ -22,8 +22,15 @@ const StyledButton = styled(ButtonWithPaddingAndMargin)`
 `
 
 const SearchForm = () => {
-  const { page, search, setSearch, rowsPerPage, setPage, setSearchVariables } =
-    useContext(UserSearchContext)
+  const {
+    page,
+    search,
+    setSearch,
+    rowsPerPage,
+    setPage,
+    setSearchVariables,
+    resetResults,
+  } = useContext(UserSearchContext)
   const t = useTranslator(UsersTranslations)
 
   const handleSubmit = useCallback(() => {
@@ -34,6 +41,7 @@ const SearchForm = () => {
         skip: 0,
       })
       setPage(0)
+      resetResults()
     }
   }, [search, page, rowsPerPage])
 

--- a/frontend/components/Dashboard/Users/SearchForm.tsx
+++ b/frontend/components/Dashboard/Users/SearchForm.tsx
@@ -1,6 +1,21 @@
-import { useCallback, useContext } from "react"
+import { SyntheticEvent, useCallback, useContext, useState } from "react"
 
-import { TextField, useMediaQuery } from "@mui/material"
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp"
+import {
+  Collapse,
+  FormHelperText,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  useMediaQuery,
+} from "@mui/material"
 import { styled } from "@mui/material/styles"
 import { useEventCallback } from "@mui/material/utils"
 
@@ -11,9 +26,20 @@ import { H1NoBackground } from "/components/Text/headers"
 import UserSearchContext from "/contexts/UserSearchContext"
 import { useTranslator } from "/hooks/useTranslator"
 import UsersTranslations from "/translations/users"
+import notEmpty from "/util/notEmpty"
+
+import { UserSearchMetaFieldsFragment } from "/graphql/generated"
 
 const StyledForm = styled("form")`
   display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 1rem;
+`
+
+const Row = styled("div")`
+  display: flex;
+  flex-direction: row;
   width: 100%;
 `
 
@@ -21,17 +47,66 @@ const StyledButton = styled(ButtonWithPaddingAndMargin)`
   color: white;
 `
 
+const StyledTableContainer = styled(TableContainer)`
+  width: max-content;
+`
+const StyledFormHelperText = styled(FormHelperText)`
+  margin: 8px 0;
+`
+
+const ResultMeta = ({
+  meta,
+}: {
+  meta: Array<UserSearchMetaFieldsFragment>
+}) => {
+  const t = useTranslator(UsersTranslations)
+
+  return (
+    <StyledTableContainer>
+      <Table size="small" style={{ tableLayout: "auto" }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>{t("searchField")}</TableCell>
+            <TableCell>{t("searchFieldValue")}</TableCell>
+            <TableCell>{t("searchFieldResultCount")}</TableCell>
+            <TableCell>{t("searchFieldUniqueResultCount")}</TableCell>
+            <TableCell>{t("searchCount")}</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {meta.map((m) => (
+            <TableRow key={m.field}>
+              <TableCell>{m.field}</TableCell>
+              <TableCell>{m.fieldValue}</TableCell>
+              <TableCell>{m.fieldResultCount}</TableCell>
+              <TableCell>{m.fieldUniqueResultCount}</TableCell>
+              <TableCell>{m.count}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </StyledTableContainer>
+  )
+}
+
 const SearchForm = () => {
   const {
+    loading,
     page,
+    meta,
+    totalMeta,
     search,
     setSearch,
     rowsPerPage,
+    searchVariables,
     setPage,
     setSearchVariables,
     resetResults,
   } = useContext(UserSearchContext)
   const t = useTranslator(UsersTranslations)
+  const isMobile = useMediaQuery("(max-width:900px)")
+  const GridComponent = isMobile ? MobileGrid : WideGrid
+  const [metaVisible, setMetaVisible] = useState(false)
 
   const handleSubmit = useCallback(() => {
     if (search !== "") {
@@ -45,25 +120,63 @@ const SearchForm = () => {
     }
   }, [search, page, rowsPerPage])
 
+  const onSubmit = useCallback(
+    <T extends Element>(event: SyntheticEvent<T>) => {
+      event.preventDefault()
+      handleSubmit()
+    },
+    [handleSubmit],
+  )
+
   const onTextBoxChange = useEventCallback((event: any) => {
     setSearch(event.target.value as string)
   })
 
-  const isMobile = useMediaQuery("(max-width:900px)", { noSsr: true })
-  const GridComponent = isMobile ? MobileGrid : WideGrid
+  const HelperText = useCallback(() => {
+    if (!searchVariables.search) {
+      return <StyledFormHelperText />
+    }
+
+    if (meta.finished) {
+      return (
+        <FormHelperText>
+          {t("searchFinished")}
+
+          {meta.count > 0 && (
+            <Tooltip title={t("searchResultMeta")}>
+              <IconButton
+                size="small"
+                onClick={() => setMetaVisible((prev) => !prev)}
+              >
+                {metaVisible ? (
+                  <KeyboardArrowUpIcon fontSize="small" />
+                ) : (
+                  <KeyboardArrowDownIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          )}
+        </FormHelperText>
+      )
+    }
+
+    return (
+      <StyledFormHelperText>
+        {t("searchInProgress")}
+        {notEmpty(meta.fieldIndex)
+          ? `: ${t("searchCondition")} ${meta.fieldIndex}/${meta.fieldCount}`
+          : null}
+      </StyledFormHelperText>
+    )
+  }, [searchVariables.search, metaVisible, loading, meta])
 
   return (
     <>
       <H1NoBackground component="h1" variant="h1" align="center">
         {t("userSearch")}
       </H1NoBackground>
-      <div>
-        <StyledForm
-          onSubmit={async (event: any) => {
-            event.preventDefault()
-            handleSubmit()
-          }}
-        >
+      <StyledForm onSubmit={onSubmit}>
+        <Row>
           <TextField
             id="standard-search"
             label={t("searchByString")}
@@ -73,20 +186,22 @@ const SearchForm = () => {
             value={search}
             onChange={onTextBoxChange}
           />
-
           <StyledButton
             variant="contained"
             disabled={search === ""}
-            onClick={async (event: any) => {
-              event.preventDefault()
-              handleSubmit()
-            }}
+            onClick={onSubmit}
           >
             {t("search")}
           </StyledButton>
-        </StyledForm>
-        <GridComponent />
-      </div>
+        </Row>
+        <HelperText />
+        {!loading && meta.finished && (
+          <Collapse in={metaVisible} unmountOnExit>
+            <ResultMeta meta={totalMeta} />
+          </Collapse>
+        )}
+      </StyledForm>
+      <GridComponent />
     </>
   )
 }

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -63,7 +63,9 @@ const WideGrid = () => {
       <TableWrapper>
         <Table>
           <TableHead>
-            {rowsPerPage >= 50 && data?.userDetailsContains?.edges?.length ? (
+            {rowsPerPage >= 50 &&
+            data?.matches.slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+              ?.length ? (
               <PaginationComponent />
             ) : null}
             <TableRow>
@@ -93,9 +95,9 @@ const WideGrid = () => {
 
 const RenderResults = () => {
   const t = useTranslator(UsersTranslations)
-  const { data, loading } = useContext(UserSearchContext)
+  const { data, loading, rowsPerPage, page } = useContext(UserSearchContext)
 
-  const results = data?.userDetailsContains?.edges ?? []
+  const results = data?.matches ?? []
 
   if (loading) {
     return (
@@ -122,37 +124,39 @@ const RenderResults = () => {
 
   return (
     <TableBody>
-      {results.map((row) => {
-        const { upstream_id, email, first_name, last_name, student_number } =
-          row?.node ?? {}
+      {results
+        .slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+        .map((row) => {
+          const { upstream_id, email, first_name, last_name, student_number } =
+            row ?? {}
 
-        return (
-          <TableRow key={upstream_id}>
-            <TableCell component="th" scope="row">
-              {email}
-            </TableCell>
-            <TableCell align="right">{first_name}</TableCell>
-            <TableCell align="right">{last_name}</TableCell>
-            <TableCell align="right">{student_number}</TableCell>
-            <TableCell align="right">
-              <ButtonContainer>
-                <Button
-                  href={`/users/${upstream_id}/summary`}
-                  variant="contained"
-                >
-                  {t("summary")}
-                </Button>
-                <Button
-                  href={`/users/${upstream_id}/completions`}
-                  variant="contained"
-                >
-                  {t("completions")}
-                </Button>
-              </ButtonContainer>
-            </TableCell>
-          </TableRow>
-        )
-      })}
+          return (
+            <TableRow key={upstream_id}>
+              <TableCell component="th" scope="row">
+                {email}
+              </TableCell>
+              <TableCell align="right">{first_name}</TableCell>
+              <TableCell align="right">{last_name}</TableCell>
+              <TableCell align="right">{student_number}</TableCell>
+              <TableCell align="right">
+                <ButtonContainer>
+                  <Button
+                    href={`/users/${upstream_id}/summary`}
+                    variant="contained"
+                  >
+                    {t("summary")}
+                  </Button>
+                  <Button
+                    href={`/users/${upstream_id}/completions`}
+                    variant="contained"
+                  >
+                    {t("completions")}
+                  </Button>
+                </ButtonContainer>
+              </TableCell>
+            </TableRow>
+          )
+        })}
     </TableBody>
   )
 }

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -12,6 +12,7 @@ import {
   TableFooter,
   TableHead,
   TableRow,
+  useMediaQuery,
 } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
@@ -36,19 +37,21 @@ const StyledPaper = styled(Paper)`
 
 const ButtonContainer = styled("div")`
   display: flex;
+  justify-content: flex-end;
   gap: 0.5rem;
 `
 
 const WideGrid = () => {
   const t = useTranslator(UsersTranslations)
+  const isVeryWide = useMediaQuery("(min-width: 1200px)")
   const { data, rowsPerPage, page, loading } = useContext(UserSearchContext)
 
   const PaginationComponent = useCallback(
     () => (
       <TableRow>
         {loading ? (
-          <TableCell>
-            <Skeleton />
+          <TableCell colSpan={5}>
+            <Skeleton width="400px" style={{ margin: "auto" }} />
           </TableCell>
         ) : (
           <Pagination />
@@ -63,11 +66,7 @@ const WideGrid = () => {
       <TableWrapper>
         <Table>
           <TableHead>
-            {rowsPerPage >= 50 &&
-            data?.matches.slice(page * rowsPerPage, (page + 1) * rowsPerPage)
-              ?.length ? (
-              <PaginationComponent />
-            ) : null}
+            {rowsPerPage >= 50 ? <PaginationComponent /> : null}
             <TableRow>
               <StyledTableCell>{t("userEmail")}</StyledTableCell>
               {/*             <StyledTableCell align="right">upstream_id</StyledTableCell> */}
@@ -77,9 +76,12 @@ const WideGrid = () => {
               <StyledTableCell align="right">
                 {t("userLastName")}
               </StyledTableCell>
-              <StyledTableCell align="right">
-                {t("userStudentNumber")}
-              </StyledTableCell>
+              <StyledTableCell align="right">{t("userTMCid")}</StyledTableCell>
+              {isVeryWide && (
+                <StyledTableCell align="right">
+                  {t("userStudentNumber")}
+                </StyledTableCell>
+              )}
               <StyledTableCell align="right"></StyledTableCell>
             </TableRow>
           </TableHead>
@@ -95,16 +97,15 @@ const WideGrid = () => {
 
 const RenderResults = () => {
   const t = useTranslator(UsersTranslations)
-  const { data, loading, rowsPerPage, page } = useContext(UserSearchContext)
-
-  const results = data?.matches ?? []
-
+  const { data, loading } = useContext(UserSearchContext)
+  const isVeryWide = useMediaQuery("(min-width: 1200px)")
+  const colSpan = 5 + (isVeryWide ? 1 : 0)
   if (loading) {
     return (
       <TableBody>
         {range(5).map((n) => (
           <TableRow key={`skeleton-${n}`}>
-            <TableCell colSpan={5}>
+            <TableCell colSpan={colSpan}>
               <Skeleton />
             </TableCell>
           </TableRow>
@@ -113,50 +114,51 @@ const RenderResults = () => {
     )
   }
 
-  if (results.length < 1)
+  if (data.length < 1)
     return (
       <TableBody>
         <TableRow>
-          <TableCell colSpan={5}>{t("noResults")}</TableCell>
+          <TableCell colSpan={colSpan}>{t("noResults")}</TableCell>
         </TableRow>
       </TableBody>
     )
 
   return (
     <TableBody>
-      {results
-        .slice(page * rowsPerPage, (page + 1) * rowsPerPage)
-        .map((row) => {
-          const { upstream_id, email, first_name, last_name, student_number } =
-            row ?? {}
+      {data.map((row) => {
+        const { upstream_id, email, first_name, last_name, student_number } =
+          row ?? {}
 
-          return (
-            <TableRow key={upstream_id}>
-              <TableCell component="th" scope="row">
-                {email}
-              </TableCell>
-              <TableCell align="right">{first_name}</TableCell>
-              <TableCell align="right">{last_name}</TableCell>
+        return (
+          <TableRow key={upstream_id}>
+            <TableCell component="th" scope="row">
+              {email}
+            </TableCell>
+            <TableCell align="right">{first_name}</TableCell>
+            <TableCell align="right">{last_name}</TableCell>
+            <TableCell align="right">{upstream_id}</TableCell>
+            {isVeryWide && (
               <TableCell align="right">{student_number}</TableCell>
-              <TableCell align="right">
-                <ButtonContainer>
-                  <Button
-                    href={`/users/${upstream_id}/summary`}
-                    variant="contained"
-                  >
-                    {t("summary")}
-                  </Button>
-                  <Button
-                    href={`/users/${upstream_id}/completions`}
-                    variant="contained"
-                  >
-                    {t("completions")}
-                  </Button>
-                </ButtonContainer>
-              </TableCell>
-            </TableRow>
-          )
-        })}
+            )}
+            <TableCell align="right">
+              <ButtonContainer>
+                <Button
+                  href={`/users/${upstream_id}/summary`}
+                  variant="contained"
+                >
+                  {t("summary")}
+                </Button>
+                <Button
+                  href={`/users/${upstream_id}/completions`}
+                  variant="contained"
+                >
+                  {t("completions")}
+                </Button>
+              </ButtonContainer>
+            </TableCell>
+          </TableRow>
+        )
+      })}
     </TableBody>
   )
 }

--- a/frontend/contexts/UserSearchContext.ts
+++ b/frontend/contexts/UserSearchContext.ts
@@ -1,12 +1,12 @@
 import { createContext } from "react"
 
 import {
-  UserDetailsContainsQuery,
+  UserCoreFieldsFragment,
   UserDetailsContainsQueryVariables,
 } from "/graphql/generated"
 
 interface UserSearchContext {
-  data?: UserDetailsContainsQuery
+  data?: { count?: number; matches: Array<UserCoreFieldsFragment> }
   loading: boolean
   page: number
   rowsPerPage: number
@@ -18,10 +18,11 @@ interface UserSearchContext {
   >
   setRowsPerPage: React.Dispatch<React.SetStateAction<number>>
   setSearch: React.Dispatch<React.SetStateAction<string>>
+  resetResults: () => void
 }
 
 export default createContext<UserSearchContext>({
-  data: {} as UserDetailsContainsQuery,
+  data: { matches: [] as Array<UserCoreFieldsFragment> },
   loading: false,
   page: 0,
   rowsPerPage: 10,
@@ -33,4 +34,5 @@ export default createContext<UserSearchContext>({
   setSearchVariables: () => void 0,
   setRowsPerPage: () => void 0,
   setSearch: () => void 0,
+  resetResults: () => void 0,
 })

--- a/frontend/contexts/UserSearchContext.ts
+++ b/frontend/contexts/UserSearchContext.ts
@@ -3,10 +3,13 @@ import { createContext } from "react"
 import {
   UserCoreFieldsFragment,
   UserDetailsContainsQueryVariables,
+  UserSearchMetaFieldsFragment,
 } from "/graphql/generated"
 
 interface UserSearchContext {
-  data?: { count?: number; matches: Array<UserCoreFieldsFragment> }
+  data: Array<UserCoreFieldsFragment>
+  meta: UserSearchMetaFieldsFragment
+  totalMeta: Array<UserSearchMetaFieldsFragment>
   loading: boolean
   page: number
   rowsPerPage: number
@@ -22,7 +25,9 @@ interface UserSearchContext {
 }
 
 export default createContext<UserSearchContext>({
-  data: { matches: [] as Array<UserCoreFieldsFragment> },
+  data: [] as Array<UserCoreFieldsFragment>,
+  meta: {} as UserSearchMetaFieldsFragment,
+  totalMeta: [] as Array<UserSearchMetaFieldsFragment>,
   loading: false,
   page: 0,
   rowsPerPage: 10,

--- a/frontend/graphql/generated/apollo-helpers.ts
+++ b/frontend/graphql/generated/apollo-helpers.ts
@@ -1368,6 +1368,10 @@ export type UserSearchKeySpecifier = (
   | "field"
   | "fieldCount"
   | "fieldIndex"
+  | "fieldResultCount"
+  | "fieldUniqueResultCount"
+  | "fieldValue"
+  | "finished"
   | "matches"
   | "search"
   | UserSearchKeySpecifier
@@ -1377,6 +1381,10 @@ export type UserSearchFieldPolicy = {
   field?: FieldPolicy<any> | FieldReadFunction<any>
   fieldCount?: FieldPolicy<any> | FieldReadFunction<any>
   fieldIndex?: FieldPolicy<any> | FieldReadFunction<any>
+  fieldResultCount?: FieldPolicy<any> | FieldReadFunction<any>
+  fieldUniqueResultCount?: FieldPolicy<any> | FieldReadFunction<any>
+  fieldValue?: FieldPolicy<any> | FieldReadFunction<any>
+  finished?: FieldPolicy<any> | FieldReadFunction<any>
   matches?: FieldPolicy<any> | FieldReadFunction<any>
   search?: FieldPolicy<any> | FieldReadFunction<any>
 }

--- a/frontend/graphql/generated/apollo-helpers.ts
+++ b/frontend/graphql/generated/apollo-helpers.ts
@@ -1035,6 +1035,13 @@ export type StudyModuleTranslationFieldPolicy = {
   study_module_id?: FieldPolicy<any> | FieldReadFunction<any>
   updated_at?: FieldPolicy<any> | FieldReadFunction<any>
 }
+export type SubscriptionKeySpecifier = (
+  | "userSearch"
+  | SubscriptionKeySpecifier
+)[]
+export type SubscriptionFieldPolicy = {
+  userSearch?: FieldPolicy<any> | FieldReadFunction<any>
+}
 export type TagKeySpecifier = (
   | "courses"
   | "created_at"
@@ -1356,6 +1363,23 @@ export type UserOrganizationFieldPolicy = {
   user?: FieldPolicy<any> | FieldReadFunction<any>
   user_id?: FieldPolicy<any> | FieldReadFunction<any>
 }
+export type UserSearchKeySpecifier = (
+  | "count"
+  | "field"
+  | "fieldCount"
+  | "fieldIndex"
+  | "matches"
+  | "search"
+  | UserSearchKeySpecifier
+)[]
+export type UserSearchFieldPolicy = {
+  count?: FieldPolicy<any> | FieldReadFunction<any>
+  field?: FieldPolicy<any> | FieldReadFunction<any>
+  fieldCount?: FieldPolicy<any> | FieldReadFunction<any>
+  fieldIndex?: FieldPolicy<any> | FieldReadFunction<any>
+  matches?: FieldPolicy<any> | FieldReadFunction<any>
+  search?: FieldPolicy<any> | FieldReadFunction<any>
+}
 export type VerifiedUserKeySpecifier = (
   | "created_at"
   | "display_name"
@@ -1632,6 +1656,13 @@ export type StrictTypedTypePolicies = {
       | (() => undefined | StudyModuleTranslationKeySpecifier)
     fields?: StudyModuleTranslationFieldPolicy
   }
+  Subscription?: Omit<TypePolicy, "fields" | "keyFields"> & {
+    keyFields?:
+      | false
+      | SubscriptionKeySpecifier
+      | (() => undefined | SubscriptionKeySpecifier)
+    fields?: SubscriptionFieldPolicy
+  }
   Tag?: Omit<TypePolicy, "fields" | "keyFields"> & {
     keyFields?: false | TagKeySpecifier | (() => undefined | TagKeySpecifier)
     fields?: TagFieldPolicy
@@ -1716,6 +1747,13 @@ export type StrictTypedTypePolicies = {
       | UserOrganizationKeySpecifier
       | (() => undefined | UserOrganizationKeySpecifier)
     fields?: UserOrganizationFieldPolicy
+  }
+  UserSearch?: Omit<TypePolicy, "fields" | "keyFields"> & {
+    keyFields?:
+      | false
+      | UserSearchKeySpecifier
+      | (() => undefined | UserSearchKeySpecifier)
+    fields?: UserSearchFieldPolicy
   }
   VerifiedUser?: Omit<TypePolicy, "fields" | "keyFields"> & {
     keyFields?:

--- a/frontend/graphql/generated/index.ts
+++ b/frontend/graphql/generated/index.ts
@@ -15,7 +15,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>
 }
-// Generated on 2023-04-11T23:25:59+03:00
+// Generated on 2023-04-12T15:38:55+03:00
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -2556,10 +2556,21 @@ export type UserOrganizationWhereUniqueInput = {
 
 export type UserSearch = {
   __typename?: "UserSearch"
+  /** total count of matches so far */
   count: Scalars["Int"]
+  /** current search condition field(s) */
   field: Maybe<Scalars["String"]>
+  /** total number of search fields */
   fieldCount: Scalars["Int"]
+  /** index of current search field */
   fieldIndex: Scalars["Int"]
+  /** total number of matches for current search field */
+  fieldResultCount: Scalars["Int"]
+  /** total number of unique matches for current search field */
+  fieldUniqueResultCount: Scalars["Int"]
+  /** values used for current search condition field(s) */
+  fieldValue: Maybe<Scalars["String"]>
+  finished: Scalars["Boolean"]
   matches: Array<User>
   search: Maybe<Scalars["String"]>
 }
@@ -6261,10 +6272,14 @@ export type UserSearchSubscription = {
   userSearch: {
     __typename?: "UserSearch"
     field: string | null
+    fieldValue: string | null
     search: string | null
     count: number
     fieldIndex: number
     fieldCount: number
+    fieldResultCount: number
+    fieldUniqueResultCount: number
+    finished: boolean
     matches: Array<{
       __typename?: "User"
       id: string
@@ -6280,6 +6295,19 @@ export type UserSearchSubscription = {
       updated_at: any | null
     }>
   }
+}
+
+export type UserSearchMetaFieldsFragment = {
+  __typename?: "UserSearch"
+  field: string | null
+  fieldValue: string | null
+  search: string | null
+  count: number
+  fieldIndex: number
+  fieldCount: number
+  fieldResultCount: number
+  fieldUniqueResultCount: number
+  finished: boolean
 }
 
 export type ExportUserCourseProgressesQueryVariables = Exact<{
@@ -11764,6 +11792,36 @@ export const VerifiedUserFieldsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<VerifiedUserFieldsFragment, unknown>
+export const UserSearchMetaFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UserSearchMetaFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "UserSearch" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "field" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldValue" } },
+          { kind: "Field", name: { kind: "Name", value: "search" } },
+          { kind: "Field", name: { kind: "Name", value: "count" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldIndex" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldCount" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldResultCount" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "fieldUniqueResultCount" },
+          },
+          { kind: "Field", name: { kind: "Name", value: "finished" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UserSearchMetaFieldsFragment, unknown>
 export const CreateRegistrationAttemptDateDocument = {
   kind: "Document",
   definitions: [
@@ -21052,11 +21110,10 @@ export const UserSearchDocument = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [
-                { kind: "Field", name: { kind: "Name", value: "field" } },
-                { kind: "Field", name: { kind: "Name", value: "search" } },
-                { kind: "Field", name: { kind: "Name", value: "count" } },
-                { kind: "Field", name: { kind: "Name", value: "fieldIndex" } },
-                { kind: "Field", name: { kind: "Name", value: "fieldCount" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "UserSearchMetaFields" },
+                },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "matches" },
@@ -21073,6 +21130,31 @@ export const UserSearchDocument = {
               ],
             },
           },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UserSearchMetaFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "UserSearch" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "field" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldValue" } },
+          { kind: "Field", name: { kind: "Name", value: "search" } },
+          { kind: "Field", name: { kind: "Name", value: "count" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldIndex" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldCount" } },
+          { kind: "Field", name: { kind: "Name", value: "fieldResultCount" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "fieldUniqueResultCount" },
+          },
+          { kind: "Field", name: { kind: "Name", value: "finished" } },
         ],
       },
     },

--- a/frontend/graphql/generated/index.ts
+++ b/frontend/graphql/generated/index.ts
@@ -15,7 +15,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>
 }
-// Generated on 2023-04-11T18:26:52+03:00
+// Generated on 2023-04-11T23:25:59+03:00
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -2091,6 +2091,15 @@ export type StudyModuleWhereUniqueInput = {
   slug?: InputMaybe<Scalars["String"]>
 }
 
+export type Subscription = {
+  __typename?: "Subscription"
+  userSearch: UserSearch
+}
+
+export type SubscriptionuserSearchArgs = {
+  search: Scalars["String"]
+}
+
 export type Tag = {
   __typename?: "Tag"
   courses: Array<Course>
@@ -2543,6 +2552,16 @@ export type UserOrganizationOrderByRelationAggregateInput = {
 
 export type UserOrganizationWhereUniqueInput = {
   id?: InputMaybe<Scalars["String"]>
+}
+
+export type UserSearch = {
+  __typename?: "UserSearch"
+  count: Scalars["Int"]
+  field: Maybe<Scalars["String"]>
+  fieldCount: Scalars["Int"]
+  fieldIndex: Scalars["Int"]
+  matches: Array<User>
+  search: Maybe<Scalars["String"]>
 }
 
 export type UserWhereUniqueInput = {
@@ -6231,6 +6250,36 @@ export type VerifiedUserFieldsFragment = {
       name: string
     }>
   } | null
+}
+
+export type UserSearchSubscriptionVariables = Exact<{
+  search: Scalars["String"]
+}>
+
+export type UserSearchSubscription = {
+  __typename?: "Subscription"
+  userSearch: {
+    __typename?: "UserSearch"
+    field: string | null
+    search: string | null
+    count: number
+    fieldIndex: number
+    fieldCount: number
+    matches: Array<{
+      __typename?: "User"
+      id: string
+      upstream_id: number
+      first_name: string | null
+      last_name: string | null
+      full_name: string | null
+      username: string
+      email: string
+      student_number: string | null
+      real_student_number: string | null
+      created_at: any | null
+      updated_at: any | null
+    }>
+  }
 }
 
 export type ExportUserCourseProgressesQueryVariables = Exact<{
@@ -20961,6 +21010,104 @@ export const ConnectionTestDocument = {
     },
   ],
 } as unknown as DocumentNode<ConnectionTestQuery, ConnectionTestQueryVariables>
+export const UserSearchDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "subscription",
+      name: { kind: "Name", value: "UserSearch" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "search" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "String" },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userSearch" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "search" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "search" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "field" } },
+                { kind: "Field", name: { kind: "Name", value: "search" } },
+                { kind: "Field", name: { kind: "Name", value: "count" } },
+                { kind: "Field", name: { kind: "Name", value: "fieldIndex" } },
+                { kind: "Field", name: { kind: "Name", value: "fieldCount" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "matches" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "UserCoreFields" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UserCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "User" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "upstream_id" } },
+          { kind: "Field", name: { kind: "Name", value: "first_name" } },
+          { kind: "Field", name: { kind: "Name", value: "last_name" } },
+          { kind: "Field", name: { kind: "Name", value: "full_name" } },
+          { kind: "Field", name: { kind: "Name", value: "username" } },
+          { kind: "Field", name: { kind: "Name", value: "email" } },
+          { kind: "Field", name: { kind: "Name", value: "student_number" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "real_student_number" },
+          },
+          { kind: "Field", name: { kind: "Name", value: "created_at" } },
+          { kind: "Field", name: { kind: "Name", value: "updated_at" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  UserSearchSubscription,
+  UserSearchSubscriptionVariables
+>
 export const ExportUserCourseProgressesDocument = {
   kind: "Document",
   definitions: [

--- a/frontend/graphql/queries/user.queries.graphql
+++ b/frontend/graphql/queries/user.queries.graphql
@@ -128,3 +128,16 @@ fragment VerifiedUserFields on VerifiedUser {
   personal_unique_code
   display_name
 }
+
+subscription UserSearch($search: String!) {
+  userSearch(search: $search) {
+    field
+    search
+    count
+    fieldIndex
+    fieldCount
+    matches {
+      ...UserCoreFields
+    }
+  }
+}

--- a/frontend/graphql/queries/user.queries.graphql
+++ b/frontend/graphql/queries/user.queries.graphql
@@ -131,13 +131,21 @@ fragment VerifiedUserFields on VerifiedUser {
 
 subscription UserSearch($search: String!) {
   userSearch(search: $search) {
-    field
-    search
-    count
-    fieldIndex
-    fieldCount
+    ...UserSearchMetaFields
     matches {
       ...UserCoreFields
     }
   }
+}
+
+fragment UserSearchMetaFields on UserSearch {
+  field
+  fieldValue
+  search
+  count
+  fieldIndex
+  fieldCount
+  fieldResultCount
+  fieldUniqueResultCount
+  finished
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "formik-mui": "^5.0.0-alpha.0",
         "formik-mui-x-date-pickers": "^0.0.1",
         "graphql": "16.6.0",
+        "graphql-ws": "^5.12.1",
         "immer": "^9.0.19",
         "isomorphic-unfetch": "^4.0.2",
         "lodash": "^4.17.21",
@@ -3667,6 +3668,18 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/graphql-ws": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
+      "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws/node_modules/tslib": {
@@ -9325,10 +9338,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/graphql-ws": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
-      "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
-      "devOptional": true,
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
+      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
       "engines": {
         "node": ">=10"
       },
@@ -18117,6 +18129,13 @@
         "ws": "8.12.1"
       },
       "dependencies": {
+        "graphql-ws": {
+          "version": "5.11.3",
+          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
+          "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
+          "dev": true,
+          "requires": {}
+        },
         "tslib": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -22358,10 +22377,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.3.tgz",
-      "integrity": "sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==",
-      "devOptional": true,
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
+      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
       "requires": {}
     },
     "gzip-size": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "formik-mui": "^5.0.0-alpha.0",
     "formik-mui-x-date-pickers": "^0.0.1",
     "graphql": "16.6.0",
+    "graphql-ws": "^5.12.1",
     "immer": "^9.0.19",
     "isomorphic-unfetch": "^4.0.2",
     "lodash": "^4.17.21",

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react"
 import { range } from "lodash"
 
 import { useMutation, useQuery } from "@apollo/client"
-import CancelIcon from "@mui/icons-material/Cancel"
 import {
   Button,
   Card,
@@ -12,8 +11,6 @@ import {
   ContainerProps,
   Grid,
   GridProps,
-  IconButton,
-  InputAdornment,
   Skeleton,
   TextField,
   Typography,
@@ -312,28 +309,13 @@ const Register = () => {
         <TextField
           style={{ marginBottom: "0.5rem" }}
           name="search"
-          type="text"
+          type="search"
           variant="outlined"
           value={searchBox}
           autoComplete="off"
           onChange={(e) => setSearchBox(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && cancelFilterDebounce()}
           placeholder={t("search")}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  onClick={() => {
-                    cancelFilterDebounce("")
-                    setSearchBox("")
-                  }}
-                  size="large"
-                >
-                  <CancelIcon />
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
         />
         <OrganizationItems />
       </FormContainer>

--- a/frontend/pages/users/search/[[...text]].tsx
+++ b/frontend/pages/users/search/[[...text]].tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { NextSeo } from "next-seo"
 import { useRouter } from "next/router"
 
-import { useSubscription } from "@apollo/client"
+import { useApolloClient } from "@apollo/client"
 
 import Container from "/components/Container"
 import SearchForm from "/components/Dashboard/Users/SearchForm"
@@ -13,22 +13,38 @@ import { useBreadcrumbs } from "/hooks/useBreadcrumbs"
 import { useQueryParameter } from "/hooks/useQueryParameter"
 import { useSearch } from "/hooks/useSearch"
 import withAdmin from "/lib/with-admin"
+import notEmpty from "/util/notEmpty"
 
 import {
   UserCoreFieldsFragment,
   UserDetailsContainsQueryVariables,
   UserSearchDocument,
+  UserSearchMetaFieldsFragment,
 } from "/graphql/generated"
+
+interface UserSearchResults {
+  data: Array<UserCoreFieldsFragment>
+  meta: UserSearchMetaFieldsFragment
+  totalMeta: Array<UserSearchMetaFieldsFragment>
+}
+
+const emptyResults: UserSearchResults = {
+  data: [],
+  meta: {} as UserSearchMetaFieldsFragment,
+  totalMeta: [],
+}
 
 const UserSearch = () => {
   const router = useRouter()
+  const client = useApolloClient()
   const textParam = useQueryParameter("text", false)
   const pageParam = parseInt(useQueryParameter("page", false), 10) || 0
   const rowsParam = parseInt(useQueryParameter("rowsPerPage", false), 10) || 10
-
-  const [results, setResults] = useState<Array<UserCoreFieldsFragment>>([])
+  const isSearching = useRef(false)
+  const [results, setResults] = useState<UserSearchResults>(emptyResults)
 
   const userSearch = useSearch({
+    search: textParam,
     page: pageParam,
     rowsPerPage: rowsParam,
   })
@@ -40,20 +56,9 @@ const UserSearch = () => {
       skip: pageParam > 0 ? pageParam * rowsParam : undefined,
     })
 
-  const resetResults = useCallback(() => setResults([]), [setResults])
-
-  const { data, loading } = useSubscription(UserSearchDocument, {
-    variables: { search: searchVariables.search },
-    onData: ({ data }) => {
-      console.log("onData", data)
-      if (data.data) {
-        setResults((prev) => [
-          ...prev.concat(data.data?.userSearch.matches ?? []),
-        ])
-      }
-    },
-    skip: !searchVariables.search,
-  })
+  const resetResults = useCallback(() => {
+    setResults({ ...emptyResults })
+  }, [setResults])
 
   const { rowsPerPage, page } = userSearch
 
@@ -61,6 +66,72 @@ const UserSearch = () => {
     if ((searchVariables.search ?? "").trim().length === 0) {
       return
     }
+
+    if (!isSearching.current) {
+      const observer = client.subscribe({
+        query: UserSearchDocument,
+        variables: { search: searchVariables.search },
+      })
+      const subscription = observer.subscribe(
+        ({ data }) => {
+          if (notEmpty(data?.userSearch)) {
+            setResults((prev) => {
+              const {
+                matches,
+                field,
+                fieldValue,
+                count,
+                fieldIndex,
+                fieldCount,
+                fieldResultCount,
+                fieldUniqueResultCount,
+                finished,
+              } = data?.userSearch ?? {}
+              const meta = {
+                field: field ?? "",
+                fieldValue: fieldValue ?? "",
+                search: searchVariables.search,
+                count: count ?? 0,
+                fieldIndex: fieldIndex ?? 0,
+                fieldCount: fieldCount ?? 0,
+                fieldResultCount: fieldResultCount ?? 0,
+                fieldUniqueResultCount: fieldUniqueResultCount ?? 0,
+                finished: finished ?? false,
+              }
+
+              return {
+                meta,
+                totalMeta: [...prev.totalMeta, meta],
+                data: [...prev.data.concat(matches ?? [])],
+              }
+            })
+            if (data?.userSearch?.finished) {
+              isSearching.current = false
+              // subscription.unsubscribe()
+            }
+          }
+        },
+        (_error) => {
+          setResults((prev) => ({
+            ...prev,
+            meta: {
+              ...prev.meta,
+              finished: true,
+            },
+          }))
+          isSearching.current = false
+          subscription.unsubscribe()
+        },
+        () => {
+          subscription.unsubscribe()
+          isSearching.current = false
+        },
+      )
+      isSearching.current = true
+    }
+  }, [searchVariables.search])
+
+  useEffect(() => {
     const searchParams = new URLSearchParams()
     if (rowsPerPage !== 10) {
       searchParams.append("rowsPerPage", rowsPerPage.toString())
@@ -74,12 +145,11 @@ const UserSearch = () => {
       searchVariables.search !== ""
         ? `/users/search/${encodeURIComponent(searchVariables.search)}${query}`
         : `/users/search${query}`
-
     if (router?.asPath !== href) {
       // the history is still a bit wonky - how should it work?
       router.push(href, undefined, { shallow: true })
     }
-  }, [searchVariables, rowsPerPage, page])
+  }, [rowsPerPage, page, searchVariables])
 
   const crumbs: Breadcrumb[] = [
     {
@@ -102,13 +172,22 @@ const UserSearch = () => {
   const value = useMemo(
     () => ({
       ...userSearch,
-      data: { count: data?.userSearch.count, matches: results },
-      loading,
+      meta: results.meta,
+      totalMeta: results.totalMeta,
+      data: results.data.slice(page * rowsPerPage, (page + 1) * rowsPerPage),
+      loading: isSearching.current,
       searchVariables,
       setSearchVariables,
       resetResults,
     }),
-    [results, loading, userSearch, searchVariables, resetResults],
+    [
+      results.meta,
+      results.data,
+      isSearching.current,
+      userSearch,
+      searchVariables,
+      resetResults,
+    ],
   )
 
   return (

--- a/frontend/translations/users/en.json
+++ b/frontend/translations/users/en.json
@@ -6,11 +6,21 @@
   "userFirstName": "First name",
   "userLastName": "Last name",
   "userStudentNumber": "Student number",
+  "userTMCid": "TMC ID",
   "completions": "Completions",
   "summary": "Summary",
   "rowsPerPage": "Rows per page:",
   "displayedRowsOf": " of ",
   "searchByString": "Search by string",
   "searchInCourses": "Search in courses",
-  "searchUser": "Search for another user..."
+  "searchUser": "Search for another user...",
+  "searchInProgress": "Search in progress",
+  "searchFinished": "Search finished",
+  "searchCondition": "condition",
+  "searchField": "field",
+  "searchFieldValue": "value",
+  "searchFieldResultCount": "matches",
+  "searchFieldUniqueResultCount": "unique",
+  "searchCount": "total",
+  "searchResultMeta": "Show search details"
 }

--- a/frontend/translations/users/fi.json
+++ b/frontend/translations/users/fi.json
@@ -6,11 +6,21 @@
   "userFirstName": "Etunimi",
   "userLastName": "Sukunimi",
   "userStudentNumber": "Opiskelijanumero",
+  "userTMCid": "TMC ID",
   "completions": "Suoritukset",
   "summary": "Yhteenveto",
   "rowsPerPage": "Rivejä sivulla:",
   "displayedRowsOf": "/",
   "searchByString": "Etsi merkkijonolla",
   "searchInCourses": "Etsi kursseista",
-  "searchUser": "Etsi toista käyttäjää..."
+  "searchUser": "Etsi toista käyttäjää...",
+  "searchInProgress": "Haku käynnissä",
+  "searchFinished": "Haku valmis",
+  "searchCondition": "hakuehto",
+  "searchField": "ehto",
+  "searchFieldValue": "arvo",
+  "searchFieldResultCount": "osumia",
+  "searchFieldUniqueResultCount": "uniikkeja",
+  "searchCount": "yhteensä",
+  "searchResultMeta": "Näytä lisätietoja hausta"
 }


### PR DESCRIPTION
User search built up a very complicated and slow query with zillions of different conditions, so now we go through each of the possible conditions one by one with a separate query and return the results through a subscription. This way the search feels more responsive. Also added some meta information on the searches in the form, if someone should ever need that -- probably not, but that was almost a side effect of the implementation.

GraphQL playground didn't like subscriptions (probably using some other implementation of subscriptions) so I guess we're using the newer default Apollo ones now. It did only affect the subscription, though, so if we don't really need to do that in the playground, then we can revert.  Tthe old user search works there as well.