### PR TITLE
Get auth to actually work on graphql subscription

### DIFF
--- a/backend/accessControl.ts
+++ b/backend/accessControl.ts
@@ -1,10 +1,10 @@
 import { FieldAuthorizeResolver } from "nexus/dist/plugins/fieldAuthorizePlugin"
 
 export enum Role {
-  USER,
-  ADMIN,
-  ORGANIZATION, //for automated scripts, not for accounts
-  VISITOR,
+  VISITOR = 0,
+  USER = 1,
+  ADMIN = 2,
+  ORGANIZATION = 3, //for automated scripts, not for accounts
 }
 
 type AuthorizeFunction = <TypeName extends string, FieldName extends string>(

--- a/backend/context.ts
+++ b/backend/context.ts
@@ -24,6 +24,7 @@ export interface Context extends BaseContext {
   tmcClient: TmcClient
   locale?: string
   req: IncomingMessage
+  connectionParams?: Record<string, any>
 }
 
 export interface ServerContext extends BaseContext {

--- a/backend/graphql/User/queries.ts
+++ b/backend/graphql/User/queries.ts
@@ -9,7 +9,7 @@ import {
 
 import { User } from "@prisma/client"
 
-import { isAdmin, Role } from "../../accessControl"
+import { isAdmin } from "../../accessControl"
 import { ForbiddenError, UserInputError } from "../../lib/errors"
 import { buildUserSearch, convertPagination } from "../../util/db-functions"
 import { notEmpty } from "../../util/notEmpty"
@@ -139,10 +139,6 @@ export const UserSubscriptions = extendType({
       },
       authorize: isAdmin,
       subscribe(_, { search }, ctx) {
-        if (ctx.role !== Role.ADMIN) {
-          throw new ForbiddenError("Not authorized")
-        }
-
         const queries = buildUserSearch(search) ?? []
         const fieldCount = queries.length
 

--- a/backend/patches/nexus+1.3.0.patch
+++ b/backend/patches/nexus+1.3.0.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/nexus/dist/builder.js b/node_modules/nexus/dist/builder.js
+index 656750b..ed7f817 100644
+--- a/node_modules/nexus/dist/builder.js
++++ b/node_modules/nexus/dist/builder.js
+@@ -807,8 +807,15 @@ class SchemaBuilder {
+                 parentTypeConfig: typeConfig,
+                 schemaConfig: this.config,
+                 schemaExtension: this.schemaExtension,
+-            }, fieldConfig.resolve), subscribe: fieldConfig.subscribe }, builderFieldConfig);
++            }, fieldConfig.resolve), subscribe: this.makeFinalResolver({
++                builder: this.builderLens,
++                fieldConfig: builderFieldConfig,
++                parentTypeConfig: typeConfig,
++                schemaConfig: this.config,
++                schemaExtension: this.schemaExtension,
++            }, fieldConfig.subscribe) }, builderFieldConfig);
+     }
++    
+     makeFinalResolver(info, resolver) {
+         const resolveFn = resolver || graphql_1.defaultFieldResolver;
+         if (this.onCreateResolverFns.length) {
+@@ -819,6 +826,7 @@ class SchemaBuilder {
+         }
+         return resolveFn;
+     }
++
+     buildInputObjectField(fieldConfig, typeConfig) {
+         var _a, _b, _c, _d;
+         const nonNullDefault = this.getNonNullDefault((_b = (_a = typeConfig.extensions) === null || _a === void 0 ? void 0 : _a.nexus) === null || _b === void 0 ? void 0 : _b.config, 'input');

--- a/frontend/components/Dashboard/Users/SearchForm.tsx
+++ b/frontend/components/Dashboard/Users/SearchForm.tsx
@@ -51,7 +51,7 @@ const StyledTableContainer = styled(TableContainer)`
   width: max-content;
 `
 const StyledFormHelperText = styled(FormHelperText)`
-  margin: 8px 0;
+  margin: 8px 0 9px 0;
 `
 
 const ResultMeta = ({
@@ -139,7 +139,9 @@ const SearchForm = () => {
 
     if (meta.finished) {
       return (
-        <FormHelperText>
+        <StyledFormHelperText
+          style={{ margin: meta.count > 0 ? "3px 0" : undefined }}
+        >
           {t("searchFinished")}
 
           {meta.count > 0 && (
@@ -156,7 +158,7 @@ const SearchForm = () => {
               </IconButton>
             </Tooltip>
           )}
-        </FormHelperText>
+        </StyledFormHelperText>
       )
     }
 

--- a/frontend/components/Dashboard/Users/WideGrid.tsx
+++ b/frontend/components/Dashboard/Users/WideGrid.tsx
@@ -97,9 +97,10 @@ const WideGrid = () => {
 
 const RenderResults = () => {
   const t = useTranslator(UsersTranslations)
-  const { data, loading } = useContext(UserSearchContext)
+  const { data, loading, meta } = useContext(UserSearchContext)
   const isVeryWide = useMediaQuery("(min-width: 1200px)")
   const colSpan = 5 + (isVeryWide ? 1 : 0)
+
   if (loading) {
     return (
       <TableBody>
@@ -114,14 +115,21 @@ const RenderResults = () => {
     )
   }
 
-  if (data.length < 1)
+  if (data.length < 1) {
+    if (!meta.finished) {
+      return null
+    }
+
     return (
       <TableBody>
         <TableRow>
-          <TableCell colSpan={colSpan}>{t("noResults")}</TableCell>
+          <TableCell component="th" scope="row" colSpan={colSpan}>
+            {t("noResults")}
+          </TableCell>
         </TableRow>
       </TableBody>
     )
+  }
 
   return (
     <TableBody>

--- a/frontend/lib/with-apollo-client/get-apollo.ts
+++ b/frontend/lib/with-apollo-client/get-apollo.ts
@@ -125,6 +125,13 @@ function create(
     ? new GraphQLWsLink(
         createClient({
           url: production ? "wss://www.mooc.fi/api" : "ws://localhost:4000",
+          connectionParams: () => {
+            const accessToken = nookies.get()["access_token"]
+            if (accessToken) {
+              return { authorization: `Bearer ${accessToken}` }
+            }
+            return {}
+          },
         }),
       )
     : null
@@ -162,7 +169,7 @@ function create(
         error: (error) => {
           // ...
           console.log("error", error)
-          // observer.error(error)
+          observer.error(error)
         },
       })
     })

--- a/helm/templates/shibbo/shibbo-deployment.yml
+++ b/helm/templates/shibbo/shibbo-deployment.yml
@@ -6,7 +6,7 @@ metadata:
     {{- include "helm.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.shibboTest.replicaCount }}
   {{- end }}
   selector:
     matchLabels: 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,11 +19,14 @@ kafkaConsumer:
   userCourseProgressRealtime:
     replicaCount: 1
   userPoints:
-    replicaCount: 10
+    replicaCount: 4
   userPointsRealtime:
     replicaCount: 1
   userCoursePoints:
     replicaCount: 2
+
+shibboTest:
+  replicaCount: 0
 
 email:
   # controls whether the background email service should be running


### PR DESCRIPTION
When using only the field resolver in the plugin, the queries would have actually run on the server before the auth plugin could do its job and deny access if the user had no privileges. Apparently Nexus didn't really implement the same with the subscriber so we can authorize _before_ the subscription is started, sooooo I had to patch that. Great.