### PR TITLE
feat: Add support for URL query search

### DIFF
--- a/frontend/components/NewLayout/Courses/CourseGrid.tsx
+++ b/frontend/components/NewLayout/Courses/CourseGrid.tsx
@@ -275,6 +275,13 @@ function CourseGrid() {
   const { locale = "fi" } = router
   const language = mapNextLanguageToLocaleCode(locale)
   const isNarrow = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"))
+  const initialEncodedSearchString = useQueryParameter("search", {
+    enforce: false,
+    array: false,
+  })
+  const initialSearchString = initialEncodedSearchString
+    ? decodeURIComponent(initialEncodedSearchString)
+    : ""
   const initialActiveTags = useQueryParameter("tag", {
     enforce: false,
     array: true,
@@ -317,11 +324,29 @@ function CourseGrid() {
     initialFilteredStatuses = initialStatuses
   }
 
-  const [searchString, setSearchString] = useState<string>("")
+  const [searchString, innerSetSearchString] =
+    useState<string>(initialSearchString)
   const [activeTags, setActiveTags] = useState<Array<TagCoreFieldsFragment>>([])
   const [filteredStatuses, setFilteredStatuses] = useState<CourseStatus[]>(
     initialFilteredStatuses,
   )
+
+  const updateUrlSearchParam = (newSearch: string) => {
+    const newQuery = { ...router.query }
+    if (newSearch) {
+      newQuery.search = encodeURIComponent(newSearch)
+    } else {
+      delete newQuery.search
+    }
+    router.replace({ pathname: router.pathname, query: newQuery }, undefined, {
+      shallow: true,
+    })
+  }
+
+  const setSearchString = (newSearch: string) => {
+    updateUrlSearchParam(newSearch)
+    innerSetSearchString(newSearch)
+  }
 
   const tags = useMemo(() => {
     const res = (tagsData?.tags ?? []).reduce(


### PR DESCRIPTION
I noticed that the courses page has support for adding tags and a few other URL params, but is missing any search param. 
I think that can be useful for sharing and link purposes: e.g. https://www.mooc.fi/en/courses/?status=Active&search=cybersecurity
y 
This PR adds support for that!

Unfortunately I got many issues when setting up the environment, and the pre-commit hook kept failing, even if `npm run prettier` worked correctly (after I deleted `backend/.prettierrc.js` as that was incorrectly set to `../.prettierrc`).
So, for all such reasons, I wasn't able to properly test this, so I'd need some help, either with someone else testing this or helping me set this up correctly.

Great work with all the MOOC initiative, that's an amazing opportunity! 😃 