### PR TITLE
Fix Apollo invariant error on some course/module edit

### DIFF
--- a/backend/graphql/Course/__test__/Course.mutations.test.ts
+++ b/backend/graphql/Course/__test__/Course.mutations.test.ts
@@ -604,6 +604,8 @@ const createCourseMutation = gql`
       }
       study_modules {
         id
+        slug
+        name
       }
       course_variants {
         id
@@ -616,9 +618,13 @@ const createCourseMutation = gql`
       }
       inherit_settings_from {
         id
+        slug
+        name
       }
       completions_handled_by {
         id
+        slug
+        name
       }
       has_certificate
       user_course_settings_visibilities {
@@ -688,6 +694,8 @@ const updateCourseMutation = gql`
       }
       study_modules {
         id
+        slug
+        name
       }
       course_variants {
         id
@@ -700,9 +708,13 @@ const updateCourseMutation = gql`
       }
       inherit_settings_from {
         id
+        slug
+        name
       }
       completions_handled_by {
         id
+        slug
+        name
       }
       has_certificate
       user_course_settings_visibilities {
@@ -733,6 +745,8 @@ const deleteCourseMutation = gql`
   mutation deleteCourse($id: ID, $slug: String) {
     deleteCourse(id: $id, slug: $slug) {
       id
+      slug
+      name
     }
   }
 `

--- a/backend/graphql/Course/__test__/Course.queries.test.ts
+++ b/backend/graphql/Course/__test__/Course.queries.test.ts
@@ -370,6 +370,8 @@ const fullCourseQuery = gql`
       }
       study_modules {
         id
+        slug
+        name
       }
       course_variants {
         id
@@ -382,9 +384,13 @@ const fullCourseQuery = gql`
       }
       inherit_settings_from {
         id
+        slug
+        name
       }
       completions_handled_by {
         id
+        slug
+        name
       }
       has_certificate
       user_course_settings_visibilities {
@@ -456,6 +462,7 @@ const coursesQuery = gql`
       study_modules {
         id
         slug
+        name
       }
       course_translations {
         id
@@ -487,8 +494,12 @@ const handlerCoursesQuery = gql`
   query handlerCourses {
     handlerCourses {
       id
+      slug
+      name
       handles_completions_for {
         id
+        slug
+        name
       }
     }
   }

--- a/backend/graphql/Course/__test__/Course.test.ts
+++ b/backend/graphql/Course/__test__/Course.test.ts
@@ -21,6 +21,8 @@ const courseCompletionsQuery = gql`
   ) {
     course(slug: $slug) {
       id
+      slug
+      name
       completions(user_id: $user_id, user_upstream_id: $user_upstream_id) {
         id
         user {
@@ -45,6 +47,8 @@ const courseTagsQuery = gql`
   ) {
     course(slug: $slug, language: $language) {
       id
+      slug
+      name
       tags(
         language: $language
         types: $types

--- a/backend/graphql/Course/__test__/__snapshots__/Course.mutations.test.ts.snap
+++ b/backend/graphql/Course/__test__/__snapshots__/Course.mutations.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Course mutations addCourse creates a course full: toMatchStrippedSnapsh
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "course_aliases": [
     {
@@ -37,6 +39,8 @@ exports[`Course mutations addCourse creates a course full: toMatchStrippedSnapsh
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "language": "en",
   "name": "new1",
@@ -61,6 +65,8 @@ exports[`Course mutations addCourse creates a course full: toMatchStrippedSnapsh
   "study_modules": [
     {
       "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -333,6 +339,8 @@ exports[`Course mutations addCourse creates a course with no course tags: toMatc
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "course_aliases": [
     {
@@ -364,6 +372,8 @@ exports[`Course mutations addCourse creates a course with no course tags: toMatc
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "language": "en",
   "name": "new1",
@@ -388,6 +398,8 @@ exports[`Course mutations addCourse creates a course with no course tags: toMatc
   "study_modules": [
     {
       "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -618,6 +630,8 @@ exports[`Course mutations addCourse creates a course with no course_translations
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "course_aliases": [
     {
@@ -641,6 +655,8 @@ exports[`Course mutations addCourse creates a course with no course_translations
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "language": "en",
   "name": "new1",
@@ -665,6 +681,8 @@ exports[`Course mutations addCourse creates a course with no course_translations
   "study_modules": [
     {
       "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -927,6 +945,8 @@ exports[`Course mutations addCourse creates a course with no photo: toMatchStrip
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "course_aliases": [
     {
@@ -958,6 +978,8 @@ exports[`Course mutations addCourse creates a course with no photo: toMatchStrip
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "language": "en",
   "name": "new1",
@@ -975,6 +997,8 @@ exports[`Course mutations addCourse creates a course with no photo: toMatchStrip
   "study_modules": [
     {
       "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -1236,6 +1260,8 @@ exports[`Course mutations addCourse creates a course with no study_modules: toMa
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "course_aliases": [
     {
@@ -1267,6 +1293,8 @@ exports[`Course mutations addCourse creates a course with no study_modules: toMa
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course1",
+    "slug": "course1",
   },
   "language": "en",
   "name": "new1",
@@ -1540,6 +1568,8 @@ exports[`Course mutations deleteCourse deletes course on id 1`] = `
 {
   "deleteCourse": {
     "id": "00000000-0000-0000-0000-000000000002",
+    "name": "course1",
+    "slug": "course1",
   },
 }
 `;
@@ -1548,6 +1578,8 @@ exports[`Course mutations deleteCourse deletes course on slug 1`] = `
 {
   "deleteCourse": {
     "id": "00000000-0000-0000-0000-000000000002",
+    "name": "course1",
+    "slug": "course1",
   },
 }
 `;
@@ -1558,6 +1590,8 @@ exports[`Course mutations updateCourse deletes photo: toMatchStrippedSnapshot 1`
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "course_aliases": [
     {
@@ -1596,6 +1630,8 @@ exports[`Course mutations updateCourse deletes photo: toMatchStrippedSnapshot 1`
   "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "language": "en",
   "name": "updated course1",
@@ -1620,6 +1656,8 @@ exports[`Course mutations updateCourse deletes photo: toMatchStrippedSnapshot 1`
   "study_modules": [
     {
       "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -1949,6 +1987,8 @@ exports[`Course mutations updateCourse removes language tag: toMatchStrippedSnap
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "course_aliases": [
     {
@@ -1987,6 +2027,8 @@ exports[`Course mutations updateCourse removes language tag: toMatchStrippedSnap
   "id": "00000000-0000-0000-0000-000000000002",
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "language": null,
   "name": "updated course1",
@@ -2018,6 +2060,8 @@ exports[`Course mutations updateCourse removes language tag: toMatchStrippedSnap
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -2316,6 +2360,8 @@ exports[`Course mutations updateCourse updates course: toMatchStrippedSnapshot 1
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "course_aliases": [
     {
@@ -2354,6 +2400,8 @@ exports[`Course mutations updateCourse updates course: toMatchStrippedSnapshot 1
   "id": "00000000-0000-0000-0000-000000000002",
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "language": "en",
   "name": "updated course1",
@@ -2385,6 +2433,8 @@ exports[`Course mutations updateCourse updates course: toMatchStrippedSnapshot 1
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -2725,6 +2775,8 @@ exports[`Course mutations updateCourse updates language tag: toMatchStrippedSnap
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "course_aliases": [
     {
@@ -2763,6 +2815,8 @@ exports[`Course mutations updateCourse updates language tag: toMatchStrippedSnap
   "id": "00000000-0000-0000-0000-000000000002",
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "language": "fi",
   "name": "updated course1",
@@ -2794,6 +2848,8 @@ exports[`Course mutations updateCourse updates language tag: toMatchStrippedSnap
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,
@@ -3134,6 +3190,8 @@ exports[`Course mutations updateCourse updates photo: toMatchStrippedSnapshot 1`
   "automatic_completions_eligible_for_ects": true,
   "completions_handled_by": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "course_aliases": [
     {
@@ -3172,6 +3230,8 @@ exports[`Course mutations updateCourse updates photo: toMatchStrippedSnapshot 1`
   "id": "00000000-0000-0000-0000-000000000002",
   "inherit_settings_from": {
     "id": StringMatching /\\[a-f\\\\d\\]\\{8\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{4\\}-\\[a-f\\\\d\\]\\{12\\}/i,
+    "name": "course2",
+    "slug": "course2",
   },
   "language": "en",
   "name": "updated course1",
@@ -3203,6 +3263,8 @@ exports[`Course mutations updateCourse updates photo: toMatchStrippedSnapshot 1`
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
   ],
   "support_email": null,

--- a/backend/graphql/Course/__test__/__snapshots__/Course.queries.test.ts.snap
+++ b/backend/graphql/Course/__test__/__snapshots__/Course.queries.test.ts.snap
@@ -70,9 +70,13 @@ exports[`Course queries course admin returns full course on id and slug 1`] = `
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
     {
       "id": "00000000-0000-0000-0000-000000000102",
+      "name": "module1",
+      "slug": "module1",
     },
   ],
   "support_email": null,
@@ -212,9 +216,13 @@ exports[`Course queries course admin returns full course on id and slug 2`] = `
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
     {
       "id": "00000000-0000-0000-0000-000000000102",
+      "name": "module1",
+      "slug": "module1",
     },
   ],
   "support_email": null,
@@ -359,9 +367,13 @@ exports[`Course queries course admin should include deleted exercises if specifi
   "study_modules": [
     {
       "id": "00000000-0000-0000-0000-000000000101",
+      "name": "module2",
+      "slug": "module2",
     },
     {
       "id": "00000000-0000-0000-0000-000000000102",
+      "name": "module1",
+      "slug": "module1",
     },
   ],
   "support_email": null,
@@ -521,6 +533,7 @@ exports[`Course queries courses returns courses 1`] = `
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -561,10 +574,12 @@ exports[`Course queries courses returns courses 1`] = `
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000101",
+        "name": "module2",
         "slug": "module2",
       },
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -692,10 +707,12 @@ exports[`Course queries courses returns courses filtered by language: courses-la
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000101",
+        "name": "module2",
         "slug": "module2",
       },
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -761,10 +778,12 @@ exports[`Course queries courses returns courses filtered by language: courses-la
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000101",
+        "name": "module2",
         "slug": "module2",
       },
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -816,6 +835,7 @@ exports[`Course queries courses returns courses filtered by language: courses-la
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -861,10 +881,12 @@ exports[`Course queries courses returns courses ordered: courses-order-asc 1`] =
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000101",
+        "name": "module2",
         "slug": "module2",
       },
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -916,6 +938,7 @@ exports[`Course queries courses returns courses ordered: courses-order-asc 1`] =
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -1072,6 +1095,7 @@ exports[`Course queries courses returns courses ordered: courses-order-desc 1`] 
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -1112,10 +1136,12 @@ exports[`Course queries courses returns courses ordered: courses-order-desc 1`] 
     "study_modules": [
       {
         "id": "00000000-0000-0000-0000-000000000101",
+        "name": "module2",
         "slug": "module2",
       },
       {
         "id": "00000000-0000-0000-0000-000000000102",
+        "name": "module1",
         "slug": "module1",
       },
     ],
@@ -1152,9 +1178,13 @@ exports[`Course queries handlerCourses returns correctly 1`] = `
     "handles_completions_for": [
       {
         "id": "00000000-0000-0000-0000-000000000667",
+        "name": "handled",
+        "slug": "handled",
       },
     ],
     "id": "00000000-0000-0000-0000-000000000666",
+    "name": "handler",
+    "slug": "handler",
   },
 ]
 `;

--- a/backend/graphql/Course/__test__/__snapshots__/Course.test.ts.snap
+++ b/backend/graphql/Course/__test__/__snapshots__/Course.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Course model completions shouldn't return anything with non-existent us
   "course": {
     "completions": [],
     "id": "00000000-0000-0000-0000-000000000002",
+    "name": "course1",
+    "slug": "course1",
   },
 }
 `;
@@ -27,6 +29,8 @@ exports[`Course model completions works with user_id 1`] = `
       },
     ],
     "id": "00000000-0000-0000-0000-000000000002",
+    "name": "course1",
+    "slug": "course1",
   },
 }
 `;
@@ -48,6 +52,8 @@ exports[`Course model completions works with user_upstream_id 1`] = `
       },
     ],
     "id": "00000000-0000-0000-0000-000000000002",
+    "name": "course1",
+    "slug": "course1",
   },
 }
 `;

--- a/frontend/graphql/fragments/completion.fragments.graphql
+++ b/frontend/graphql/fragments/completion.fragments.graphql
@@ -45,8 +45,6 @@ fragment CompletionsQueryNodeFields on Completion {
   }
   course {
     ...CourseCoreFields
-    id
-    name
   }
   completions_registered {
     id

--- a/frontend/graphql/fragments/course.fragments.graphql
+++ b/frontend/graphql/fragments/course.fragments.graphql
@@ -1,6 +1,11 @@
-fragment CourseCoreFields on Course {
+fragment CourseKeyFields on Course {
   id
   slug
+  name
+}
+
+fragment CourseCoreFields on Course {
+  ...CourseKeyFields
   name
   ects
   language
@@ -92,7 +97,7 @@ fragment EditorCourseDetailedFields on Course {
     ...OpenUniversityRegistrationLinkCoreFields
   }
   inherit_settings_from {
-    id
+    ...CourseKeyFields
   }
   automatic_completions
   automatic_completions_eligible_for_ects

--- a/frontend/graphql/fragments/studyModule.fragments.graphql
+++ b/frontend/graphql/fragments/studyModule.fragments.graphql
@@ -1,7 +1,11 @@
-fragment StudyModuleCoreFields on StudyModule {
+fragment StudyModuleKeyFields on StudyModule {
   id
   slug
   name
+}
+
+fragment StudyModuleCoreFields on StudyModule {
+  ...StudyModuleKeyFields
 }
 
 fragment StudyModuleFields on StudyModule {

--- a/frontend/graphql/generated/index.ts
+++ b/frontend/graphql/generated/index.ts
@@ -15,7 +15,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>
 }
-// Generated on 2023-04-12T15:38:55+03:00
+// Generated on 2023-04-18T20:14:22+03:00
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -2632,13 +2632,13 @@ export type CompletionCoreFieldsFragment = {
 export type CompletionCourseFieldsFragment = {
   __typename?: "Course"
   has_certificate: boolean | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   photo: {
     __typename?: "Image"
     id: string
@@ -2712,13 +2712,13 @@ export type CompletionDetailedFieldsWithCourseFragment = {
   course: {
     __typename?: "Course"
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     photo: {
       __typename?: "Image"
       id: string
@@ -2787,13 +2787,13 @@ export type CompletionsQueryNodeFieldsFragment = {
   } | null
   course: {
     __typename?: "Course"
-    id: string
     name: string
-    slug: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
   completions_registered: Array<{
     __typename?: "CompletionRegistered"
@@ -2850,13 +2850,13 @@ export type CompletionsQueryConnectionFieldsFragment = {
       } | null
       course: {
         __typename?: "Course"
-        id: string
         name: string
-        slug: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
       } | null
       completions_registered: Array<{
         __typename?: "CompletionRegistered"
@@ -2888,26 +2888,33 @@ export type CompletionRegisteredCoreFieldsFragment = {
   organization: { __typename?: "Organization"; id: string; slug: string } | null
 }
 
-export type CourseCoreFieldsFragment = {
+export type CourseKeyFieldsFragment = {
   __typename?: "Course"
   id: string
   slug: string
+  name: string
+}
+
+export type CourseCoreFieldsFragment = {
+  __typename?: "Course"
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
 }
 
 export type CourseWithPhotoCoreFieldsFragment = {
   __typename?: "Course"
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   photo: {
     __typename?: "Image"
     id: string
@@ -2962,13 +2969,13 @@ export type CourseFieldsFragment = {
   start_date: string
   end_date: string | null
   has_certificate: boolean | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   course_translations: Array<{
     __typename?: "CourseTranslation"
     id: string
@@ -3030,22 +3037,22 @@ export type EditorCourseFieldsFragment = {
   start_date: string
   end_date: string | null
   has_certificate: boolean | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   completions_handled_by: {
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
   course_variants: Array<{
     __typename?: "CourseVariant"
@@ -3128,13 +3135,13 @@ export type EditorCourseDetailedFieldsFragment = {
   start_date: string
   end_date: string | null
   has_certificate: boolean | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   course_translations: Array<{
     __typename?: "CourseTranslation"
     course_id: string | null
@@ -3154,16 +3161,21 @@ export type EditorCourseDetailedFieldsFragment = {
     language: string
     link: string | null
   }>
-  inherit_settings_from: { __typename?: "Course"; id: string } | null
-  completions_handled_by: {
+  inherit_settings_from: {
     __typename?: "Course"
     id: string
     slug: string
+    name: string
+  } | null
+  completions_handled_by: {
+    __typename?: "Course"
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
   course_variants: Array<{
     __typename?: "CourseVariant"
@@ -3218,13 +3230,13 @@ export type EditorCourseDetailedFieldsFragment = {
 
 export type EditorCourseOtherCoursesFieldsFragment = {
   __typename?: "Course"
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   course_translations: Array<{
     __typename?: "CourseTranslation"
     id: string
@@ -3349,13 +3361,13 @@ export type ProgressCoreFieldsFragment = {
   __typename?: "Progress"
   course: {
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
   user_course_progress: {
     __typename?: "UserCourseProgress"
@@ -3387,6 +3399,13 @@ export type ProgressCoreFieldsFragment = {
     updated_at: any | null
     service: { __typename?: "Service"; name: string; id: string } | null
   }> | null
+}
+
+export type StudyModuleKeyFieldsFragment = {
+  __typename?: "StudyModule"
+  id: string
+  slug: string
+  name: string
 }
 
 export type StudyModuleCoreFieldsFragment = {
@@ -3468,13 +3487,13 @@ export type StudyModuleFieldsWithCoursesFragment = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       id: string
@@ -3591,13 +3610,13 @@ export type UserProgressesFieldsFragment = {
     __typename?: "Progress"
     course: {
       __typename?: "Course"
-      id: string
-      slug: string
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     } | null
     user_course_progress: {
       __typename?: "UserCourseProgress"
@@ -3635,13 +3654,13 @@ export type UserProgressesFieldsFragment = {
 export type UserOverviewCourseFieldsFragment = {
   __typename?: "Course"
   has_certificate: boolean | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   photo: {
     __typename?: "Image"
     id: string
@@ -3692,13 +3711,13 @@ export type UserOverviewFieldsFragment = {
     course: {
       __typename?: "Course"
       has_certificate: boolean | null
-      id: string
-      slug: string
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
       photo: {
         __typename?: "Image"
         id: string
@@ -3815,13 +3834,13 @@ export type StudentProgressesQueryNodeFieldsFragment = {
       __typename?: "Progress"
       course: {
         __typename?: "Course"
-        id: string
-        slug: string
         name: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
       } | null
       user_course_progress: {
         __typename?: "UserCourseProgress"
@@ -3872,13 +3891,13 @@ export type UserProfileUserCourseSettingsQueryNodeFieldsFragment = {
   updated_at: any | null
   course: {
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
 }
 
@@ -3887,13 +3906,13 @@ export type UserCourseSummaryCourseFieldsFragment = {
   has_certificate: boolean | null
   points_needed: number | null
   exercise_completions_needed: number | null
-  id: string
-  slug: string
   name: string
   ects: string | null
   language: string | null
   created_at: any | null
   updated_at: any | null
+  id: string
+  slug: string
   exercises: Array<{
     __typename?: "Exercise"
     id: string
@@ -3928,13 +3947,13 @@ export type UserCourseSummaryCoreFieldsFragment = {
     has_certificate: boolean | null
     points_needed: number | null
     exercise_completions_needed: number | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     exercises: Array<{
       __typename?: "Exercise"
       id: string
@@ -4166,13 +4185,13 @@ export type AddCourseMutation = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       course_id: string | null
@@ -4192,16 +4211,21 @@ export type AddCourseMutation = {
       language: string
       link: string | null
     }>
-    inherit_settings_from: { __typename?: "Course"; id: string } | null
-    completions_handled_by: {
+    inherit_settings_from: {
       __typename?: "Course"
       id: string
       slug: string
+      name: string
+    } | null
+    completions_handled_by: {
+      __typename?: "Course"
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     } | null
     course_variants: Array<{
       __typename?: "CourseVariant"
@@ -4285,13 +4309,13 @@ export type UpdateCourseMutation = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     completion_email: {
       __typename?: "EmailTemplate"
       id: string
@@ -4335,16 +4359,21 @@ export type UpdateCourseMutation = {
       language: string
       link: string | null
     }>
-    inherit_settings_from: { __typename?: "Course"; id: string } | null
-    completions_handled_by: {
+    inherit_settings_from: {
       __typename?: "Course"
       id: string
       slug: string
+      name: string
+    } | null
+    completions_handled_by: {
+      __typename?: "Course"
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     } | null
     course_variants: Array<{
       __typename?: "CourseVariant"
@@ -4406,13 +4435,13 @@ export type DeleteCourseMutation = {
   __typename?: "Mutation"
   deleteCourse: {
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
 }
 
@@ -4707,13 +4736,13 @@ export type PaginatedCompletionsQuery = {
         } | null
         course: {
           __typename?: "Course"
-          id: string
           name: string
-          slug: string
           ects: string | null
           language: string | null
           created_at: any | null
           updated_at: any | null
+          id: string
+          slug: string
         } | null
         completions_registered: Array<{
           __typename?: "CompletionRegistered"
@@ -4782,13 +4811,13 @@ export type PaginatedCompletionsPreviousPageQuery = {
         } | null
         course: {
           __typename?: "Course"
-          id: string
           name: string
-          slug: string
           ects: string | null
           language: string | null
           created_at: any | null
           updated_at: any | null
+          id: string
+          slug: string
         } | null
         completions_registered: Array<{
           __typename?: "CompletionRegistered"
@@ -4829,13 +4858,13 @@ export type CoursesQuery = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       id: string
@@ -4903,13 +4932,13 @@ export type FrontpageCoursesModulesQuery = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       id: string
@@ -4993,22 +5022,22 @@ export type EditorCoursesQuery = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     completions_handled_by: {
       __typename?: "Course"
-      id: string
-      slug: string
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     } | null
     course_variants: Array<{
       __typename?: "CourseVariant"
@@ -5084,13 +5113,13 @@ export type CourseFromSlugQuery = {
     __typename?: "Course"
     description: string | null
     instructions: string | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   } | null
 }
 
@@ -5102,13 +5131,13 @@ export type CourseEditorOtherCoursesQuery = {
   __typename?: "Query"
   courses: Array<{
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       id: string
@@ -5137,13 +5166,13 @@ export type HandlerCoursesQuery = {
   __typename?: "Query"
   handlerCourses: Array<{
     __typename?: "Course"
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
   }> | null
 }
 
@@ -5177,13 +5206,13 @@ export type CourseEditorDetailsQuery = {
     start_date: string
     end_date: string | null
     has_certificate: boolean | null
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     course_translations: Array<{
       __typename?: "CourseTranslation"
       course_id: string | null
@@ -5203,16 +5232,21 @@ export type CourseEditorDetailsQuery = {
       language: string
       link: string | null
     }>
-    inherit_settings_from: { __typename?: "Course"; id: string } | null
-    completions_handled_by: {
+    inherit_settings_from: {
       __typename?: "Course"
       id: string
       slug: string
+      name: string
+    } | null
+    completions_handled_by: {
+      __typename?: "Course"
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     } | null
     course_variants: Array<{
       __typename?: "CourseVariant"
@@ -5277,13 +5311,13 @@ export type EmailTemplateEditorCoursesQuery = {
     teacher_in_charge_name: string
     teacher_in_charge_email: string
     start_date: string
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     completion_email: {
       __typename?: "EmailTemplate"
       id: string
@@ -5323,13 +5357,13 @@ export type CourseDashboardQuery = {
     teacher_in_charge_name: string
     teacher_in_charge_email: string
     start_date: string
-    id: string
-    slug: string
     name: string
     ects: string | null
     language: string | null
     created_at: any | null
     updated_at: any | null
+    id: string
+    slug: string
     completion_email: {
       __typename?: "EmailTemplate"
       id: string
@@ -5493,13 +5527,13 @@ export type StudyModulesWithCoursesQuery = {
       start_date: string
       end_date: string | null
       has_certificate: boolean | null
-      id: string
-      slug: string
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
       course_translations: Array<{
         __typename?: "CourseTranslation"
         id: string
@@ -5587,13 +5621,13 @@ export type EditorStudyModuleDetailsQuery = {
     name: string
     courses: Array<{
       __typename?: "Course"
-      id: string
-      slug: string
       name: string
       ects: string | null
       language: string | null
       created_at: any | null
       updated_at: any | null
+      id: string
+      slug: string
     }> | null
     study_module_translations: Array<{
       __typename?: "StudyModuleTranslation"
@@ -5779,13 +5813,13 @@ export type UserSummaryQuery = {
         has_certificate: boolean | null
         points_needed: number | null
         exercise_completions_needed: number | null
-        id: string
-        slug: string
         name: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
         exercises: Array<{
           __typename?: "Exercise"
           id: string
@@ -5939,13 +5973,13 @@ export type CurrentUserOverviewQuery = {
       course: {
         __typename?: "Course"
         has_certificate: boolean | null
-        id: string
-        slug: string
         name: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
         photo: {
           __typename?: "Image"
           id: string
@@ -6024,13 +6058,13 @@ export type UserOverviewQuery = {
       course: {
         __typename?: "Course"
         has_certificate: boolean | null
-        id: string
-        slug: string
         name: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
         photo: {
           __typename?: "Image"
           id: string
@@ -6091,13 +6125,13 @@ export type CurrentUserProgressesQuery = {
       __typename?: "Progress"
       course: {
         __typename?: "Course"
-        id: string
-        slug: string
         name: string
         ects: string | null
         language: string | null
         created_at: any | null
         updated_at: any | null
+        id: string
+        slug: string
       } | null
       user_course_progress: {
         __typename?: "UserCourseProgress"
@@ -6388,13 +6422,13 @@ export type StudentProgressesQuery = {
             __typename?: "Progress"
             course: {
               __typename?: "Course"
-              id: string
-              slug: string
               name: string
               ects: string | null
               language: string | null
               created_at: any | null
               updated_at: any | null
+              id: string
+              slug: string
             } | null
             user_course_progress: {
               __typename?: "UserCourseProgress"
@@ -6462,13 +6496,13 @@ export type UserProfileUserCourseSettingsQuery = {
         updated_at: any | null
         course: {
           __typename?: "Course"
-          id: string
-          slug: string
           name: string
           ects: string | null
           language: string | null
           created_at: any | null
           updated_at: any | null
+          id: string
+          slug: string
         } | null
       }
     }>
@@ -6771,6 +6805,27 @@ export const CompletionDetailedFieldsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<CompletionDetailedFieldsFragment, unknown>
+export const CourseKeyFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CourseKeyFieldsFragment, unknown>
 export const CourseCoreFieldsFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -6784,13 +6839,31 @@ export const CourseCoreFieldsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
           { kind: "Field", name: { kind: "Name", value: "created_at" } },
           { kind: "Field", name: { kind: "Name", value: "updated_at" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
         ],
       },
     },
@@ -6865,7 +6938,7 @@ export const CourseWithPhotoCoreFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -6875,6 +6948,24 @@ export const CourseWithPhotoCoreFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -6937,7 +7028,7 @@ export const CompletionCourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -6947,6 +7038,24 @@ export const CompletionCourseFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -7133,7 +7242,7 @@ export const CompletionDetailedFieldsWithCourseFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -7143,6 +7252,24 @@ export const CompletionDetailedFieldsWithCourseFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -7354,8 +7481,6 @@ export const CompletionsQueryNodeFieldsFragmentDoc = {
                   kind: "FragmentSpread",
                   name: { kind: "Name", value: "CourseCoreFields" },
                 },
-                { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "name" } },
               ],
             },
           },
@@ -7380,6 +7505,22 @@ export const CompletionsQueryNodeFieldsFragmentDoc = {
               ],
             },
           },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
         ],
       },
     },
@@ -7454,8 +7595,10 @@ export const CompletionsQueryNodeFieldsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -7589,7 +7732,7 @@ export const CompletionsQueryConnectionFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -7599,6 +7742,24 @@ export const CompletionsQueryConnectionFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -7644,8 +7805,6 @@ export const CompletionsQueryConnectionFieldsFragmentDoc = {
                   kind: "FragmentSpread",
                   name: { kind: "Name", value: "CourseCoreFields" },
                 },
-                { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "name" } },
               ],
             },
           },
@@ -7696,12 +7855,50 @@ export const CourseTranslationCoreFieldsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<CourseTranslationCoreFieldsFragment, unknown>
+export const StudyModuleKeyFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StudyModuleKeyFieldsFragment, unknown>
 export const StudyModuleCoreFieldsFragmentDoc = {
   kind: "Document",
   definitions: [
     {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -7884,7 +8081,7 @@ export const CourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -7894,6 +8091,24 @@ export const CourseFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -7928,6 +8143,22 @@ export const CourseFieldsFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "created_at" } },
           { kind: "Field", name: { kind: "Name", value: "updated_at" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
         ],
       },
     },
@@ -8004,9 +8235,10 @@ export const CourseFieldsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -8116,7 +8348,7 @@ export const EditorCourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -8126,6 +8358,24 @@ export const EditorCourseFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -8211,7 +8461,7 @@ export const EditorCourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -8222,6 +8472,23 @@ export const EditorCourseFieldsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -8486,7 +8753,10 @@ export const EditorCourseDetailedFieldsFragmentDoc = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [
-                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CourseKeyFields" },
+                },
               ],
             },
           },
@@ -8511,7 +8781,7 @@ export const EditorCourseDetailedFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -8521,6 +8791,24 @@ export const EditorCourseDetailedFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -8606,7 +8894,7 @@ export const EditorCourseDetailedFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -8617,6 +8905,23 @@ export const EditorCourseDetailedFieldsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -8901,7 +9206,7 @@ export const EditorCourseOtherCoursesFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -8911,6 +9216,24 @@ export const EditorCourseOtherCoursesFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -9112,7 +9435,7 @@ export const StudyModuleFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -9123,6 +9446,23 @@ export const StudyModuleFieldsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -9187,7 +9527,7 @@ export const StudyModuleDetailedFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -9198,6 +9538,23 @@ export const StudyModuleDetailedFieldsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -9279,10 +9636,43 @@ export const StudyModuleFieldsWithCoursesFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
       name: { kind: "Name", value: "StudyModuleCoreFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
       },
       selectionSet: {
         kind: "SelectionSet",
@@ -9303,8 +9693,10 @@ export const StudyModuleFieldsWithCoursesFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -9709,7 +10101,7 @@ export const ProgressCoreFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -9719,6 +10111,24 @@ export const ProgressCoreFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -9836,7 +10246,7 @@ export const UserProgressesFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -9846,6 +10256,24 @@ export const UserProgressesFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -10084,7 +10512,7 @@ export const UserOverviewCourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -10094,6 +10522,24 @@ export const UserOverviewCourseFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -10323,7 +10769,7 @@ export const UserOverviewFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -10333,6 +10779,24 @@ export const UserOverviewFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -10569,7 +11033,7 @@ export const StudentProgressesQueryNodeFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -10579,6 +11043,24 @@ export const StudentProgressesQueryNodeFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -10863,6 +11345,22 @@ export const UserProfileUserCourseSettingsQueryNodeFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
       name: { kind: "Name", value: "UserCourseSettingDetailedFields" },
       typeCondition: {
         kind: "NamedType",
@@ -10894,8 +11392,10 @@ export const UserProfileUserCourseSettingsQueryNodeFieldsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -10997,7 +11497,7 @@ export const UserCourseSummaryCourseFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -11007,6 +11507,24 @@ export const UserCourseSummaryCourseFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -11232,7 +11750,7 @@ export const UserCourseSummaryCoreFieldsFragmentDoc = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -11242,6 +11760,24 @@ export const UserCourseSummaryCoreFieldsFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -12157,7 +12693,7 @@ export const AddCourseDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -12167,6 +12703,24 @@ export const AddCourseDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -12252,7 +12806,7 @@ export const AddCourseDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -12263,6 +12817,23 @@ export const AddCourseDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -12562,7 +13133,10 @@ export const AddCourseDocument = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [
-                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CourseKeyFields" },
+                },
               ],
             },
           },
@@ -12673,7 +13247,7 @@ export const UpdateCourseDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -12683,6 +13257,24 @@ export const UpdateCourseDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -12768,7 +13360,7 @@ export const UpdateCourseDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -12779,6 +13371,23 @@ export const UpdateCourseDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -13078,7 +13687,10 @@ export const UpdateCourseDocument = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [
-                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CourseKeyFields" },
+                },
               ],
             },
           },
@@ -13179,7 +13791,7 @@ export const DeleteCourseDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -13189,6 +13801,24 @@ export const DeleteCourseDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -13838,7 +14468,7 @@ export const AddStudyModuleDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -13849,6 +14479,23 @@ export const AddStudyModuleDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -13982,7 +14629,7 @@ export const UpdateStudyModuleDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -13993,6 +14640,23 @@ export const UpdateStudyModuleDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -14120,7 +14784,7 @@ export const DeleteStudyModuleDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -14131,6 +14795,23 @@ export const DeleteStudyModuleDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -14736,7 +15417,7 @@ export const PaginatedCompletionsDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -14746,6 +15427,24 @@ export const PaginatedCompletionsDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -14791,8 +15490,6 @@ export const PaginatedCompletionsDocument = {
                   kind: "FragmentSpread",
                   name: { kind: "Name", value: "CourseCoreFields" },
                 },
-                { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "name" } },
               ],
             },
           },
@@ -15053,7 +15750,7 @@ export const PaginatedCompletionsPreviousPageDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -15063,6 +15760,24 @@ export const PaginatedCompletionsPreviousPageDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -15108,8 +15823,6 @@ export const PaginatedCompletionsPreviousPageDocument = {
                   kind: "FragmentSpread",
                   name: { kind: "Name", value: "CourseCoreFields" },
                 },
-                { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "name" } },
               ],
             },
           },
@@ -15266,7 +15979,7 @@ export const CoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -15276,6 +15989,24 @@ export const CoursesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -15361,7 +16092,7 @@ export const CoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -15372,6 +16103,23 @@ export const CoursesDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -15616,7 +16364,7 @@ export const FrontpageCoursesModulesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -15626,6 +16374,24 @@ export const FrontpageCoursesModulesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -15711,7 +16477,7 @@ export const FrontpageCoursesModulesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -15722,6 +16488,23 @@ export const FrontpageCoursesModulesDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -16036,7 +16819,7 @@ export const EditorCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -16046,6 +16829,24 @@ export const EditorCoursesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -16131,7 +16932,7 @@ export const EditorCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -16142,6 +16943,23 @@ export const EditorCoursesDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -16423,7 +17241,7 @@ export const CourseFromSlugDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -16433,6 +17251,24 @@ export const CourseFromSlugDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -16474,7 +17310,7 @@ export const CourseEditorOtherCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -16484,6 +17320,24 @@ export const CourseEditorOtherCoursesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -16630,7 +17484,7 @@ export const HandlerCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -16640,6 +17494,24 @@ export const HandlerCoursesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -16695,7 +17567,7 @@ export const CourseEditorDetailsDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -16705,6 +17577,24 @@ export const CourseEditorDetailsDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -16790,7 +17680,7 @@ export const CourseEditorDetailsDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -16801,6 +17691,23 @@ export const CourseEditorDetailsDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -17100,7 +18007,10 @@ export const CourseEditorDetailsDocument = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [
-                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CourseKeyFields" },
+                },
               ],
             },
           },
@@ -17197,7 +18107,7 @@ export const EmailTemplateEditorCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -17207,6 +18117,24 @@ export const EmailTemplateEditorCoursesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -17353,7 +18281,7 @@ export const CourseDashboardDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -17363,6 +18291,24 @@ export const CourseDashboardDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -17768,7 +18714,7 @@ export const StudyModulesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -17779,6 +18725,23 @@ export const StudyModulesDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -17891,10 +18854,43 @@ export const StudyModulesWithCoursesDocument = {
     },
     {
       kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
       name: { kind: "Name", value: "StudyModuleCoreFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
       },
       selectionSet: {
         kind: "SelectionSet",
@@ -17915,8 +18911,10 @@ export const StudyModulesWithCoursesDocument = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -18206,7 +19204,7 @@ export const EditorStudyModulesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
@@ -18217,6 +19215,23 @@ export const EditorStudyModulesDocument = {
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
         ],
       },
     },
@@ -18376,10 +19391,43 @@ export const EditorStudyModuleDetailsDocument = {
     },
     {
       kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StudyModuleKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
       name: { kind: "Name", value: "StudyModuleCoreFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "StudyModule" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "StudyModuleKeyFields" },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseKeyFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
       },
       selectionSet: {
         kind: "SelectionSet",
@@ -18422,8 +19470,10 @@ export const EditorStudyModuleDetailsDocument = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "slug" } },
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -19173,7 +20223,7 @@ export const UserSummaryDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -19183,6 +20233,24 @@ export const UserSummaryDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -19882,7 +20950,7 @@ export const CurrentUserOverviewDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -19892,6 +20960,24 @@ export const CurrentUserOverviewDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -20253,7 +21339,7 @@ export const UserOverviewDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -20263,6 +21349,24 @@ export const UserOverviewDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -20451,7 +21555,7 @@ export const CurrentUserProgressesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -20461,6 +21565,24 @@ export const CurrentUserProgressesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -21517,7 +22639,7 @@ export const StudentProgressesDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -21527,6 +22649,24 @@ export const StudentProgressesDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },
@@ -21853,7 +22993,7 @@ export const UserProfileUserCourseSettingsDocument = {
     },
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "CourseCoreFields" },
+      name: { kind: "Name", value: "CourseKeyFields" },
       typeCondition: {
         kind: "NamedType",
         name: { kind: "Name", value: "Course" },
@@ -21863,6 +23003,24 @@ export const UserProfileUserCourseSettingsDocument = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slug" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CourseCoreFields" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Course" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "CourseKeyFields" },
+          },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "ects" } },
           { kind: "Field", name: { kind: "Name", value: "language" } },


### PR DESCRIPTION
Apollo frontend cache is using [id, slug, name] as key for course and study module, so we should query those. Editor was crashing as we queried only the ids of parent courses.