### PR TITLE
Refactor new layout: no extra languages; responsive layout

### DIFF
--- a/backend/migrations/20230512085720_update-tags-create_other_language_tags.ts
+++ b/backend/migrations/20230512085720_update-tags-create_other_language_tags.ts
@@ -1,0 +1,45 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    insert into tag (id, hidden) values ('other_language', false) on conflict do nothing;
+  `)
+  await knex.raw(`
+    insert into "_TagToTagType" ("A", "B") values ('other_language', 'language') on conflict do nothing;
+  `)
+  await knex.raw(`
+    insert into "_CourseToTag" ("A", "B")
+    select c.id, 'other_language' from course c
+        join "_CourseToTag" ctt on c.id = ctt."A"
+        join tag on ctt."B" = tag.id
+        join "_TagToTagType" ttt on tag.id = ttt."A"
+        where ttt."B" = 'language'
+        and tag.id not in ('en', 'fi', 'se')
+    on conflict do nothing;
+  `)
+  await knex.raw(`
+    insert into tag_translation (tag_id, language, name)
+      values ('other_language', 'en_US', 'other language')
+      on conflict do nothing;
+  `)
+  await knex.raw(`
+    insert into tag_translation (tag_id, language, name)
+      values ('other_language', 'fi_FI', 'muu kieli')
+      on conflict do nothing;
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    delete from tag_translation where tag_id = 'other_language';
+  `)
+  await knex.raw(`
+    delete from "_CourseToTag" where "B" = 'other_language';
+  `)
+  await knex.raw(`
+    delete from "_TagToTagType" where "A" = 'other_language';
+  `)
+  await knex.raw(`
+    delete from tag where id = 'other_language';
+  `)
+}

--- a/backend/migrations/20230512085720_update-tags-create_other_language_tags.ts
+++ b/backend/migrations/20230512085720_update-tags-create_other_language_tags.ts
@@ -5,7 +5,11 @@ export async function up(knex: Knex): Promise<void> {
     insert into tag (id, hidden) values ('other_language', false) on conflict do nothing;
   `)
   await knex.raw(`
-    insert into "_TagToTagType" ("A", "B") values ('other_language', 'language') on conflict do nothing;
+    insert into tag_type (name) values ('language') on conflict do nothing;
+  `)
+  await knex.raw(`
+    insert into "_TagToTagType" ("A", "B") values ('other_language', 'language') 
+      on conflict do nothing;
   `)
   await knex.raw(`
     insert into "_CourseToTag" ("A", "B")

--- a/frontend/components/BorderedSection.tsx
+++ b/frontend/components/BorderedSection.tsx
@@ -52,12 +52,19 @@ const BorderedSectionBase = styled("div")`
   }
 `
 
+type PropsOf<T> = T extends React.ComponentType<infer P> ? P : never
+
 function BorderedSection({
   title,
   children,
-}: PropsWithChildren<{ title?: string | React.ReactNode }>) {
+  ...props
+}: PropsWithChildren<
+  Omit<PropsOf<typeof BorderedSectionBase>, "title"> & {
+    title?: string | React.ReactNode
+  }
+>) {
   return (
-    <BorderedSectionBase>
+    <BorderedSectionBase {...props}>
       <div className="header">
         <div className="headerBorderBefore"></div>
         {title && <div className="headerTitle">{title}</div>}

--- a/frontend/components/NewLayout/Courses/Catalogue.tsx
+++ b/frontend/components/NewLayout/Courses/Catalogue.tsx
@@ -8,6 +8,7 @@ import CoursesTranslations from "/translations/_new/courses"
 const Container = styled("section")`
   display: grid;
   justify-items: center;
+  margin: 0 auto;
 `
 
 const Header = styled(Typography)`

--- a/frontend/components/NewLayout/Courses/CourseCard.tsx
+++ b/frontend/components/NewLayout/Courses/CourseCard.tsx
@@ -211,6 +211,8 @@ const MoocfiLogo = styled(CardHeaderImage)``
 const prettifyDate = (date: string) =>
   date.split("T").shift()?.split("-").reverse().join(".")
 
+const allowedLanguages = ["en", "fi", "se"]
+
 interface CourseCardProps {
   course: CourseFieldsFragment
   tags?: string[]
@@ -303,6 +305,7 @@ function CourseCard({ course }: CourseCardProps) {
           <LanguageTags>
             {course?.tags
               ?.filter((t) => t.types?.includes("language"))
+              .filter((t) => allowedLanguages.includes(t.id))
               .map((tag) => (
                 <LanguageTag
                   key={tag.id}

--- a/frontend/components/NewLayout/Courses/TagSelectButtons.tsx
+++ b/frontend/components/NewLayout/Courses/TagSelectButtons.tsx
@@ -51,12 +51,6 @@ const TagChip = styled(Chip, {
 `,
 )
 
-/*
-    color: ${({ variant }) => (variant === "outlined" ? "#F5F6F7" : "#378170")};
-    background-color: ${({ variant }) =>
-      variant === "outlined" ? "#378170" : "#F5F6F7"};
-*/
-
 const SelectAllButton = styled(Button)(
   ({ theme, variant }) => `
   margin: 0 1rem auto auto;

--- a/frontend/components/NewLayout/Courses/TagSelectButtons.tsx
+++ b/frontend/components/NewLayout/Courses/TagSelectButtons.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback } from "react"
+
+import { Button, Chip } from "@mui/material"
+import { styled } from "@mui/material/styles"
+
+import { useTranslator } from "/hooks/useTranslator"
+import CommonTranslations from "/translations/common"
+
+import { TagCoreFieldsFragment } from "/graphql/generated"
+
+const TagsContainer = styled("div")`
+  display: grid;
+  grid-template-areas:
+    "languageTags languageSelectAll"
+    "difficultyTags difficultySelectAll"
+    "moduleTags moduleSelectAll";
+  gap: 0.5rem;
+`
+
+const TagChip = styled(Chip, {
+  shouldForwardProp: (prop) => prop !== "variant",
+})(
+  ({ theme, variant }) => `
+  border-radius: 2rem;
+  margin: 0.05rem 0.2rem;
+  font-weight: bold;
+  border-width: 0.1rem;
+  border-style: solid;
+  text-transform: uppercase;
+
+  border-color: ${theme.palette.primary.main};
+  color: ${
+    variant === "filled"
+      ? theme.palette.primary.contrastText
+      : theme.palette.primary.main
+  };
+  background-color: ${
+    variant === "filled"
+      ? theme.palette.primary.main
+      : theme.palette.background.default
+  };
+
+  &:hover {
+    border-radius: 2rem;
+    margin: 0.05rem 0.2rem;
+    border-width: 0.1rem;
+    border-style: solid;
+    background-color: ${theme.palette.primary.light};
+    color: ${theme.palette.primary.contrastText};
+  }
+`,
+)
+
+/*
+    color: ${({ variant }) => (variant === "outlined" ? "#F5F6F7" : "#378170")};
+    background-color: ${({ variant }) =>
+      variant === "outlined" ? "#378170" : "#F5F6F7"};
+*/
+
+const SelectAllButton = styled(Button)(
+  ({ theme, variant }) => `
+  margin: 0 1rem auto auto;
+
+  border-radius: 1rem;
+  font-weight: bold;
+  border-width: 0.1rem;
+  border-style: solid;
+  text-transform: uppercase;
+  border-color: ${theme.palette.primary.main};
+  color: ${
+    variant === "contained"
+      ? theme.palette.primary.contrastText
+      : theme.palette.primary.main
+  };
+  background-color: ${
+    variant === "contained"
+      ? theme.palette.primary.main
+      : theme.palette.background.default
+  };
+
+  &:hover {
+    border-radius: 1rem;
+    border-width: 0.1rem;
+    border-style: solid;
+    background-color: ${theme.palette.primary.light};
+    color: ${
+      variant === "contained"
+        ? theme.palette.primary.main
+        : theme.palette.primary.contrastText
+    };
+  }
+`,
+)
+
+interface TagSelectButtonsProps {
+  tags: Record<string, Array<TagCoreFieldsFragment>>
+  activeTags: Array<TagCoreFieldsFragment>
+  setActiveTags: (tags: Array<TagCoreFieldsFragment>) => void
+  selectAllTags: () => void
+}
+
+const TagSelectButtons = ({
+  tags,
+  activeTags,
+  setActiveTags,
+  selectAllTags,
+}: TagSelectButtonsProps) => {
+  const t = useTranslator(CommonTranslations)
+
+  const handleClick = useCallback(
+    (tag: TagCoreFieldsFragment) => {
+      if (activeTags.includes(tag)) {
+        setActiveTags(activeTags.filter((t) => t !== tag))
+      } else {
+        setActiveTags([...activeTags, tag])
+      }
+    },
+    [activeTags],
+  )
+
+  const handleSelectAllClick = useCallback(
+    (category: string) => {
+      if (category in tags) {
+        if (tags[category].every((tag) => activeTags.includes(tag))) {
+          setActiveTags(
+            activeTags.filter((tag) => !tags[category].includes(tag)),
+          )
+        } else {
+          const activeTagsWithAll = [...activeTags, ...tags[category]]
+          setActiveTags([...new Set(activeTagsWithAll)])
+        }
+      } else {
+        selectAllTags()
+      }
+    },
+    [activeTags],
+  )
+
+  return (
+    <TagsContainer>
+      {Object.keys(tags).map((category) => (
+        <React.Fragment key={category}>
+          <div style={{ gridArea: `${category}Tags` }}>
+            {tags[category].map((tag) => (
+              <TagChip
+                id={`tag-${category}-${tag.id}`}
+                key={tag.id}
+                variant={activeTags.includes(tag) ? "filled" : "outlined"}
+                onClick={() => handleClick(tag)}
+                size="small"
+                label={tag.name}
+              />
+            ))}
+          </div>
+          <div style={{ gridArea: `${category}SelectAll` }}>
+            <SelectAllButton
+              id={`select-all-${category}-tags`}
+              variant={
+                tags[category].every((tag) => activeTags.includes(tag))
+                  ? "contained"
+                  : "outlined"
+              }
+              onClick={() => handleSelectAllClick(category)}
+              size="small"
+            >
+              {t("selectAll")}
+            </SelectAllButton>
+          </div>
+        </React.Fragment>
+      ))}
+    </TagsContainer>
+  )
+}
+
+export default TagSelectButtons

--- a/frontend/components/NewLayout/Courses/TagSelectDropdowns.tsx
+++ b/frontend/components/NewLayout/Courses/TagSelectDropdowns.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback } from "react"
+
+import { Autocomplete, TextField } from "@mui/material"
+import { styled } from "@mui/material/styles"
+
+import { useTranslator } from "/hooks/useTranslator"
+import CommonTranslations from "/translations/common"
+import notEmpty from "/util/notEmpty"
+
+import { TagCoreFieldsFragment } from "/graphql/generated"
+
+const TagsContainer = styled("div")`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  & > .MuiAutocomplete-root {
+    margin-bottom: 0.5rem;
+  }
+`
+
+interface TagSelectDropdownProps {
+  tags: Record<string, Array<TagCoreFieldsFragment>>
+  activeTags: Array<TagCoreFieldsFragment>
+  setActiveTags: (tags: Array<TagCoreFieldsFragment>) => void
+  selectAllTags: () => void
+}
+
+const TagSelectDropdowns = ({
+  tags,
+  activeTags,
+  setActiveTags,
+}: TagSelectDropdownProps) => {
+  const t = useTranslator(CommonTranslations)
+  const allTags = Object.values(tags).flatMap((t) => t)
+
+  const onChange = useCallback(
+    (_: any, value: Array<string> | Array<TagCoreFieldsFragment>) => {
+      setActiveTags(
+        value
+          .map((s) => {
+            if (typeof s === "string") {
+              return allTags.find((tag) => tag.id === s)
+            }
+            return s
+          })
+          .filter(notEmpty),
+      )
+    },
+    [allTags],
+  )
+
+  return (
+    <TagsContainer>
+      {Object.keys(tags).map((category) => {
+        const categoryActiveTags = activeTags.filter((tag) =>
+          tag.types?.includes(category),
+        )
+        return (
+          <Autocomplete
+            key={category}
+            multiple
+            fullWidth
+            getOptionLabel={(option) => option.name ?? ""}
+            options={tags[category]}
+            value={categoryActiveTags}
+            onChange={onChange}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t(category as keyof (typeof CommonTranslations)[string])}
+              />
+            )}
+          />
+        )
+      })}
+    </TagsContainer>
+  )
+}
+
+export default TagSelectDropdowns

--- a/frontend/components/NewLayout/Frontpage/CourseList.tsx
+++ b/frontend/components/NewLayout/Frontpage/CourseList.tsx
@@ -1,5 +1,0 @@
-function CourseList() {
-  return null
-}
-
-export default CourseList

--- a/frontend/components/NewLayout/Frontpage/SelectedCourses.tsx
+++ b/frontend/components/NewLayout/Frontpage/SelectedCourses.tsx
@@ -36,7 +36,7 @@ const CardActions = styled("div")`
   align-items: center;
 `
 
-const Date = (props: TypographyProps) => (
+const CourseDate = (props: TypographyProps) => (
   <Typography variant="subtitle2" {...props} />
 )
 
@@ -66,7 +66,7 @@ const CourseCard = ({
       <CardBody>
         <CardDescription>{description}</CardDescription>
         <CardActions>
-          <Date>{date}</Date>
+          <CourseDate>{date}</CourseDate>
           <Button>Kurssin tiedot</Button>
         </CardActions>
       </CardBody>
@@ -96,6 +96,7 @@ function SelectedCourses() {
   const language = mapNextLanguageToLocaleCode(locale)
   const { loading, data } = useQuery(CoursesDocument, {
     variables: { language },
+    ssr: false,
   })
 
   return (

--- a/frontend/components/NewLayout/Navigation/DesktopNavigationMenu.tsx
+++ b/frontend/components/NewLayout/Navigation/DesktopNavigationMenu.tsx
@@ -93,7 +93,7 @@ const UserOptionsMenu = () => {
   const { pathname, locale } = useRouter()
   const { loggedIn, logInOrOut, currentUser } = useLoginStateContext()
   const t = useTranslator(CommonTranslations)
-  const isNarrow = useMediaQuery("(max-width: 899px)")
+  const isNarrow = useMediaQuery("(max-width: 899px)", { noSsr: true })
 
   const userDisplayName = useMemo(() => {
     const name = currentUser?.full_name

--- a/frontend/pages/_new/courses/index.tsx
+++ b/frontend/pages/_new/courses/index.tsx
@@ -5,8 +5,7 @@ import { styled } from "@mui/material/styles"
 import Catalogue from "/components/NewLayout/Courses/Catalogue"
 
 const Container = styled("div")`
-  display: grid;
-  justify-content: center;
+  margin: 0 auto;
   position: relative;
 `
 

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -86,5 +86,8 @@
     "previousPage": "previous page",
     "nextPage": "next page",
     "copyToClipboard": "Copy to clipboard",
-    "copiedToClipboard": "Copied!"
+    "copiedToClipboard": "Copied!",
+    "language": "Language",
+    "difficulty": "Difficulty",
+    "module": "Module"
 } 

--- a/frontend/translations/common/fi.json
+++ b/frontend/translations/common/fi.json
@@ -86,6 +86,9 @@
     "previousPage": "edellinen sivu",
     "nextPage": "seuraava sivu",
     "copyToClipboard": "Kopioi leikepöydälle",
-    "copiedToClipboard": "Kopioitu!"
+    "copiedToClipboard": "Kopioitu!",
+    "language": "Kieli",
+    "difficulty": "Vaikeustaso",
+    "module": "Kokonaisuus"
 }
 

--- a/frontend/translations/common/se.json
+++ b/frontend/translations/common/se.json
@@ -86,5 +86,8 @@
     "previousPage": "previous page",
     "nextPage": "next page",
     "copyToClipboard": "Copy to clipboard",
-    "copiedToClipboard": "Copied!"
+    "copiedToClipboard": "Copied!",
+    "language": "Language",
+    "difficulty": "Difficulty",
+    "module": "Module"
 }


### PR DESCRIPTION
- create a special `other_language` language tag for languages other than the default three
- course catalogue filters now turn into autocomplete/dropdown menus on narrow screens
- changed the tag filter buttons into chips
- other minor responsiveness and style changes 