### PR TITLE
Convert backend to use alpine to get libssl3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
           docker_layer_caching: true
       - jq/install
       - docker/install-docker-tools:
@@ -230,7 +229,6 @@ jobs:
       - attach_workspace:
           at: ~/project
       - setup_remote_docker:
-          version: 19.03.13
           docker_layer_caching: true
       - run:
           name: "Restore image"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:18.16.0-buster
+FROM node:18.16.0-alpine
 
-RUN apt-get update \
-  && apt-get install -yy build-essential libpng-dev postgresql-client libpq-dev redis-tools git jq \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add --no-cache build-base libpng-dev postgresql-client libpq redis git jq bash python3
+
 RUN wget https://github.com/edenhill/librdkafka/archive/v2.0.2.tar.gz  -O - | tar -xz \
   && cd librdkafka-2.0.2 \
   && ./configure --prefix=/usr \

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -28,8 +28,9 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
 })
 
+const ctx: ServerContext = { prisma, logger, knex }
+
 const startApp = async () => {
-  const ctx: ServerContext = { prisma, logger, knex }
   const { httpServer } = await server(ctx)
 
   attachPrismaEvents(ctx)

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -32,7 +32,7 @@ export const DATABASE_URL =
     ? "postgres://prisma:prisma@localhost:5678/testing"
     : process.env.DATABASE_URL
 
-const url = new URL(DATABASE_URL || "")
+const url = new URL((DATABASE_URL || "").replaceAll('"', ""))
 url.searchParams.delete("schema")
 
 export const DATABASE_URL_WITHOUT_SCHEMA = url.href

--- a/backend/graphql/Completion/index.ts
+++ b/backend/graphql/Completion/index.ts
@@ -1,4 +1,4 @@
-// generated Fri May 26 2023 13:59:17 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Fri May 26 2023 14:24:46 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/Course/index.ts
+++ b/backend/graphql/Course/index.ts
@@ -1,4 +1,4 @@
-// generated Fri May 26 2023 13:59:17 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Fri May 26 2023 14:24:46 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/StudyModule/index.ts
+++ b/backend/graphql/StudyModule/index.ts
@@ -1,4 +1,4 @@
-// generated Fri May 26 2023 13:59:17 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Fri May 26 2023 14:24:46 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/User/index.ts
+++ b/backend/graphql/User/index.ts
@@ -1,4 +1,4 @@
-// generated Fri May 26 2023 13:59:17 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Fri May 26 2023 14:24:46 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./input"
 export * from "./model"

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -1,4 +1,4 @@
-// generated Fri May 26 2023 13:59:17 GMT+0300 (Itä-Euroopan kesäaika)
+// generated Fri May 26 2023 14:24:46 GMT+0300 (Itä-Euroopan kesäaika)
 
 export * from "./ABEnrollment"
 export * from "./ABStudy"


### PR DESCRIPTION
Debian buster (nor bullseye) have libssl3, so a mismatch between Node.js 18, Prisma and the distribution libssl version here. Alpine has it, though, and migrating the Dockerfile to use that was easy.

Also, Prisma connection url no longer accepts quoted strings.