### PR TITLE
Add short caching on subscription

### DIFF
--- a/backend/middlewares/cache.ts
+++ b/backend/middlewares/cache.ts
@@ -39,4 +39,47 @@ export const cachePlugin = () =>
         return res
       }
     },
+    onCreateFieldSubscribe() {
+      return async (root, args, ctx, info, next) => {
+        const key = `${info.fieldName}-${JSON.stringify(
+          info.fieldNodes,
+        )}-${JSON.stringify(args)}`
+
+        const hash = createHash("sha512").update(key).digest("hex")
+
+        const res = await redisify<any>(
+          async () => {
+            const subscriptionRes = []
+            const maybeSubscription = await next(root, args, ctx, info) // NOSONAR: is async
+
+            if (
+              maybeSubscription &&
+              typeof maybeSubscription[Symbol.asyncIterator] === "function"
+            ) {
+              for await (const item of maybeSubscription) {
+                subscriptionRes.push(item)
+              }
+            } else {
+              return maybeSubscription
+            }
+
+            return subscriptionRes
+          },
+          {
+            prefix: "graphql-subscription",
+            expireTime: 60,
+            key: hash,
+          },
+          {
+            logger: ctx.logger,
+          },
+        )
+
+        return (async function* () {
+          for (const item of res) {
+            yield item
+          }
+        })()
+      }
+    },
   })

--- a/backend/patches/nexus+1.3.0.patch
+++ b/backend/patches/nexus+1.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/nexus/dist/builder.js b/node_modules/nexus/dist/builder.js
-index 656750b..ed7f817 100644
+index 656750b..c6ff041 100644
 --- a/node_modules/nexus/dist/builder.js
 +++ b/node_modules/nexus/dist/builder.js
 @@ -807,8 +807,15 @@ class SchemaBuilder {
@@ -7,7 +7,7 @@ index 656750b..ed7f817 100644
                  schemaConfig: this.config,
                  schemaExtension: this.schemaExtension,
 -            }, fieldConfig.resolve), subscribe: fieldConfig.subscribe }, builderFieldConfig);
-+            }, fieldConfig.resolve), subscribe: this.makeFinalResolver({
++            }, fieldConfig.resolve), subscribe: this.makeFinalSubscribe({
 +                builder: this.builderLens,
 +                fieldConfig: builderFieldConfig,
 +                parentTypeConfig: typeConfig,
@@ -19,10 +19,21 @@ index 656750b..ed7f817 100644
      makeFinalResolver(info, resolver) {
          const resolveFn = resolver || graphql_1.defaultFieldResolver;
          if (this.onCreateResolverFns.length) {
-@@ -819,6 +826,7 @@ class SchemaBuilder {
+@@ -819,6 +826,18 @@ class SchemaBuilder {
          }
          return resolveFn;
      }
++
++    makeFinalSubscribe(info, subscriber) {
++      const subscribeFn = subscriber || graphql_1.defaultFieldResolver;
++      if (this.onCreateSubscribeFns.length) {
++          const toCompose = this.onCreateSubscribeFns.map((fn) => fn(info)).filter((f) => f);
++          if (toCompose.length) {
++              return (0, plugin_1.composeMiddlewareFns)(toCompose, subscribeFn);
++          }
++      }
++      return subscribeFn;
++    }
 +
      buildInputObjectField(fieldConfig, typeConfig) {
          var _a, _b, _c, _d;


### PR DESCRIPTION
So that navigating away and then coming back will not trigger a completely new query waterfall.

Also fix the Nexus patch a bit so it actually runs the subscribe fn, not the resolver...