### PR TITLE
Reduce fetching during ssr

### DIFF
--- a/frontend/lib/with-apollo-client/index.tsx
+++ b/frontend/lib/with-apollo-client/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   apolloState: any
   accessToken?: string
   router?: Router
+  skipSsrFetch?: boolean
 }
 
 const isAppContext = (ctx: AppContext | NextPageContext): ctx is AppContext => {
@@ -27,12 +28,18 @@ const withApolloClient = (App: any) => {
     apollo,
     apolloState,
     accessToken,
+    skipSsrFetch,
     ...pageProps
   }: Props) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const router = useRouter()
     const locale = router.locale ?? pageProps?.router?.locale
-    const apolloClient = getApollo(apolloState, accessToken, locale)
+    const apolloClient = getApollo(
+      apolloState,
+      accessToken,
+      locale,
+      skipSsrFetch,
+    )
 
     return (
       <ApolloProvider client={apolloClient}>
@@ -62,7 +69,13 @@ const withApolloClient = (App: any) => {
         : ({} as any)
 
     if (!signedIn) {
-      const apollo = getApollo(apolloState, accessToken, ctx.locale)
+      const skipSsrFetch = typeof window === "undefined"
+      const apollo = getApollo(
+        apolloState,
+        accessToken,
+        ctx.locale,
+        skipSsrFetch,
+      )
 
       if (!pageProps.pageProps) {
         pageProps.pageProps = {}
@@ -79,6 +92,7 @@ const withApolloClient = (App: any) => {
         accessToken,
         apolloState,
         apollo,
+        skipSsrFetch,
       }
     }
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,6 +5,7 @@ import Hype from "/components/NewLayout/Frontpage/Hype"
 import { ModuleNavigation } from "/components/NewLayout/Frontpage/Modules"
 // import News from "/components/NewLayout/Frontpage/News"
 import SelectedCourses from "/components/NewLayout/Frontpage/SelectedCourses"
+import withNoSsr from "/util/withNoSsr"
 
 // import UkraineInfo from "/components/NewLayout/Frontpage/UkraineInfo"
 
@@ -32,4 +33,4 @@ const Home = () => {
   )
 }
 
-export default Home
+export default withNoSsr(Home)

--- a/frontend/pages/study-modules/index.tsx
+++ b/frontend/pages/study-modules/index.tsx
@@ -1,5 +1,6 @@
 import { StudyModuleList } from "/components/NewLayout/Modules"
 import { useBreadcrumbs } from "/hooks/useBreadcrumbs"
+import withNoSsr from "/util/withNoSsr"
 
 function StudyModules() {
   useBreadcrumbs([
@@ -16,4 +17,4 @@ function StudyModules() {
   )
 }
 
-export default StudyModules
+export default withNoSsr(StudyModules)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added an option to skip server-side data fetching for Apollo Client, giving pages finer control over SSR data initialization.
  * Enabled opting out of server-side rendering for specific pages by wrapping them with a no-SSR helper, preventing SSR for those routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->