### PR TITLE
Remove duplicate rows from emailer SQL queries

### DIFF
--- a/backend/bin/linkopingStatsEmailer.ts
+++ b/backend/bin/linkopingStatsEmailer.ts
@@ -12,20 +12,24 @@ const linkopingStatsEmailer = async () => {
     throw new Error("No recipients set for completion emails")
   }
 
-  // TODO: one completion per user?
   const result = await prisma.$queryRaw<
     Array<{ email: string; completion_date: string; tier: number }>
   >`
-    SELECT u.email, c.completion_date, c.tier 
-      FROM "user" u
-      JOIN user_course_setting ucs on ucs.user_id = u.id
-      JOIN completion c on c.user_id = u.id
-    WHERE u.email ILIKE '%liu.se'
-      AND ucs.other ->> 'ects_consent_sweden' = 'true'
-      AND ucs.other ->> 'bai_completion' = 'true'
-      AND c.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
-      AND ucs.country = 'Sweden'
-    ORDER BY c.completion_date;
+    WITH unique_completions AS (
+      SELECT DISTINCT ON (u.email, c.tier) u.email, c.completion_date, c.tier
+        FROM "user" u
+        JOIN user_course_setting ucs on ucs.user_id = u.id
+        JOIN completion c on c.user_id = u.id
+      WHERE u.email ILIKE '%liu.se'
+        AND ucs.other ->> 'ects_consent_sweden' = 'true'
+        AND ucs.other ->> 'bai_completion' = 'true'
+        AND c.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
+        AND ucs.country = 'Sweden'
+      ORDER BY u.email, c.tier, c.completion_date
+    )
+    SELECT email, completion_date, tier
+      FROM unique_completions
+    ORDER BY completion_date, email, tier;
   `
 
   const text = result

--- a/backend/bin/linkopingStatsEmailer.ts
+++ b/backend/bin/linkopingStatsEmailer.ts
@@ -25,7 +25,7 @@ const linkopingStatsEmailer = async () => {
         AND ucs.other ->> 'bai_completion' = 'true'
         AND c.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
         AND ucs.country = 'Sweden'
-      ORDER BY u.email, c.tier, c.completion_date
+      ORDER BY u.email, c.tier, c.completion_date DESC NULLS LAST
     )
     SELECT email, completion_date, tier
       FROM unique_completions

--- a/backend/bin/masarykStatsEmailer.ts
+++ b/backend/bin/masarykStatsEmailer.ts
@@ -13,17 +13,20 @@ const masarykStatsEmailer = async () => {
     throw new Error("No recipients set for completion emails")
   }
 
-  // TODO: one completion per user?
   const result = await prisma.$queryRaw<
     Array<{ email: string; completion_date: string; tier: number }>
   >`
-    SELECT co.tier, u.email, co.completion_date
-      FROM "user" u
-      JOIN completion co on u.id = co.user_id
-    WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
-      AND u.email ILIKE '%@muni.cz' OR u.email ILIKE '%@mail.muni.cz'
-    GROUP BY co.tier, u.email, co.completion_date
-    ORDER BY co.completion_date DESC, u.email, co.tier;
+    WITH unique_completions AS (
+      SELECT DISTINCT ON (u.email, co.tier) co.tier, u.email, co.completion_date
+        FROM "user" u
+        JOIN completion co on u.id = co.user_id
+      WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
+        AND (u.email ILIKE '%@muni.cz' OR u.email ILIKE '%@mail.muni.cz')
+      ORDER BY u.email, co.tier, co.completion_date DESC
+    )
+    SELECT tier, email, completion_date
+      FROM unique_completions
+    ORDER BY completion_date DESC, email, tier;
   `
 
   const tiers: Record<number, Array<string>> = {}

--- a/backend/bin/masarykStatsEmailer.ts
+++ b/backend/bin/masarykStatsEmailer.ts
@@ -22,7 +22,7 @@ const masarykStatsEmailer = async () => {
         JOIN completion co on u.id = co.user_id
       WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
         AND (u.email ILIKE '%@muni.cz' OR u.email ILIKE '%@mail.muni.cz')
-      ORDER BY u.email, co.tier, co.completion_date DESC
+      ORDER BY u.email, co.tier, co.completion_date DESC NULLS LAST
     )
     SELECT tier, email, completion_date
       FROM unique_completions

--- a/backend/bin/opavaStatsEmailer.ts
+++ b/backend/bin/opavaStatsEmailer.ts
@@ -22,7 +22,7 @@ const opavaStatsEmailer = async () => {
         JOIN completion co on u.id = co.user_id
       WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
         AND u.email ILIKE '%@slu.cz'
-      ORDER BY u.email, co.tier, co.completion_date DESC
+      ORDER BY u.email, co.tier, co.completion_date DESC NULLS LAST
     )
     SELECT tier, email, completion_date
       FROM unique_completions

--- a/backend/bin/opavaStatsEmailer.ts
+++ b/backend/bin/opavaStatsEmailer.ts
@@ -13,17 +13,20 @@ const opavaStatsEmailer = async () => {
     throw new Error("No recipients set for completion emails")
   }
 
-  // TODO: one completion per user?
   const result = await prisma.$queryRaw<
     Array<{ email: string; completion_date: string; tier: number }>
   >`
-    SELECT co.tier, u.email, co.completion_date
-      FROM "user" u
-      JOIN completion co on u.id = co.user_id
-    WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
-      AND u.email ILIKE '%@slu.cz'
-    GROUP BY co.tier, u.email, co.completion_date
-    ORDER BY co.completion_date DESC, u.email, co.tier;
+    WITH unique_completions AS (
+      SELECT DISTINCT ON (u.email, co.tier) co.tier, u.email, co.completion_date
+        FROM "user" u
+        JOIN completion co on u.id = co.user_id
+      WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
+        AND u.email ILIKE '%@slu.cz'
+      ORDER BY u.email, co.tier, co.completion_date DESC
+    )
+    SELECT tier, email, completion_date
+      FROM unique_completions
+    ORDER BY completion_date DESC, email, tier;
   `
 
   const tiers: Record<number, Array<string>> = {}

--- a/backend/bin/pragueStatsEmailer.ts
+++ b/backend/bin/pragueStatsEmailer.ts
@@ -21,7 +21,7 @@ const pragueStatsEmailer = async () => {
         JOIN completion co on u.id = co.user_id
       WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
         AND u.email ILIKE '%@vse.cz'
-      ORDER BY u.email, co.tier, co.completion_date DESC
+      ORDER BY u.email, co.tier, co.completion_date DESC NULLS LAST
     )
     SELECT tier, email, completion_date
       FROM unique_completions

--- a/backend/bin/pragueStatsEmailer.ts
+++ b/backend/bin/pragueStatsEmailer.ts
@@ -12,17 +12,20 @@ const pragueStatsEmailer = async () => {
     throw new Error("No recipients set for completion emails")
   }
 
-  // TODO: one completion per user?
   const result = await prisma.$queryRaw<
     Array<{ email: string; completion_date: string; tier: number }>
   >`
-    SELECT co.tier, u.email, co.completion_date
-      FROM "user" u
-      JOIN completion co on u.id = co.user_id
-    WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
-      AND u.email ILIKE '%@vse.cz'
-    GROUP BY co.tier, u.email, co.completion_date
-    ORDER BY co.completion_date DESC, u.email, co.tier;
+    WITH unique_completions AS (
+      SELECT DISTINCT ON (u.email, co.tier) co.tier, u.email, co.completion_date
+        FROM "user" u
+        JOIN completion co on u.id = co.user_id
+      WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
+        AND u.email ILIKE '%@vse.cz'
+      ORDER BY u.email, co.tier, co.completion_date DESC
+    )
+    SELECT tier, email, completion_date
+      FROM unique_completions
+    ORDER BY completion_date DESC, email, tier;
   `
 
   const tiers: Record<number, Array<string>> = {}

--- a/backend/bin/purkyneStatsEmailer.ts
+++ b/backend/bin/purkyneStatsEmailer.ts
@@ -22,7 +22,7 @@ const purkyneStatsEmailer = async () => {
         JOIN completion co on u.id = co.user_id
       WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
         AND u.email ILIKE '%@ujep.cz'
-      ORDER BY u.email, co.tier, co.completion_date DESC
+      ORDER BY u.email, co.tier, co.completion_date DESC NULLS LAST
     )
     SELECT tier, email, completion_date
       FROM unique_completions

--- a/backend/bin/purkyneStatsEmailer.ts
+++ b/backend/bin/purkyneStatsEmailer.ts
@@ -13,17 +13,20 @@ const purkyneStatsEmailer = async () => {
     throw new Error("No recipients set for completion emails")
   }
 
-  // TODO: one completion per user?
   const result = await prisma.$queryRaw<
     Array<{ email: string; completion_date: string; tier: number }>
   >`
-    SELECT co.tier, u.email, co.completion_date
-      FROM "user" u
-      JOIN completion co on u.id = co.user_id
-    WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
-      AND u.email ILIKE '%@ujep.cz'
-    GROUP BY co.tier, u.email, co.completion_date
-    ORDER BY co.completion_date DESC, u.email, co.tier;
+    WITH unique_completions AS (
+      SELECT DISTINCT ON (u.email, co.tier) co.tier, u.email, co.completion_date
+        FROM "user" u
+        JOIN completion co on u.id = co.user_id
+      WHERE co.course_id = '49cbadd8-be32-454f-9b7d-e84d52100b74'::uuid
+        AND u.email ILIKE '%@ujep.cz'
+      ORDER BY u.email, co.tier, co.completion_date DESC
+    )
+    SELECT tier, email, completion_date
+      FROM unique_completions
+    ORDER BY completion_date DESC, email, tier;
   `
 
   const tiers: Record<number, Array<string>> = {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate completion entries appearing in statistics emails across all regional instances. Stats emails now properly deduplicate user completion records, displaying only the most recent completion for each user-tier combination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rage/mooc.fi/pull/1312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->