### PR TITLE
Pass schedules to emailer cronjobs from values.yaml

### DIFF
--- a/helm/templates/prague-stats-mailer-cronjob.yml
+++ b/helm/templates/prague-stats-mailer-cronjob.yml
@@ -1,12 +1,13 @@
+{{- range $cron := .Values.cronjob.prague.crons }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: prague-stats-emailer
   labels:
-    {{- include "helm.labels" . | nindent 4 }}
+    {{- include "helm.labels" $ | nindent 4 }}
 spec:
-  # Run at 10:00 AM on 30th of November
-  schedule: "0 10 24 1 *"
+  schedule: "0 10 {{$cron.day}} {{$cron.month}} *"
   startingDeadlineSeconds: 3600
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -14,7 +15,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        {{- include "helm.selectorLabels" . | nindent 8 }}
+        {{- include "helm.selectorLabels" $ | nindent 8 }}
     spec:
       activeDeadlineSeconds: 7200
       template:
@@ -22,7 +23,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: prague-stats-emailer
-              image: "{{ .Values.image.repository }}/moocfi-backend:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              image: "{{ $.Values.image.repository }}/moocfi-backend:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               command: ["sh", "-c", "npm run prague-stats-emailer"]
               envFrom:
                 - secretRef:
@@ -33,3 +34,4 @@ spec:
                     secretKeyRef:
                       name: new-redis
                       key: redis-password
+{{- end }}

--- a/helm/templates/purkyne-stats-mailer-cronjob.yml
+++ b/helm/templates/purkyne-stats-mailer-cronjob.yml
@@ -1,12 +1,13 @@
+{{- range $cron := .Values.cronjob.purkyne.crons }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: purkyne-stats-emailer
   labels:
-    {{- include "helm.labels" . | nindent 4 }}
+    {{- include "helm.labels" $ | nindent 4 }}
 spec:
-  # Run at 10:00 AM on 30th of June
-  schedule: "0 10 30 6 *"
+  schedule: "0 10 {{$cron.day}} {{$cron.month}} *"
   startingDeadlineSeconds: 3600
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -14,7 +15,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        {{- include "helm.selectorLabels" . | nindent 8 }}
+        {{- include "helm.selectorLabels" $ | nindent 8 }}
     spec:
       activeDeadlineSeconds: 7200
       template:
@@ -22,7 +23,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: purkyne-stats-emailer
-              image: "{{ .Values.image.repository }}/moocfi-backend:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              image: "{{ $.Values.image.repository }}/moocfi-backend:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               command: ["sh", "-c", "npm run purkyne-stats-emailer"]
               envFrom:
                 - secretRef:
@@ -33,3 +34,4 @@ spec:
                     secretKeyRef:
                       name: new-redis
                       key: redis-password
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -122,7 +122,7 @@ tolerations: []
 affinity: {}
 
 cronjob:
-  prague:
+  prague: # @vse.cz report, see backend/bin/pragueStatsEmailer.ts
     crons:
       - id: "0"
         day: 24
@@ -136,7 +136,7 @@ cronjob:
       - id: "3"
         day: 29
         month: 11
-  purkyne:
+  purkyne: # @ujep.cz report, see backend/bin/purkyneStatsEmailer.ts
     crons:
       - id: "0"
         day: 30

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -120,3 +120,30 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cronjob:
+  prague:
+    crons:
+      - id: "0"
+        day: 24
+        month: 1
+      - id: "1"
+        day: 31
+        month: 5
+      - id: "2"
+        day: 25
+        month: 8
+      - id: "3"
+        day: 29
+        month: 11
+  purkyne:
+    crons:
+      - id: "0"
+        day: 30
+        month: 6
+      - id: "1"
+        day: 31
+        month: 8
+      - id: "2"
+        day: 20
+        month: 12


### PR DESCRIPTION
We want to run prague and purkyne emailers multiple times a year, but the dates vary too much for cronjob's schedule syntax. Added the dates to values.yaml so that we can run the same template multiple times a year, and to easily modify when to run them.