### PR TITLE
Don't do the getInitialProps work for logged out users

### DIFF
--- a/backend/middlewares/__test__/expressGraphqlCache.test.ts
+++ b/backend/middlewares/__test__/expressGraphqlCache.test.ts
@@ -127,7 +127,7 @@ describe("GraphQL response cache middleware", () => {
     expect(mockRedisClient.set).toHaveBeenCalledTimes(1)
     const [, payload, opts] = (mockRedisClient.set as jest.Mock).mock.calls[0]
     expect(typeof payload).toBe("string")
-    expect(opts).toEqual(expect.objectContaining({ EX: 60 * 60 }))
+    expect(opts).toEqual(expect.objectContaining({ EX: 60 * 60 * 5 }))
     expect(res._headers["x-cache"]).toBe("MISS")
   })
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -109,6 +109,10 @@ const originalGetInitialProps = MyApp.getInitialProps
 MyApp.getInitialProps = async (props: AppContext) => {
   const { ctx, Component } = props
 
+  const signedIn = isSignedIn(ctx)
+  const admin = signedIn && isAdmin(ctx)
+  const accessToken = getAccessToken(ctx)
+
   let originalProps: any = {}
 
   if (originalGetInitialProps) {
@@ -117,14 +121,10 @@ MyApp.getInitialProps = async (props: AppContext) => {
   if (!originalProps?.pageProps) {
     originalProps.pageProps = {}
   }
-  if (Component.getInitialProps) {
+  if (signedIn && Component.getInitialProps) {
     const originalComponentProps = (await Component.getInitialProps(ctx)) ?? {}
     Object.assign(originalProps.pageProps, originalComponentProps)
   }
-
-  const signedIn = isSignedIn(ctx)
-  const admin = signedIn && isAdmin(ctx)
-  const accessToken = getAccessToken(ctx)
 
   return {
     ...originalProps,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced server-side work for unsigned visitors to speed initial page loads and avoid redundant authentication checks; consolidated auth info into page props for more efficient page initialization.
* **Tests**
  * Extended server response cache duration from 1 hour to 5 hours to improve cache effectiveness and reduce repeated backend queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->