### PR TITLE
Fix stats emailer cronjobs

### DIFF
--- a/helm/templates/prague-stats-mailer-cronjob.yml
+++ b/helm/templates/prague-stats-mailer-cronjob.yml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: prague-stats-emailer
+  name: prague-stats-emailer-{{$cron.id}}
   labels:
     {{- include "helm.labels" $ | nindent 4 }}
 spec:

--- a/helm/templates/purkyne-stats-mailer-cronjob.yml
+++ b/helm/templates/purkyne-stats-mailer-cronjob.yml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: purkyne-stats-emailer
+  name: purkyne-stats-emailer-{{$cron.id}}
   labels:
     {{- include "helm.labels" $ | nindent 4 }}
 spec:


### PR DESCRIPTION
Multiple cronjobs are generated from values.yaml. They had identical name so only the last one was created, this PR gives unique names to the cronjobs based on the id defined in values.yaml. This should allow for multiple cronjobs from the same template (with differing schedules).