### PR TITLE
update postgres and redis in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Create `.env` files for backend and frontend. See examples and ask your local boffin for details.
 
-Install `docker-compose`, if not already installed.
-
 ## Development workflow
 
 Current `node` version is `18.16.0`.
@@ -30,7 +28,9 @@ npm run migrate
 npm run dev
 ```
 
-If the database doesn't seem to do anything, ie. no messages after the initial ones after running `docker-compose up` and the database queries are not getting through, run `docker-compose down` and try again. You can always run the database container in detached mode (`-d`) but then you won't see the logs live.
+If the database doesn't seem to do anything, ie. no messages after the initial ones after running `docker compose up` and the database queries are not getting through, run `docker compose down` and try again. You can always run the database container in detached mode (`-d`) but then you won't see the logs live.
+
+If you have used a development database with an older version of PostgreSQL and you want to keep your data, you will need to migrate it to the new version. See [here](docs/postgres.md) for instructions.
 
 Run `npm run prettier` in the root directory before committing. The commit runs hooks to check this as well as some linters, type checks etc.
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
   postgres:
-    image: postgres:10.3
+    image: postgres:15.3
     restart: always
     command: postgres -c log_statement='all'
-    ports: 
+    ports:
     - "5678:5432"
     environment:
       POSTGRES_USER: prisma
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
   redis:
-    image: redis:5.0.5
+    image: redis:7.0.11
     command: ["redis-server", "--appendonly", "yes"]
     hostname: redis
     ports:

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,0 +1,24 @@
+# Migrating from an older version
+
+If your development database is created with the older version, it is not usable with the newer one straight away. To keep the old one, have the old version running in `docker compose` -- if you've already merged this, just change the image back to `postgres:10.3` -- and do a `pg_dump`:
+
+```bash
+pg-dump -h localhost -p 5678 -U prisma -W > /tmp/moocfi-dev-dump
+```
+
+Provide `prisma` for the password.
+ 
+You can probably do the dump inside the running container, but you will need to move the dump file contents to your local machine as we will delete the container. 
+
+Do `docker compose down` and you can delete the container and the volume:
+
+```bash
+docker container rm backend-postgres-1
+docker volume rm backend_postgres
+```
+
+Change the image version back to `postgres:15.3`,  do `docker compose up` and it should create the database. While it's running, restore the database contents:
+
+```bash
+psql -h localhost -p 5678 -U prisma -W prisma < /tmp/moocfi-dev-dump
+```


### PR DESCRIPTION
We've migrated up to version 15 of Postgres in production, so better have the dev database running the same major version as well.

As the dev database is created with the older version, it is not usable with the newer one straight away. To keep the old one, have the old version running in `docker compose` -- if you've already merged this, just change the image back to `postgres:10.3` -- and do a `pg_dump`, preferably with a version included in Postgres 15 which you should have installed locally:

```bash
pg-dump -h localhost -p 5678 -U prisma -W > /tmp/moocfi-dev-dump
```

Provide `prisma` for the password.
 
Do `docker compose down` and you can delete the container and the volume:

```bash
docker container rm backend-postgres-1
docker volume rm backend_postgres
```

Change the image version back to `postgres:15.3`,  do `docker compose up` and it should create the database. While it's running, restore the database contents:

```bash
psql -h localhost -p 5678 -U prisma -W prisma < /tmp/moocfi-dev-dump
```